### PR TITLE
operators [R] etcd (0.6.1 0.9.0 0.9.2 0.9.2-clusterwide 0.9.4 0.9.4-clusterwide)

### DIFF
--- a/operators/etcd/0.6.1/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.6.1/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,4 +13,23 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.0/etcdbackups.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.0/etcdbackups.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdbackups.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdbackups
     singular: etcdbackup
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.0/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.0/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,4 +13,23 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.0/etcdrestores.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.0/etcdrestores.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdrestores.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdrestores
     singular: etcdrestore
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.2-clusterwide/etcdbackups.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.2-clusterwide/etcdbackups.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdbackups.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdbackups
     singular: etcdbackup
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.2-clusterwide/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.2-clusterwide/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,4 +13,23 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.2-clusterwide/etcdrestores.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.2-clusterwide/etcdrestores.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdrestores.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdrestores
     singular: etcdrestore
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.2/etcdbackups.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.2/etcdbackups.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdbackups.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdbackups
     singular: etcdbackup
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.2/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.2/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,4 +13,23 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.2/etcdrestores.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.2/etcdrestores.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdrestores.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdrestores
     singular: etcdrestore
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.4-clusterwide/etcdbackups.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.4-clusterwide/etcdbackups.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdbackups.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdbackups
     singular: etcdbackup
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.4-clusterwide/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.4-clusterwide/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,4 +13,23 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.4-clusterwide/etcdrestores.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.4-clusterwide/etcdrestores.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdrestores.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdrestores
     singular: etcdrestore
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.4/etcdbackups.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.4/etcdbackups.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdbackups.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdbackups
     singular: etcdbackup
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.4/etcdclusters.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.4/etcdclusters.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdclusters.etcd.database.coreos.com
@@ -13,4 +13,23 @@ spec:
     - etcd
     singular: etcdcluster
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/operators/etcd/0.9.4/etcdrestores.etcd.database.coreos.com.crd.yaml
+++ b/operators/etcd/0.9.4/etcdrestores.etcd.database.coreos.com.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: etcdrestores.etcd.database.coreos.com
@@ -10,4 +10,23 @@ spec:
     plural: etcdrestores
     singular: etcdrestore
   scope: Namespaced
-  version: v1beta2
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Substitute https://github.com/operator-framework/community-operators/pull/4146, a simple description as follows,

This `apiextensions.k8s.io/v1beta1` has been deprecated in OCP 4.9(K8s 1.22) according to the [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22). It leads to the etcd operator failed to install on OCP 4.9, so this PR updates the related CRD.