### PR TITLE
operators [O] assisted-service-operator (0.0.7)

### DIFF
--- a/operators/assisted-service-operator/0.0.7/assisted-service-operator.clusterserviceversion.yaml
+++ b/operators/assisted-service-operator/0.0.7/assisted-service-operator.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
     containerImage: quay.io/ocpmetal/assisted-service@sha256:82b37b50fdd2a8880ee5f519cbd33be24752fa70e527e25662c308f917e7ddf2
     createdAt: 2021-07-08T14:02:34Z
     description: The Infrastructure Operator for Red Hat OpenShift is responsible for managing the deployment of the Assisted Service.
-    olm.skipRange: '>=0.0.0 <0.0.7'
+    olm.skipRange: '>=0.0.1 <0.0.7'
     operatorframework.io/suggested-namespace: assisted-installer
     operators.operatorframework.io/builder: operator-sdk-v1.7.1+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
**Description**
Fix invalid range config in the distribution 0.0.7 by replacing `olm.skipRange: '>=0.0.0 <0.0.7'` with `olm.skipRange: '>=0.0.1 <0.0.7'` which is a valid range for this package. Note that the version 0.0.0 does not exist. 