### PR TITLE
operators [R] cert-manager (1.4.0 1.4.1 1.4.2 1.4.3 1.4.4 1.5.3 1.5.4 1.6.0 1.6.1)

### DIFF
--- a/operators/cert-manager/1.4.0/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.4.0/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.4.0
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.4.1/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.4.1/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.4.1
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.4.2/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.4.2/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.4.2
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.4.3/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.4.3/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.4.3
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.4.4/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.4.4/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.4.4
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.5.3/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.5.3/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.5.3
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.5.4/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.5.4/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.5.4
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.6.0/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.6.0/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.6.0
   namespace: placeholder
 spec:

--- a/operators/cert-manager/1.6.1/manifests/cert-manager.clusterserviceversion.yaml
+++ b/operators/cert-manager/1.6.1/manifests/cert-manager.clusterserviceversion.yaml
@@ -41,6 +41,11 @@ metadata:
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/jetstack/cert-manager
     support: The cert-manager maintainers
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: cert-manager.v1.6.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
This causes the operator to be displayed in OperatorHub in the web console on architectures other than x86_64.

Please let me know if there is a different way to add these; I didn't see a CSV upstream.

/cc @wallrj 

### Updates to existing Operators

* [ ] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [ ] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [ ] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [ ] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [ ] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**
