### PR TITLE
disable 4.10 to allow OCP version release develop

### DIFF
--- a/ci/pipeline-config-ocp.yaml
+++ b/ci/pipeline-config-ocp.yaml
@@ -12,7 +12,7 @@ production:
       - v4.7-db
       - v4.8-db
       - v4.9-db
-      - v4.10-rcdb
+      # - v4.10-rcdb
       - v4.11-rc
     latest: "v4.6"
     signature: 1


### PR DESCRIPTION
Signed-off-by: J0zi <jbreza@redhat.com>
disable 4.10 sync to allow OCP version release development