### PR TITLE
operators [R] tf-operator (0.0.1-2011 1.0.0)

### DIFF
--- a/operators/tf-operator/0.0.1-2011/metadata/annotations.yaml
+++ b/operators/tf-operator/0.0.1-2011/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: tf-operator
-  com.redhat.openshift.versions: "v4.6-v4.8"
+  com.redhat.openshift.versions: "=v4.6"
   # Updating com.redhat.openshift.versions programmatically.
   # This annotation was update because was possible to identify that this distribution uses API(s),
   # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, this annotation will prevent the bundle from being distributed on 4.9.

--- a/operators/tf-operator/1.0.0/metadata/annotations.yaml
+++ b/operators/tf-operator/1.0.0/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: tf-operator
-  com.redhat.openshift.versions: "v4.6-v4.8"
+  com.redhat.openshift.versions: "=v4.6"
   # Updating com.redhat.openshift.versions programmatically.
   # This annotation was update because was possible to identify that this distribution uses API(s),
   # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, this annotation will prevent the bundle from being distributed on 4.9.


### PR DESCRIPTION
Signed-off-by: J0zi <jbreza@redhat.com>

@ivanvtimofeev, bundle label from `annotations.yaml` (v4.6-v.4.8) is in conflict with olm.properties (max v4.6) from clusterserviceversion. Please let me know if it is better to set bundle label to `=v.46` or raise `olm.maxOpenShiftVersion` to `v4.8`.