### PR TITLE
operators ack-lambda-controller (0.0.8)

### DIFF
--- a/operators/ack-lambda-controller/0.0.8/bundle.Dockerfile
+++ b/operators/ack-lambda-controller/0.0.8/bundle.Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ack-lambda-controller
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.16.0+git
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=unknown
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-controller.clusterserviceversion.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-controller.clusterserviceversion.yaml
@@ -1,0 +1,302 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "lambda.services.k8s.aws/v1alpha1",
+          "kind": "Alias",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "lambda.services.k8s.aws/v1alpha1",
+          "kind": "CodeSigningConfig",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "lambda.services.k8s.aws/v1alpha1",
+          "kind": "EventSourceMapping",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "lambda.services.k8s.aws/v1alpha1",
+          "kind": "Function",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {}
+        }
+      ]
+    capabilities: Basic Install
+    categories: Cloud Provider
+    certified: "false"
+    containerImage: public.ecr.aws/aws-controllers-k8s/lambda-controller:v0.0.8
+    createdAt: "2022-02-15 09:28:47"
+    description: AWS Lambda controller is a service controller for managing Lambda
+      resources in Kubernetes
+    operatorframework.io/suggested-namespace: ack-system
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
+    operators.operatorframework.io/project_layout: unknown
+    repository: https://github.com/aws-controllers-k8s
+    support: Community
+  name: ack-lambda-controller.v0.0.8
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Alias represents the state of an AWS lambda Alias resource.
+      displayName: Alias
+      kind: Alias
+      name: aliases.lambda.services.k8s.aws
+      version: v1alpha1
+    - description: CodeSigningConfig represents the state of an AWS lambda CodeSigningConfig
+        resource.
+      displayName: CodeSigningConfig
+      kind: CodeSigningConfig
+      name: codesigningconfigs.lambda.services.k8s.aws
+      version: v1alpha1
+    - description: EventSourceMapping represents the state of an AWS lambda EventSourceMapping
+        resource.
+      displayName: EventSourceMapping
+      kind: EventSourceMapping
+      name: eventsourcemappings.lambda.services.k8s.aws
+      version: v1alpha1
+    - description: Function represents the state of an AWS lambda Function resource.
+      displayName: Function
+      kind: Function
+      name: functions.lambda.services.k8s.aws
+      version: v1alpha1
+  description: |-
+    Manage Amazon Lambda resources in AWS from within your Kubernetes cluster.
+
+    **About Amazon Lambda**
+
+    Lambda is a compute service that lets you run code without provisioning or managing servers. Lambda runs your code on a high-availability compute infrastructure and performs all of the administration of the compute resources, including server and operating system maintenance, capacity provisioning and automatic scaling, code monitoring and logging. With Lambda, you can run code for virtually any type of application or backend service. All you need to do is supply your code in one of the [languages that Lambda supports](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+
+    **About the AWS Controllers for Kubernetes**
+
+    This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s) project. This project is currently in **developer preview**.
+
+    **Pre-Installation Steps**
+
+    Please follow the following link: [Red Hat OpenShift](https://aws-controllers-k8s.github.io/community/docs/user-docs/openshift/)
+  displayName: AWS Controllers for Kubernetes - Amazon Lambda
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IiB2aWV3Qm94PSIwIDAgMzA0IDE4MiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzA0IDE4MjsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMyNTJGM0U7fQoJLnN0MXtmaWxsLXJ1bGU6ZXZlbm9kZDtjbGlwLXJ1bGU6ZXZlbm9kZDtmaWxsOiNGRjk5MDA7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04Ni40LDY2LjRjMCwzLjcsMC40LDYuNywxLjEsOC45YzAuOCwyLjIsMS44LDQuNiwzLjIsNy4yYzAuNSwwLjgsMC43LDEuNiwwLjcsMi4zYzAsMS0wLjYsMi0xLjksM2wtNi4zLDQuMiAgIGMtMC45LDAuNi0xLjgsMC45LTIuNiwwLjljLTEsMC0yLTAuNS0zLTEuNEM3Ni4yLDkwLDc1LDg4LjQsNzQsODYuOGMtMS0xLjctMi0zLjYtMy4xLTUuOWMtNy44LDkuMi0xNy42LDEzLjgtMjkuNCwxMy44ICAgYy04LjQsMC0xNS4xLTIuNC0yMC03LjJjLTQuOS00LjgtNy40LTExLjItNy40LTE5LjJjMC04LjUsMy0xNS40LDkuMS0yMC42YzYuMS01LjIsMTQuMi03LjgsMjQuNS03LjhjMy40LDAsNi45LDAuMywxMC42LDAuOCAgIGMzLjcsMC41LDcuNSwxLjMsMTEuNSwyLjJ2LTcuM2MwLTcuNi0xLjYtMTIuOS00LjctMTZjLTMuMi0zLjEtOC42LTQuNi0xNi4zLTQuNmMtMy41LDAtNy4xLDAuNC0xMC44LDEuM2MtMy43LDAuOS03LjMsMi0xMC44LDMuNCAgIGMtMS42LDAuNy0yLjgsMS4xLTMuNSwxLjNjLTAuNywwLjItMS4yLDAuMy0xLjYsMC4zYy0xLjQsMC0yLjEtMS0yLjEtMy4xdi00LjljMC0xLjYsMC4yLTIuOCwwLjctMy41YzAuNS0wLjcsMS40LTEuNCwyLjgtMi4xICAgYzMuNS0xLjgsNy43LTMuMywxMi42LTQuNWM0LjktMS4zLDEwLjEtMS45LDE1LjYtMS45YzExLjksMCwyMC42LDIuNywyNi4yLDguMWM1LjUsNS40LDguMywxMy42LDguMywyNC42VjY2LjR6IE00NS44LDgxLjYgICBjMy4zLDAsNi43LTAuNiwxMC4zLTEuOGMzLjYtMS4yLDYuOC0zLjQsOS41LTYuNGMxLjYtMS45LDIuOC00LDMuNC02LjRjMC42LTIuNCwxLTUuMywxLTguN3YtNC4yYy0yLjktMC43LTYtMS4zLTkuMi0xLjcgICBjLTMuMi0wLjQtNi4zLTAuNi05LjQtMC42Yy02LjcsMC0xMS42LDEuMy0xNC45LDRjLTMuMywyLjctNC45LDYuNS00LjksMTEuNWMwLDQuNywxLjIsOC4yLDMuNywxMC42ICAgQzM3LjcsODAuNCw0MS4yLDgxLjYsNDUuOCw4MS42eiBNMTI2LjEsOTIuNGMtMS44LDAtMy0wLjMtMy44LTFjLTAuOC0wLjYtMS41LTItMi4xLTMuOUw5Ni43LDEwLjJjLTAuNi0yLTAuOS0zLjMtMC45LTQgICBjMC0xLjYsMC44LTIuNSwyLjQtMi41aDkuOGMxLjksMCwzLjIsMC4zLDMuOSwxYzAuOCwwLjYsMS40LDIsMiwzLjlsMTYuOCw2Ni4ybDE1LjYtNjYuMmMwLjUtMiwxLjEtMy4zLDEuOS0zLjljMC44LTAuNiwyLjItMSw0LTEgICBoOGMxLjksMCwzLjIsMC4zLDQsMWMwLjgsMC42LDEuNSwyLDEuOSwzLjlsMTUuOCw2N2wxNy4zLTY3YzAuNi0yLDEuMy0zLjMsMi0zLjljMC44LTAuNiwyLjEtMSwzLjktMWg5LjNjMS42LDAsMi41LDAuOCwyLjUsMi41ICAgYzAsMC41LTAuMSwxLTAuMiwxLjZjLTAuMSwwLjYtMC4zLDEuNC0wLjcsMi41bC0yNC4xLDc3LjNjLTAuNiwyLTEuMywzLjMtMi4xLDMuOWMtMC44LDAuNi0yLjEsMS0zLjgsMWgtOC42Yy0xLjksMC0zLjItMC4zLTQtMSAgIGMtMC44LTAuNy0xLjUtMi0xLjktNEwxNTYsMjNsLTE1LjQsNjQuNGMtMC41LDItMS4xLDMuMy0xLjksNGMtMC44LDAuNy0yLjIsMS00LDFIMTI2LjF6IE0yNTQuNiw5NS4xYy01LjIsMC0xMC40LTAuNi0xNS40LTEuOCAgIGMtNS0xLjItOC45LTIuNS0xMS41LTRjLTEuNi0wLjktMi43LTEuOS0zLjEtMi44Yy0wLjQtMC45LTAuNi0xLjktMC42LTIuOHYtNS4xYzAtMi4xLDAuOC0zLjEsMi4zLTMuMWMwLjYsMCwxLjIsMC4xLDEuOCwwLjMgICBjMC42LDAuMiwxLjUsMC42LDIuNSwxYzMuNCwxLjUsNy4xLDIuNywxMSwzLjVjNCwwLjgsNy45LDEuMiwxMS45LDEuMmM2LjMsMCwxMS4yLTEuMSwxNC42LTMuM2MzLjQtMi4yLDUuMi01LjQsNS4yLTkuNSAgIGMwLTIuOC0wLjktNS4xLTIuNy03Yy0xLjgtMS45LTUuMi0zLjYtMTAuMS01LjJMMjQ2LDUyYy03LjMtMi4zLTEyLjctNS43LTE2LTEwLjJjLTMuMy00LjQtNS05LjMtNS0xNC41YzAtNC4yLDAuOS03LjksMi43LTExLjEgICBjMS44LTMuMiw0LjItNiw3LjItOC4yYzMtMi4zLDYuNC00LDEwLjQtNS4yYzQtMS4yLDguMi0xLjcsMTIuNi0xLjdjMi4yLDAsNC41LDAuMSw2LjcsMC40YzIuMywwLjMsNC40LDAuNyw2LjUsMS4xICAgYzIsMC41LDMuOSwxLDUuNywxLjZjMS44LDAuNiwzLjIsMS4yLDQuMiwxLjhjMS40LDAuOCwyLjQsMS42LDMsMi41YzAuNiwwLjgsMC45LDEuOSwwLjksMy4zdjQuN2MwLDIuMS0wLjgsMy4yLTIuMywzLjIgICBjLTAuOCwwLTIuMS0wLjQtMy44LTEuMmMtNS43LTIuNi0xMi4xLTMuOS0xOS4yLTMuOWMtNS43LDAtMTAuMiwwLjktMTMuMywyLjhjLTMuMSwxLjktNC43LDQuOC00LjcsOC45YzAsMi44LDEsNS4yLDMsNy4xICAgYzIsMS45LDUuNywzLjgsMTEsNS41bDE0LjIsNC41YzcuMiwyLjMsMTIuNCw1LjUsMTUuNSw5LjZjMy4xLDQuMSw0LjYsOC44LDQuNiwxNGMwLDQuMy0wLjksOC4yLTIuNiwxMS42ICAgYy0xLjgsMy40LTQuMiw2LjQtNy4zLDguOGMtMy4xLDIuNS02LjgsNC4zLTExLjEsNS42QzI2NC40LDk0LjQsMjU5LjcsOTUuMSwyNTQuNiw5NS4xeiIvPgoJPGc+CgkJPHBhdGggY2xhc3M9InN0MSIgZD0iTTI3My41LDE0My43Yy0zMi45LDI0LjMtODAuNywzNy4yLTEyMS44LDM3LjJjLTU3LjYsMC0xMDkuNS0yMS4zLTE0OC43LTU2LjdjLTMuMS0yLjgtMC4zLTYuNiwzLjQtNC40ICAgIGM0Mi40LDI0LjYsOTQuNywzOS41LDE0OC44LDM5LjVjMzYuNSwwLDc2LjYtNy42LDExMy41LTIzLjJDMjc0LjIsMTMzLjYsMjc4LjksMTM5LjcsMjczLjUsMTQzLjd6Ii8+CgkJPHBhdGggY2xhc3M9InN0MSIgZD0iTTI4Ny4yLDEyOC4xYy00LjItNS40LTI3LjgtMi42LTM4LjUtMS4zYy0zLjIsMC40LTMuNy0yLjQtMC44LTQuNWMxOC44LTEzLjIsNDkuNy05LjQsNTMuMy01ICAgIGMzLjYsNC41LTEsMzUuNC0xOC42LDUwLjJjLTIuNywyLjMtNS4zLDEuMS00LjEtMS45QzI4Mi41LDE1NS43LDI5MS40LDEzMy40LDI4Ny4yLDEyOC4xeiIvPgoJPC9nPgo8L2c+Cjwvc3ZnPg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - aliases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - aliases/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - codesigningconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - codesigningconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - eventsourcemappings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - eventsourcemappings/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - functions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - lambda.services.k8s.aws
+          resources:
+          - functions/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - services.k8s.aws
+          resources:
+          - adoptedresources
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - services.k8s.aws
+          resources:
+          - adoptedresources/status
+          verbs:
+          - get
+          - patch
+          - update
+        serviceAccountName: ack-lambda-controller
+      deployments:
+      - name: ack-lambda-controller
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller
+            spec:
+              containers:
+              - args:
+                - --aws-region
+                - $(AWS_REGION)
+                - --enable-development-logging
+                - $(ACK_ENABLE_DEVELOPMENT_LOGGING)
+                - --log-level
+                - $(ACK_LOG_LEVEL)
+                - --resource-tags
+                - $(ACK_RESOURCE_TAGS)
+                - --watch-namespace
+                - $(ACK_WATCH_NAMESPACE)
+                command:
+                - ./bin/controller
+                env:
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                envFrom:
+                - configMapRef:
+                    name: ack-user-config
+                    optional: false
+                - secretRef:
+                    name: ack-user-secrets
+                    optional: false
+                image: public.ecr.aws/aws-controllers-k8s/lambda-controller:v0.0.8
+                name: controller
+                ports:
+                - containerPort: 8080
+                  name: http
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 300Mi
+                  requests:
+                    cpu: 100m
+                    memory: 200Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  runAsNonRoot: true
+              serviceAccountName: ack-lambda-controller
+              terminationGracePeriodSeconds: 10
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - lambda
+  - aws
+  - amazon
+  - ack
+  links:
+  - name: AWS Controllers for Kubernetes
+    url: https://github.com/aws-controllers-k8s/community
+  - name: Documentation
+    url: https://aws-controllers-k8s.github.io/community/
+  - name: Amazon Lambda Developer Resources
+    url: https://aws.amazon.com/lambda/resources/
+  maintainers:
+  - email: ack-maintainers@amazon.com
+    name: lambda maintainer team
+  maturity: alpha
+  provider:
+    name: Amazon, Inc.
+    url: https://aws.amazon.com
+  version: 0.0.8

--- a/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-metrics-service_v1_service.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: ack-lambda-metrics-service
+spec:
+  ports:
+  - name: metricsport
+    port: 8080
+    protocol: TCP
+    targetPort: http
+  selector:
+    control-plane: controller
+  type: NodePort
+status:
+  loadBalancer: {}

--- a/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-reader_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-reader_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-lambda-reader
+rules:
+- apiGroups:
+  - lambda.services.k8s.aws
+  resources:
+  - aliases
+  - codesigningconfigs
+  - eventsourcemappings
+  - functions
+  verbs:
+  - get
+  - list
+  - watch

--- a/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-writer_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/ack-lambda-writer_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-lambda-writer
+rules:
+- apiGroups:
+  - lambda.services.k8s.aws
+  resources:
+  - aliases
+  - codesigningconfigs
+  - eventsourcemappings
+  - functions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - lambda.services.k8s.aws
+  resources:
+  - aliases
+  - codesigningconfigs
+  - eventsourcemappings
+  - functions
+  verbs:
+  - get
+  - patch
+  - update

--- a/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_aliases.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_aliases.yaml
@@ -1,0 +1,140 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: aliases.lambda.services.k8s.aws
+spec:
+  group: lambda.services.k8s.aws
+  names:
+    kind: Alias
+    listKind: AliasList
+    plural: aliases
+    singular: alias
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Alias is the Schema for the Aliases API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              description:
+                description: A description of the alias.
+                type: string
+              functionName:
+                description: "The name of the Lambda function. \n Name formats \n
+                  \   * Function name - MyFunction. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
+                  \n    * Partial ARN - 123456789012:function:MyFunction. \n The length
+                  constraint applies only to the full ARN. If you specify only the
+                  function name, it is limited to 64 characters in length."
+                type: string
+              functionVersion:
+                description: The function version that the alias invokes.
+                type: string
+              name:
+                description: The name of the alias.
+                type: string
+              routingConfig:
+                description: The routing configuration (https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html#configuring-alias-routing)
+                  of the alias.
+                properties:
+                  additionalVersionWeights:
+                    additionalProperties:
+                      type: number
+                    type: object
+                type: object
+            required:
+            - functionName
+            - functionVersion
+            - name
+            type: object
+          status:
+            description: AliasStatus defines the observed state of Alias
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              revisionID:
+                description: A unique identifier that changes when you update the
+                  alias.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_codesigningconfigs.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_codesigningconfigs.yaml
@@ -1,0 +1,136 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: codesigningconfigs.lambda.services.k8s.aws
+spec:
+  group: lambda.services.k8s.aws
+  names:
+    kind: CodeSigningConfig
+    listKind: CodeSigningConfigList
+    plural: codesigningconfigs
+    singular: codesigningconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CodeSigningConfig is the Schema for the CodeSigningConfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "CodeSigningConfigSpec defines the desired state of CodeSigningConfig.
+              \n Details about a Code signing configuration (https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html)."
+            properties:
+              allowedPublishers:
+                description: Signing profiles for this code signing configuration.
+                properties:
+                  signingProfileVersionARNs:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              codeSigningPolicies:
+                description: The code signing policies define the actions to take
+                  if the validation checks fail.
+                properties:
+                  untrustedArtifactOnDeployment:
+                    type: string
+                type: object
+              description:
+                description: Descriptive name for this code signing configuration.
+                type: string
+            required:
+            - allowedPublishers
+            type: object
+          status:
+            description: CodeSigningConfigStatus defines the observed state of CodeSigningConfig
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              codeSigningConfigID:
+                description: Unique identifer for the Code signing configuration.
+                type: string
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastModified:
+                description: The date and time that the Code signing configuration
+                  was last modified, in ISO-8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_eventsourcemappings.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_eventsourcemappings.yaml
@@ -1,0 +1,267 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: eventsourcemappings.lambda.services.k8s.aws
+spec:
+  group: lambda.services.k8s.aws
+  names:
+    kind: EventSourceMapping
+    listKind: EventSourceMappingList
+    plural: eventsourcemappings
+    singular: eventsourcemapping
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EventSourceMapping is the Schema for the EventSourceMappings
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EventSourceMappingSpec defines the desired state of EventSourceMapping.
+            properties:
+              batchSize:
+                description: "The maximum number of records in each batch that Lambda
+                  pulls from your stream or queue and sends to your function. Lambda
+                  passes all of the records in the batch to the function in a single
+                  call, up to the payload limit for synchronous invocation (6 MB).
+                  \n    * Amazon Kinesis - Default 100. Max 10,000. \n    * Amazon
+                  DynamoDB Streams - Default 100. Max 1,000. \n    * Amazon Simple
+                  Queue Service - Default 10. For standard queues the max    is 10,000.
+                  For FIFO queues the max is 10. \n    * Amazon Managed Streaming
+                  for Apache Kafka - Default 100. Max 10,000. \n    * Self-Managed
+                  Apache Kafka - Default 100. Max 10,000."
+                format: int64
+                type: integer
+              bisectBatchOnFunctionError:
+                description: (Streams only) If the function returns an error, split
+                  the batch in two and retry.
+                type: boolean
+              destinationConfig:
+                description: (Streams only) An Amazon SQS queue or Amazon SNS topic
+                  destination for discarded records.
+                properties:
+                  onFailure:
+                    description: A destination for events that failed processing.
+                    properties:
+                      destination:
+                        type: string
+                    type: object
+                  onSuccess:
+                    description: A destination for events that were processed successfully.
+                    properties:
+                      destination:
+                        type: string
+                    type: object
+                type: object
+              enabled:
+                description: "When true, the event source mapping is active. When
+                  false, Lambda pauses polling and invocation. \n Default: True"
+                type: boolean
+              eventSourceARN:
+                description: "The Amazon Resource Name (ARN) of the event source.
+                  \n    * Amazon Kinesis - The ARN of the data stream or a stream
+                  consumer. \n    * Amazon DynamoDB Streams - The ARN of the stream.
+                  \n    * Amazon Simple Queue Service - The ARN of the queue. \n    *
+                  Amazon Managed Streaming for Apache Kafka - The ARN of the cluster."
+                type: string
+              functionName:
+                description: "The name of the Lambda function. \n Name formats \n
+                  \   * Function name - MyFunction. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction.
+                  \n    * Version or Alias ARN - arn:aws:lambda:us-west-2:123456789012:function:MyFunction:PROD.
+                  \n    * Partial ARN - 123456789012:function:MyFunction. \n The length
+                  constraint applies only to the full ARN. If you specify only the
+                  function name, it's limited to 64 characters in length."
+                type: string
+              functionResponseTypes:
+                description: (Streams only) A list of current response type enums
+                  applied to the event source mapping.
+                items:
+                  type: string
+                type: array
+              maximumBatchingWindowInSeconds:
+                description: "(Streams and Amazon SQS standard queues) The maximum
+                  amount of time, in seconds, that Lambda spends gathering records
+                  before invoking the function. \n Default: 0 \n Related setting:
+                  When you set BatchSize to a value greater than 10, you must set
+                  MaximumBatchingWindowInSeconds to at least 1."
+                format: int64
+                type: integer
+              maximumRecordAgeInSeconds:
+                description: (Streams only) Discard records older than the specified
+                  age. The default value is infinite (-1).
+                format: int64
+                type: integer
+              maximumRetryAttempts:
+                description: (Streams only) Discard records after the specified number
+                  of retries. The default value is infinite (-1). When set to infinite
+                  (-1), failed records will be retried until the record expires.
+                format: int64
+                type: integer
+              parallelizationFactor:
+                description: (Streams only) The number of batches to process from
+                  each shard concurrently.
+                format: int64
+                type: integer
+              queues:
+                description: (MQ) The name of the Amazon MQ broker destination queue
+                  to consume.
+                items:
+                  type: string
+                type: array
+              selfManagedEventSource:
+                description: The Self-Managed Apache Kafka cluster to send records.
+                properties:
+                  endpoints:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    type: object
+                type: object
+              sourceAccessConfigurations:
+                description: An array of authentication protocols or VPC components
+                  required to secure your event source.
+                items:
+                  description: To secure and define access to your event source, you
+                    can specify the authentication protocol, VPC components, or virtual
+                    host.
+                  properties:
+                    type_:
+                      type: string
+                    uRI:
+                      type: string
+                  type: object
+                type: array
+              startingPosition:
+                description: The position in a stream from which to start reading.
+                  Required for Amazon Kinesis, Amazon DynamoDB, and Amazon MSK Streams
+                  sources. AT_TIMESTAMP is only supported for Amazon Kinesis streams.
+                type: string
+              startingPositionTimestamp:
+                description: With StartingPosition set to AT_TIMESTAMP, the time from
+                  which to start reading.
+                format: date-time
+                type: string
+              topics:
+                description: The name of the Kafka topic.
+                items:
+                  type: string
+                type: array
+              tumblingWindowInSeconds:
+                description: (Streams only) The duration in seconds of a processing
+                  window. The range is between 1 second up to 900 seconds.
+                format: int64
+                type: integer
+            required:
+            - functionName
+            type: object
+          status:
+            description: EventSourceMappingStatus defines the observed state of EventSourceMapping
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              functionARN:
+                description: The ARN of the Lambda function.
+                type: string
+              lastModified:
+                description: The date that the event source mapping was last updated
+                  or that its state changed.
+                format: date-time
+                type: string
+              lastProcessingResult:
+                description: The result of the last Lambda invocation of your function.
+                type: string
+              state:
+                description: 'The state of the event source mapping. It can be one
+                  of the following: Creating, Enabling, Enabled, Disabling, Disabled,
+                  Updating, or Deleting.'
+                type: string
+              stateTransitionReason:
+                description: Indicates whether a user or Lambda made the last change
+                  to the event source mapping.
+                type: string
+              uuid:
+                description: The identifier of the event source mapping.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_functions.yaml
+++ b/operators/ack-lambda-controller/0.0.8/manifests/lambda.services.k8s.aws_functions.yaml
@@ -1,0 +1,361 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: functions.lambda.services.k8s.aws
+spec:
+  group: lambda.services.k8s.aws
+  names:
+    kind: Function
+    listKind: FunctionList
+    plural: functions
+    singular: function
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Function is the Schema for the Functions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FunctionSpec defines the desired state of Function.
+            properties:
+              architectures:
+                description: The instruction set architecture that the function supports.
+                  Enter a string array with one of the valid values. The default value
+                  is x86_64.
+                items:
+                  type: string
+                type: array
+              code:
+                description: The code for the function.
+                properties:
+                  imageURI:
+                    type: string
+                  s3Bucket:
+                    type: string
+                  s3Key:
+                    type: string
+                  s3ObjectVersion:
+                    type: string
+                  zipFile:
+                    format: byte
+                    type: string
+                type: object
+              codeSigningConfigARN:
+                description: To enable code signing for this function, specify the
+                  ARN of a code-signing configuration. A code-signing configuration
+                  includes a set of signing profiles, which define the trusted publishers
+                  for this function.
+                type: string
+              deadLetterConfig:
+                description: A dead letter queue configuration that specifies the
+                  queue or topic where Lambda sends asynchronous events when they
+                  fail processing. For more information, see Dead Letter Queues (https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#dlq).
+                properties:
+                  targetARN:
+                    type: string
+                type: object
+              description:
+                description: A description of the function.
+                type: string
+              environment:
+                description: Environment variables that are accessible from function
+                  code during execution.
+                properties:
+                  variables:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              fileSystemConfigs:
+                description: Connection settings for an Amazon EFS file system.
+                items:
+                  description: Details about the connection between a Lambda function
+                    and an Amazon EFS file system (https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem.html).
+                  properties:
+                    arn:
+                      type: string
+                    localMountPath:
+                      type: string
+                  type: object
+                type: array
+              handler:
+                description: The name of the method within your code that Lambda calls
+                  to execute your function. The format includes the file name. It
+                  can also include namespaces and other qualifiers, depending on the
+                  runtime. For more information, see Programming Model (https://docs.aws.amazon.com/lambda/latest/dg/programming-model-v2.html).
+                type: string
+              imageConfig:
+                description: Container image configuration values (https://docs.aws.amazon.com/lambda/latest/dg/configuration-images.html#configuration-images-settings)
+                  that override the values in the container image Dockerfile.
+                properties:
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  entryPoint:
+                    items:
+                      type: string
+                    type: array
+                  workingDirectory:
+                    type: string
+                type: object
+              kmsKeyARN:
+                description: The ARN of the Amazon Web Services Key Management Service
+                  (KMS) key that's used to encrypt your function's environment variables.
+                  If it's not provided, Lambda uses a default service key.
+                type: string
+              memorySize:
+                description: The amount of memory available to the function (https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html)
+                  at runtime. Increasing the function memory also increases its CPU
+                  allocation. The default value is 128 MB. The value can be any multiple
+                  of 1 MB.
+                format: int64
+                type: integer
+              name:
+                description: "The name of the Lambda function. \n Name formats \n
+                  \   * Function name - my-function. \n    * Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function.
+                  \n    * Partial ARN - 123456789012:function:my-function. \n The
+                  length constraint applies only to the full ARN. If you specify only
+                  the function name, it is limited to 64 characters in length."
+                type: string
+              packageType:
+                description: The type of deployment package. Set to Image for container
+                  image and set Zip for ZIP archive.
+                type: string
+              publish:
+                description: Set to true to publish the first version of the function
+                  during creation.
+                type: boolean
+              reservedConcurrentExecutions:
+                description: The number of simultaneous executions to reserve for
+                  the function.
+                format: int64
+                type: integer
+              role:
+                description: The Amazon Resource Name (ARN) of the function's execution
+                  role.
+                type: string
+              runtime:
+                description: The identifier of the function's runtime (https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                description: A list of tags (https://docs.aws.amazon.com/lambda/latest/dg/tagging.html)
+                  to apply to the function.
+                type: object
+              timeout:
+                description: The amount of time that Lambda allows a function to run
+                  before stopping it. The default is 3 seconds. The maximum allowed
+                  value is 900 seconds. For additional information, see Lambda execution
+                  environment (https://docs.aws.amazon.com/lambda/latest/dg/runtimes-context.html).
+                format: int64
+                type: integer
+              tracingConfig:
+                description: Set Mode to Active to sample and trace a subset of incoming
+                  requests with X-Ray (https://docs.aws.amazon.com/lambda/latest/dg/services-xray.html).
+                properties:
+                  mode:
+                    type: string
+                type: object
+              vpcConfig:
+                description: For network connectivity to Amazon Web Services resources
+                  in a VPC, specify a list of security groups and subnets in the VPC.
+                  When you connect a function to a VPC, it can only access resources
+                  and the internet through that VPC. For more information, see VPC
+                  Settings (https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html).
+                properties:
+                  securityGroupIDs:
+                    items:
+                      type: string
+                    type: array
+                  subnetIDs:
+                    items:
+                      type: string
+                    type: array
+                type: object
+            required:
+            - code
+            - name
+            - role
+            type: object
+          status:
+            description: FunctionStatus defines the observed state of Function
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              codeSHA256:
+                description: The SHA256 hash of the function's deployment package.
+                type: string
+              codeSize:
+                description: The size of the function's deployment package, in bytes.
+                format: int64
+                type: integer
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageConfigResponse:
+                description: The function's image configuration values.
+                properties:
+                  error:
+                    description: Error response to GetFunctionConfiguration.
+                    properties:
+                      errorCode:
+                        type: string
+                      message:
+                        type: string
+                    type: object
+                  imageConfig:
+                    description: Configuration values that override the container
+                      image Dockerfile settings. See Container settings (https://docs.aws.amazon.com/lambda/latest/dg/images-create.html#images-parms).
+                    properties:
+                      command:
+                        items:
+                          type: string
+                        type: array
+                      entryPoint:
+                        items:
+                          type: string
+                        type: array
+                      workingDirectory:
+                        type: string
+                    type: object
+                type: object
+              lastModified:
+                description: The date and time that the function was last updated,
+                  in ISO-8601 format (https://www.w3.org/TR/NOTE-datetime) (YYYY-MM-DDThh:mm:ss.sTZD).
+                type: string
+              lastUpdateStatus:
+                description: The status of the last update that was performed on the
+                  function. This is first set to Successful after function creation
+                  completes.
+                type: string
+              lastUpdateStatusReason:
+                description: The reason for the last update that was performed on
+                  the function.
+                type: string
+              lastUpdateStatusReasonCode:
+                description: The reason code for the last update that was performed
+                  on the function.
+                type: string
+              layers:
+                description: The function's layers (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+                items:
+                  description: An Lambda layer (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
+                  properties:
+                    arn:
+                      type: string
+                    codeSize:
+                      format: int64
+                      type: integer
+                    signingJobARN:
+                      type: string
+                    signingProfileVersionARN:
+                      type: string
+                  type: object
+                type: array
+              masterARN:
+                description: For Lambda@Edge functions, the ARN of the master function.
+                type: string
+              revisionID:
+                description: The latest updated revision of the function or alias.
+                type: string
+              signingJobARN:
+                description: The ARN of the signing job.
+                type: string
+              signingProfileVersionARN:
+                description: The ARN of the signing profile version.
+                type: string
+              state:
+                description: The current state of the function. When the state is
+                  Inactive, you can reactivate the function by invoking it.
+                type: string
+              stateReason:
+                description: The reason for the function's current state.
+                type: string
+              stateReasonCode:
+                description: The reason code for the function's current state. When
+                  the code is Creating, you can't invoke or modify the function.
+                type: string
+              version:
+                description: The version of the Lambda function.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/ack-lambda-controller/0.0.8/metadata/annotations.yaml
+++ b/operators/ack-lambda-controller/0.0.8/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ack-lambda-controller
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/ack-lambda-controller/0.0.8/tests/scorecard/config.yaml
+++ b/operators/ack-lambda-controller/0.0.8/tests/scorecard/config.yaml
@@ -1,0 +1,50 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.7.1
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
After the release of ACK [lambda-controller:v0.0.8](https://gallery.ecr.aws/aws-controllers-k8s/lambda-controller), the automation job failed to generate the PR for the OLM bundle.
So I am manually raising these PR by following the instructions mentioned in the issue [here](https://github.com/aws-controllers-k8s/community/issues/1164)

NOTE: `CreateContainerConfigError` is expected since `ACK controllers` have pre-installation steps to create resources in a cluster before the manager pod can come up.