### PR TITLE
operators [O] external-secrets-operator (0.4.3)

### DIFF
--- a/operators/external-secrets-operator/0.4.3/metadata/annotations.yaml
+++ b/operators/external-secrets-operator/0.4.3/metadata/annotations.yaml
@@ -4,7 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: external-secrets-operator
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1


### PR DESCRIPTION
bump external-secrets-operator 0.4.3

The initial release of 0.4.3 was accidentally made without the stable channel. This PR promotes the existing release to stable.

relates to: https://github.com/external-secrets/external-secrets/issues/746