### PR TITLE
operators [N] [CI] deployment-validation-operator (0.2.2)

### DIFF
--- a/operators/deployment-validation-operator/0.2.2/manifests/deploymentvalidationoperator.0.2.2.clusterserviceversion.yaml
+++ b/operators/deployment-validation-operator/0.2.2/manifests/deploymentvalidationoperator.0.2.2.clusterserviceversion.yaml
@@ -1,0 +1,158 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+    categories: Application Runtime, Monitoring, Security
+    certified: "false"
+    containerImage: quay.io/deployment-validation-operator/dv-operator:0.2.2
+    createdAt: 12/14/2021
+    description: The deployment validation operator
+    repository: https://github.com/app-sre/deployment-validation-operator
+    support: Best Effort
+    ignore-check.kube-linter.io/minimum-three-replicas: "This deployment uses 1 pod as currently replicating does not replicate metric data causing installation issues"
+  name: deployment-validation-operator.v0.2.2
+spec:
+  description: "The Deployment Validator Operator(DVO) checks deployments and other\
+    \ resources against a curated collection of best practices.\nThese best practices\
+    \ focus mainly on ensuring that the applications are fault-tolerant.\n\n### Configuration\n\
+    \ To configure the checks Operator runs or to run your own custom checks, you can use a \
+    \ ConfigMap created in the **same namespace** as operator itself. ConfigMap should be named as \
+    \ *deployment-validation-operator-config* and contain *deployment-validation-operator-config.yaml* as data.\
+    \ [Example](https://github.com/app-sre/deployment-validation-operator/blob/master/deploy/openshift/configmap.yaml)\n\
+    \ \n### Metrics\nDVO will report failed validations via Prometheus metrics. All the metrics\
+    \ are gauges that will report `1` if the best-practice has failed.\nThere is \
+    \ [Instruction](https://github.com/app-sre/deployment-validation-operator#install-dashboard)\
+    \ to install a simple grafana dashboard."
+  displayName: Deployment Validation Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: deployment-validation-operator
+      deployments:
+      - name: deployment-validation-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: deployment-validation-operator
+          strategy:
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 0
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                app: deployment-validation-operator
+                name: deployment-validation-operator
+            spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: app
+                          operator: In
+                          values:
+                          - deployment-validation-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 100
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  value: ""
+                - name: OPERATOR_NAME
+                  value: deployment-validation-operator
+                - name: NAMESPACE_IGNORE_PATTERN
+                  value: "openshift.+|kube-.+"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                image: quay.io/deployment-validation-operator/dv-operator:0.2.2
+                imagePullPolicy: Always
+                name: deployment-validation-operator
+                args:
+                - --config /config/deployment-validation-operator-config.yaml
+                resources:
+                  requests:
+                    memory: "256Mi"
+                    cpu: "100n"
+                  limits:
+                    memory: "2Gi"
+                    cpu: "1"
+                volumeMounts:
+                - name: dvo-config
+                  mountPath: /config
+                securityContext:
+                  readOnlyRootFilesystem: true
+              restartPolicy: Always
+              serviceAccountName: deployment-validation-operator
+              terminationGracePeriodSeconds: 30
+              volumes:
+                - name: dvo-config
+                  configMap:
+                    optional: true
+                    name: deployment-validation-operator-config
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          verbs:
+          - get
+          - create
+          - list
+          - delete
+          - update
+          - watch
+          - patch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        serviceAccountName: deployment-validation-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: AllNamespaces
+  - supported: false
+    type: MultiNamespace
+  keywords:
+  - dvo
+  labels:
+    alm-owner-dvo: deployment-validation-operator
+    operated-by: deployment-validation-operator
+  links:
+  - name: repository
+    url: https://github.com/app-sre/deployment-validation-operator
+  - name: containerImage
+    url: https://quay.io/deployment-validation-operator/dv-operator:0.2.2
+  maturity: alpha
+  provider:
+    name: Red Hat
+  selector:
+    matchLabels:
+      alm-owner-dvo: deployment-validation-operator
+      operated-by: deployment-validation-operator
+  version: 0.2.2

--- a/operators/deployment-validation-operator/0.2.2/metadata/annotations.yaml
+++ b/operators/deployment-validation-operator/0.2.2/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: deployment-validation-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/deployment-validation-operator/0.2.2/tests/scorecard/config.yaml
+++ b/operators/deployment-validation-operator/0.2.2/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.7.2
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/operators/deployment-validation-operator/ci.yaml
+++ b/operators/deployment-validation-operator/ci.yaml
@@ -1,0 +1,10 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode
+
+reviewers:
+  - bkez322
+  - BumbleFeng
+  - npecka
+  - deepak1725
+  - TGPSKI


### PR DESCRIPTION
### New Submissions

### Operator Description must contain (in order)

The Deployment Validation Operator (DVO) checks deployments and other resources against a curated collection of best practices. 

These best practices focus mainly on ensuring that the applications are fault-tolerant.

DVO will only monitor Kubernetes resources and will not modify them in any way. As an operator it is a continuously running version of the static analysis tool Kube-linter [https://github.com/stackrox/kube-linter]. It will report failed validations via Prometheus, which will allow users of this operator to create alerts based on its results. All the metrics are gauges that will report `1` if the best-practice has failed. The metric will always have three parameters: `name`, `namespace` and `kind`. 

This operator doesn't define any CRDs at the moment. It has been bootstrapped with `operator-sdk` making it possible to add a CRD in the future if required.
