### PR TITLE
Disabling temporary 4.11 update due to cleanup

### DIFF
--- a/ci/pipeline-config-ocp.yaml
+++ b/ci/pipeline-config-ocp.yaml
@@ -13,7 +13,7 @@ production:
       - v4.8-db
       - v4.9-db
       - v4.10-db
-      - v4.11-rc
+      # - v4.11-rc
     latest: "v4.6"
     signature:
       enabled: 1


### PR DESCRIPTION
Disabling temporary 4.11 update due to cleanup
Signed-off-by: J0zi <jbreza@redhat.com>
