### PR TITLE
Pipeline uses the last supported ose image

### DIFF
--- a/ci/pipeline-config-ocp.yaml
+++ b/ci/pipeline-config-ocp.yaml
@@ -30,7 +30,6 @@ production:
         - v4.9
         - v4.10
         - v4.11
-        - v4.12
       postfix: s
     registry: quay.io
 #    organization: community-operators-backup


### PR DESCRIPTION
Pipeline uses the last supported ose image
Signed-off-by: J0zi <jbreza@redhat.com>

Thanks for submitting your Operator. Please check the below list before you create your Pull Request.

