### PR TITLE
Enable v4.12 as cleaned out index

### DIFF
--- a/ci/pipeline-config-ocp.yaml
+++ b/ci/pipeline-config-ocp.yaml
@@ -12,7 +12,7 @@ production:
       - v4.9-db
       - v4.10-db
       - v4.11
-      # - v4.12-rc
+      - v4.12
     latest: "v4.6"
     signature:
       enabled: 1


### PR DESCRIPTION
Signed-off-by: J0zi <jbreza@redhat.com>
Enable v4.12 as cleaned out index