### PR TITLE
operator [R] annotationlab (3.4.0 4.1.2 4.2.0 4.2.1 4.3.0 4.4.0 4.4.1)

### DIFF
--- a/operators/annotationlab/3.4.0/metadata/annotations.yaml
+++ b/operators/annotationlab/3.4.0/metadata/annotations.yaml
@@ -12,4 +12,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/annotationlab/4.1.2/metadata/annotations.yaml
+++ b/operators/annotationlab/4.1.2/metadata/annotations.yaml
@@ -12,4 +12,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/annotationlab/4.2.0/metadata/annotations.yaml
+++ b/operators/annotationlab/4.2.0/metadata/annotations.yaml
@@ -12,4 +12,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/annotationlab/4.2.1/metadata/annotations.yaml
+++ b/operators/annotationlab/4.2.1/metadata/annotations.yaml
@@ -12,4 +12,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/annotationlab/4.3.0/metadata/annotations.yaml
+++ b/operators/annotationlab/4.3.0/metadata/annotations.yaml
@@ -12,4 +12,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/annotationlab/4.4.0/metadata/annotations.yaml
+++ b/operators/annotationlab/4.4.0/metadata/annotations.yaml
@@ -12,4 +12,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/annotationlab/4.4.1/metadata/annotations.yaml
+++ b/operators/annotationlab/4.4.1/metadata/annotations.yaml
@@ -12,4 +12,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.8-v4.11
+  


### PR DESCRIPTION
Dear @becash143, @skattoju,

Recently, there were some problem detecting correctly deprecation of api for k8s v1.25 (ocp v4.12) and we modified your annotations to limit some version of your operator for ocp `<v4.12`. This PR should revert this change. Please verify if your versions are working on `v4.12`. Please approve this change to be merged.

**Sorry for the inconvenience.**

Community operators team

Signed-off-by: Martin Vala <mavala@redhat.com>