### PR TITLE
operator [R] aqua (2022.4.6 2022.4.7 6.5.8)

### DIFF
--- a/operators/aqua/2022.4.6/metadata/annotations.yaml
+++ b/operators/aqua/2022.4.6/metadata/annotations.yaml
@@ -7,4 +7,4 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: aqua
 
   # Annotations to specify OCP versions compatibility.
-  com.redhat.openshift.versions: v4.6-v4.11
+  com.redhat.openshift.versions: v4.6

--- a/operators/aqua/2022.4.7/metadata/annotations.yaml
+++ b/operators/aqua/2022.4.7/metadata/annotations.yaml
@@ -7,4 +7,4 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: aqua
 
   # Annotations to specify OCP versions compatibility.
-  com.redhat.openshift.versions: v4.6-v4.11
+  com.redhat.openshift.versions: v4.6

--- a/operators/aqua/6.5.8/metadata/annotations.yaml
+++ b/operators/aqua/6.5.8/metadata/annotations.yaml
@@ -7,4 +7,4 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: aqua
 
   # Annotations to specify OCP versions compatibility.
-  com.redhat.openshift.versions: v4.6-v4.11
+  com.redhat.openshift.versions: v4.6


### PR DESCRIPTION
Dear @guyyakir, @yossig-aquasec, @baruchbilanski, @semyonmor,

Recently, there were some problem detecting correctly deprecation of api for k8s v1.25 (ocp v4.12) and we modified your annotations to limit some version of your operator for ocp `<v4.12`. This PR should revert this change. Please verify if your versions are working on `v4.12`. Please approve this change to be merged.

**Sorry for the inconvenience.**

Community operators team

Signed-off-by: Martin Vala <mavala@redhat.com>