### PR TITLE
operator [O] percona-xtradb-cluster-operator (1.12.0)

### DIFF
--- a/operators/percona-xtradb-cluster-operator/1.12.0/metadata/annotations.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.12.0/metadata/annotations.yaml
@@ -6,4 +6,4 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: percona-xtradb-cluster-operator
-  com.redhat.openshift.versions: v4.10-v4.11
+  com.redhat.openshift.versions: v4.10


### PR DESCRIPTION
Dear @cap1984,

Recently, there were some problem detecting correctly deprecation of api for k8s v1.25 (ocp v4.12) and we modified your annotations to limit some version of your operator for ocp `<v4.12`. This PR should revert this change. Please verify if your versions are working on `v4.12`. Please approve this change to be merged.

**Sorry for the inconvenience.**

Community operators team

Signed-off-by: Martin Vala <mavala@redhat.com>