### PR TITLE
operator [R] dynatrace-operator (0.10.0 0.10.1 0.9.0 0.9.1)

### DIFF
--- a/operators/dynatrace-operator/0.10.0/metadata/annotations.yaml
+++ b/operators/dynatrace-operator/0.10.0/metadata/annotations.yaml
@@ -9,5 +9,3 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/dynatrace-operator/0.10.1/metadata/annotations.yaml
+++ b/operators/dynatrace-operator/0.10.1/metadata/annotations.yaml
@@ -9,5 +9,3 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/dynatrace-operator/0.9.0/metadata/annotations.yaml
+++ b/operators/dynatrace-operator/0.9.0/metadata/annotations.yaml
@@ -10,4 +10,3 @@ annotations:
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
 
-  com.redhat.openshift.versions: v4.8-v4.11

--- a/operators/dynatrace-operator/0.9.1/metadata/annotations.yaml
+++ b/operators/dynatrace-operator/0.9.1/metadata/annotations.yaml
@@ -9,5 +9,3 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   operators.operatorframework.io.bundle.channel.default.v1: alpha
-
-  com.redhat.openshift.versions: v4.8-v4.11


### PR DESCRIPTION
Dear @dt-team-kubernetes, @meik99, @0sewa0, @DTMad, @chrismuellner, @gkrenn, @luhi-DT, @mjgrzybek, @aorcholski, @waodim, @baichinger,

Recently, there were some problem detecting correctly deprecation of api for k8s v1.25 (ocp v4.12) and we modified your annotations to limit some version of your operator for ocp `<v4.12`. This PR should revert this change. Please verify if your versions are working on `v4.12`. Please approve this change to be merged.

**Sorry for the inconvenience.**

Community operators team

Signed-off-by: Martin Vala <mavala@redhat.com>