### PR TITLE
operator [O] seldon-operator (1.15.0)

### DIFF
--- a/operators/seldon-operator/1.15.0/metadata/annotations.yaml
+++ b/operators/seldon-operator/1.15.0/metadata/annotations.yaml
@@ -13,4 +13,3 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: "v4.8-v4.11"


### PR DESCRIPTION
Dear @cliveseldon, @axsaucedo, @rafalskolasinski, 

Recently, there were some problem detecting correctly deprecation of api for k8s v1.25 (ocp v4.12) and we modified your annotations to limit some version of your operator for ocp `<v4.12`. This PR should revert this change. Please verify if your versions are working on `v4.12`. Please approve this change to be merged.

**Sorry for the inconvenience.**

Community operators team

Signed-off-by: Martin Vala <mavala@redhat.com>