### PR TITLE
operator [R] awx-operator (0.30.0 1.0.0 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4 1.2.0 1.3.0 1.4.0 2.0.0 2.0.1 2.1.0 2.2.1)

### DIFF
--- a/operators/awx-operator/0.30.0/metadata/annotations.yaml
+++ b/operators/awx-operator/0.30.0/metadata/annotations.yaml
@@ -1,4 +1,6 @@
 annotations:
+  com.redhat.openshift.versions: v4.10-v4.13
+
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/

--- a/operators/awx-operator/1.0.0/metadata/annotations.yaml
+++ b/operators/awx-operator/1.0.0/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.1.0/metadata/annotations.yaml
+++ b/operators/awx-operator/1.1.0/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.1.1/metadata/annotations.yaml
+++ b/operators/awx-operator/1.1.1/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.1.2/metadata/annotations.yaml
+++ b/operators/awx-operator/1.1.2/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.1.3/metadata/annotations.yaml
+++ b/operators/awx-operator/1.1.3/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.1.4/metadata/annotations.yaml
+++ b/operators/awx-operator/1.1.4/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.2.0/metadata/annotations.yaml
+++ b/operators/awx-operator/1.2.0/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.3.0/metadata/annotations.yaml
+++ b/operators/awx-operator/1.3.0/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/1.4.0/metadata/annotations.yaml
+++ b/operators/awx-operator/1.4.0/metadata/annotations.yaml
@@ -1,5 +1,6 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
+
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/

--- a/operators/awx-operator/2.0.0/metadata/annotations.yaml
+++ b/operators/awx-operator/2.0.0/metadata/annotations.yaml
@@ -1,5 +1,6 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
+
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/

--- a/operators/awx-operator/2.0.1/metadata/annotations.yaml
+++ b/operators/awx-operator/2.0.1/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/2.1.0/metadata/annotations.yaml
+++ b/operators/awx-operator/2.1.0/metadata/annotations.yaml
@@ -1,5 +1,5 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
 
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1

--- a/operators/awx-operator/2.2.1/metadata/annotations.yaml
+++ b/operators/awx-operator/2.2.1/metadata/annotations.yaml
@@ -1,5 +1,6 @@
 annotations:
-  com.redhat.openshift.versions: v4.10-v4.12
+  com.redhat.openshift.versions: v4.10-v4.13
+
   # Core bundle annotations.
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/


### PR DESCRIPTION
The `awx-operator` does not have `v4.13` included in its annotation range, leaving updated clusters without the ability to see updated versions. Also, with the operator's `v0.30.0` version _not_ having the annotation, it becomes the only installable version on 4.13 (even with newer versions preinstalled).

This commit adds the annotation to the older release, and modifies the range to `v4.10-v4.13`.

Resolves #2729 