### PR TITLE
operator [R] gitlab-operator-kubernetes (0.11.3 0.11.4 0.13.1 0.13.2 0.13.3 0.13.4 0.14.0 0.14.2 0.15.0 0.15.1 0.15.2 0.15.3 0.15.5 0.16.0 0.16.1 0.16.2 0.16.3 0.17.0 0.17.1 0.17.2 0.17.3 0.18.0 0.18.1 0.18.2 0.18.3 0.19.0)

### DIFF
--- a/operators/gitlab-operator-kubernetes/0.11.3/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.11.3/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.11.4/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.11.4/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.13.1/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.13.1/metadata/annotations.yaml
@@ -15,3 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
 
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.13.2/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.13.2/metadata/annotations.yaml
@@ -15,3 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
 
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.13.3/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.13.3/metadata/annotations.yaml
@@ -15,3 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
 
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.13.4/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.13.4/metadata/annotations.yaml
@@ -15,3 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
 
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.14.0/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.14.0/metadata/annotations.yaml
@@ -15,3 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
 
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.14.2/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.14.2/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.15.0/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.15.0/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.15.1/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.15.1/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.15.2/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.15.2/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.15.3/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.15.3/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.15.5/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.15.5/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.16.0/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.16.0/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.16.1/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.16.1/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.16.2/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.16.2/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.16.3/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.16.3/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.17.0/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.17.0/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.17.1/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.17.1/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.17.2/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.17.2/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.17.3/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.17.3/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.18.0/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.18.0/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.18.1/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.18.1/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.18.2/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.18.2/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.18.3/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.18.3/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12

--- a/operators/gitlab-operator-kubernetes/0.19.0/metadata/annotations.yaml
+++ b/operators/gitlab-operator-kubernetes/0.19.0/metadata/annotations.yaml
@@ -13,3 +13,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.10-v4.12


### PR DESCRIPTION
Update annotations of all GitLab Operator versions that do not have `com.redhat.openshift.versions` annotation.

This change addresses https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/issues/1314.

fixes: #2988

Thanks for submitting your Operator. Please check the below list before you create your Pull Request.

### New Submissions

* [ ] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-via-pr.md)?
* [ ] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [ ] Have you tested your Operator with all Custom Resource Definitions?
* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
* [ ] Have you considered whether you want to use [semantic versioning order](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md#semver-mode)?
* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?
* [ ] Is operator [icon](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#operator-icon) set?

### Updates to existing Operators

* [ ] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [ ] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [ ] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [ ] Have you tested an update to your Operator when deployed via OLM?
* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [ ] Modify more than one operator
* [ ] Modify an Operator you don't own
* [ ] Rename an operator - please remove and add with a different name instead
* [ ] Modify any files outside the above mentioned folders
* [ ] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [ ] Description of the managed Application and where to find more information
2. [ ] Features and capabilities of your Operator and how to use it
3. [ ] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [ ] Human readable name and 1-liner description about your Operator
* [ ] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories)<sup>1</sup>
* [ ] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [ ] Links to the maintainer, source code and documentation
* [ ] Example templates for all Custom Resource Definitions intended to be used
* [ ] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file an issue against this repo and explain your need

<sup>2</sup> For more information see [here](https://sdk.operatorframework.io/docs/overview/#operator-capability-level)
