### PR TITLE
operator [R] konveyor-operator (0.1.1 0.1.2 0.2.0-alpha.1 0.2.0-alpha.2 0.2.0-alpha.3 0.2.1 0.3.0-alpha.1 0.3.0-alpha.2 0.3.0-alpha.3 0.3.0-alpha.4 0.3.0-alpha.5 0.3.0-alpha.6 0.3.0-beta.1.1 0.3.0-beta.1.2 0.3.0-beta.2)

### DIFF
--- a/operators/konveyor-operator/0.1.1/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.1.1/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -375,6 +375,3 @@ spec:
       image: quay.io/konveyor/postgresql-12-centos7@sha256:3e50f54ed6bff4738f811f69b9584dbe64276abefce29ca11801cd5762cbe82c
   version: 0.1.1
   minKubeVersion: 1.22.0
-  replaces: konveyor-operator.v0.1.0
-  skips:
-    - konveyor-operator.v0.1.0

--- a/operators/konveyor-operator/0.1.2/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.1.2/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -375,6 +375,3 @@ spec:
       image: quay.io/konveyor/postgresql-12-centos7@sha256:1287d947464fbf5275feb31d106d2feb856c6117f0eaec8d947f2e03bd8618c5
   version: 0.1.2
   minKubeVersion: 1.22.0
-  replaces: konveyor-operator.v0.1.1
-  skips:
-    - konveyor-operator.v0.1.1

--- a/operators/konveyor-operator/0.2.0-alpha.1/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.2.0-alpha.1/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -375,6 +375,3 @@ spec:
       image: quay.io/konveyor/postgresql-12-centos7@sha256:1287d947464fbf5275feb31d106d2feb856c6117f0eaec8d947f2e03bd8618c5
   version: 0.2.0-alpha.1
   minKubeVersion: 1.22.0
-  replaces: konveyor-operator.v0.1.1
-  skips:
-    - konveyor-operator.v0.1.1

--- a/operators/konveyor-operator/0.2.0-alpha.2/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.2.0-alpha.2/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -375,6 +375,3 @@ spec:
       image: quay.io/konveyor/postgresql-12-centos7@sha256:1287d947464fbf5275feb31d106d2feb856c6117f0eaec8d947f2e03bd8618c5
   version: 0.2.0-alpha.2
   minKubeVersion: 1.22.0
-  replaces: konveyor-operator.v0.2.0-alpha.1
-  skips:
-    - konveyor-operator.v0.2.0-alpha.1

--- a/operators/konveyor-operator/0.2.0-alpha.3/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.2.0-alpha.3/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -383,6 +383,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-windup@sha256:54a223f2acdf4313659425598903723f08d69a4bff157f9c25c0507bbc1d698c
       name: addon-windup
   version: 0.2.0-alpha.3
-  replaces: konveyor-operator.v0.2.0-alpha.2
-  skips:
-    - konveyor-operator.v0.2.0-alpha.2

--- a/operators/konveyor-operator/0.2.1/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.2.1/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -380,6 +380,3 @@ spec:
       image: quay.io/konveyor/postgresql-12-centos7@sha256:6016530ab1fce71d29421ce9a97b3a89fbbb126b87b1b079c6aadebb7ff5664c
   version: 0.2.1
   minKubeVersion: 1.22.0
-  replaces: konveyor-operator.v0.2.0
-  skips:
-    - konveyor-operator.v0.2.0

--- a/operators/konveyor-operator/0.3.0-alpha.1/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-alpha.1/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:0c2ce8169d115cd76490726b77a2259c90fb1e7673b7f89e15aaac7058e0f72d
       name: addon-analyzer
   version: 0.3.0-alpha.1
-  replaces: konveyor-operator.v0.2.0-alpha.3
-  skips:
-    - konveyor-operator.v0.2.0-alpha.3

--- a/operators/konveyor-operator/0.3.0-alpha.2/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-alpha.2/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:75f1f97c4488484bcedb7a3331d711b42b08fb947a9b14624efc11375761e30e
       name: addon-analyzer
   version: 0.3.0-alpha.2
-  replaces: konveyor-operator.v0.3.0-alpha.1
-  skips:
-    - konveyor-operator.v0.3.0-alpha.1

--- a/operators/konveyor-operator/0.3.0-alpha.3/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-alpha.3/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:d13c4e7f5ed7e7f00eb2b119059c0648adbb5fdd0aa0c6e1bb40514a937cb48e
       name: addon-analyzer
   version: 0.3.0-alpha.3
-  replaces: konveyor-operator.v0.3.0-alpha.2
-  skips:
-    - konveyor-operator.v0.3.0-alpha.2

--- a/operators/konveyor-operator/0.3.0-alpha.4/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-alpha.4/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:2995a31144fa8bca4ae76fa924c229b1a483a2cc18e36b61ebae966708fe7cb4
       name: addon-analyzer
   version: 0.3.0-alpha.4
-  replaces: konveyor-operator.v0.3.0-alpha.3
-  skips:
-    - konveyor-operator.v0.3.0-alpha.3

--- a/operators/konveyor-operator/0.3.0-alpha.5/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-alpha.5/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:e6f16f95086a92cbf916c6b6dd3fcfc497997cd15e54f45702510410c69fac37
       name: addon-analyzer
   version: 0.3.0-alpha.5
-  replaces: konveyor-operator.v0.3.0-alpha.4
-  skips:
-    - konveyor-operator.v0.3.0-alpha.4

--- a/operators/konveyor-operator/0.3.0-alpha.6/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-alpha.6/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:bca938b4f6f1125b283af5c3eca95e01662fdb01cab9f7226d5a0ff48c873aa1
       name: addon-analyzer
   version: 0.3.0-alpha.6
-  replaces: konveyor-operator.v0.3.0-alpha.5
-  skips:
-    - konveyor-operator.v0.3.0-alpha.5

--- a/operators/konveyor-operator/0.3.0-beta.1.1/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-beta.1.1/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:961473ff47d622409e59de7654bf668da05278c9c827b1caae8033bd5b9ba67f
       name: addon-analyzer
   version: 0.3.0-beta.1.1
-  replaces: konveyor-operator.v0.3.0-beta.1
-  skips:
-    - konveyor-operator.v0.3.0-beta.1

--- a/operators/konveyor-operator/0.3.0-beta.1.2/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-beta.1.2/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -372,6 +372,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:3ae238bcfdf92fc0f90724dc0c4333b89bc85af4023146502bd0e09ea7cad2a8
       name: addon-analyzer
   version: 0.3.0-beta.1.2
-  replaces: konveyor-operator.v0.3.0-beta.1.1
-  skips:
-    - konveyor-operator.v0.3.0-beta.1.1

--- a/operators/konveyor-operator/0.3.0-beta.2/manifests/konveyor-operator.clusterserviceversion.yaml
+++ b/operators/konveyor-operator/0.3.0-beta.2/manifests/konveyor-operator.clusterserviceversion.yaml
@@ -367,6 +367,3 @@ spec:
     - image: quay.io/konveyor/tackle2-addon-analyzer@sha256:fe3b25ecb831e66849aef89a24b11f935fe0a1230fcc44e1ab74ddf075c51870
       name: addon-analyzer
   version: 0.3.0-beta.2
-  replaces: konveyor-operator.v0.3.0-beta.1.2
-  skips:
-    - konveyor-operator.v0.3.0-beta.1.2


### PR DESCRIPTION
This should bring the konveyor-operator into compliance with the requirements of the semver mode change made in #3595 
