### PR TITLE
project-quay: remove empty "replaces"

### DIFF
--- a/operators/project-quay/3.10.0/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.10.0/manifests/quay-operator.clusterserviceversion.yaml
@@ -277,4 +277,3 @@ spec:
       alm-owner-quay-operator: quay-operator
       operated-by: quay-operator
   version: 3.10.0
-  replaces: "" ## Except for ".0", always put the previous z-stream here

--- a/operators/project-quay/3.8.0-rc.1/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.8.0-rc.1/manifests/quay-operator.clusterserviceversion.yaml
@@ -284,4 +284,3 @@ spec:
       alm-owner-quay-operator: quay-operator
       operated-by: quay-operator
   version: 3.8.0-rc.1
-  # replaces: quay-operator.v3.7.6 ## Except for ".0", always put the previous z-stream here

--- a/operators/project-quay/3.8.0/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.8.0/manifests/quay-operator.clusterserviceversion.yaml
@@ -284,4 +284,3 @@ spec:
       alm-owner-quay-operator: quay-operator
       operated-by: quay-operator
   version: 3.8.0
-  replaces: "" ## Except for ".0", always put the previous z-stream here

--- a/operators/project-quay/3.9.0/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.9.0/manifests/quay-operator.clusterserviceversion.yaml
@@ -272,4 +272,3 @@ spec:
       alm-owner-quay-operator: quay-operator
       operated-by: quay-operator
   version: 3.9.0
-  replaces: "" ## Except for ".0", always put the previous z-stream here


### PR DESCRIPTION
`replaces` can be missing or be a non-empty string.
This PR removes `replaces` that use empty strings.