### PR TITLE
PROOF OF CONCEPT: onboarding operators to FBC via a script and use of composite catalog template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,8 @@ $RECYCLE.BIN/
 site
 results.json
 scripts/add-ocp-labels/vendor/
+
+# tmp
+scripts/catalog-cache/
+bin/
+

--- a/catalog-definitions.yaml
+++ b/catalog-definitions.yaml
@@ -1,0 +1,44 @@
+schema: olm.composite.catalogs
+catalogs:
+- name: v4.10
+  destination:
+    workingDir: catalogs/v4.10
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver
+- name: v4.11
+  destination:
+    workingDir: catalogs/v4.11
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver
+- name: v4.12
+  destination:
+    workingDir: catalogs/v4.12
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver
+- name: v4.13
+  destination:
+    workingDir: catalogs/v4.13
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver
+- name: v4.14
+  destination:
+    workingDir: catalogs/v4.14
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver
+- name: v4.15
+  destination:
+    workingDir: catalogs/v4.15
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver
+- name: v4.16
+  destination:
+    workingDir: catalogs/v4.16
+  builders:
+    - olm.builder.basic
+    - olm.builder.semver

--- a/scripts/Makefile.template
+++ b/scripts/Makefile.template
@@ -1,0 +1,109 @@
+
+TOPDIR=$(abspath $(dir $(MAKEFILE_LIST))/../../)
+BINDIR=${TOPDIR}/bin
+SCRIPTDIR=${TOPDIR}/scripts
+OPERATOR_NAME = %%OPERATOR_NAME%%
+OPERATOR_CATALOG_DIR = ${TOPDIR}/catalog/${OPERATOR_NAME}
+OPERATOR_CATALOG_CONTRIBUTION = ${OPERATOR_CATALOG_DIR}/catalog.yaml
+OPERATOR_CATALOG_PRECURSOR_DIR = catalog-data
+YQ = bin/yq
+
+
+# the catalog contribution target will enforce that the user selected an FBC build approach and generated the catalog
+${OPERATOR_CATALOG_CONTRIBUTION}:
+	@echo "${OPERATOR_CATALOG_CONTRIBUTION} does not exist"; \
+         echo ">>> you must first customize and execute 'make catalog' to generate the catalog contribution"; \
+         false;
+
+.PHONY: catalog
+# replace this stub with one customized to serve your needs ... some examples below
+#catalog: ${OPERATOR_CATALOG_CONTRIBUTION}
+#
+# in order to have a deliverable target, the CI workflow executes the target "catalog" and wraps the resulting catalog contribution in
+# a PR to the modeled catalog repo
+#
+# here are a few examples of different approaches to fulfilling this target
+# comment out / customize the one that makes the most sense, or use them as examples in defining your own
+#
+# --- BASIC TEMPLATE ---
+#catalog: basic
+#
+# --- SEMVER TEMPLATE ---
+#catalog: semver framework
+#
+# --- COMPOSITE TEMPLATE ---
+catalog: composite
+#
+#  --- POST-PROCESS CUSTOM BUILDER ---
+#  this case is for when a single template cannot support the use-case, and automated changes to the generated FBC need to be made before it is complete
+#  this example models the need to set the v0.2.1 of the operator with the `olm.deprecated` property, to prevent installation
+#
+#catalog: $(YQ) semver framework
+#	$(YQ) eval 'select(.name == "testoperator.v0.2.1" and .schema == "olm.bundle").properties += [{"type" : "olm.deprecated", "value" : "true"}]' -i  $(OPERATOR_CATALOG_CONTRIBUTION)
+
+# framework target provides two pieces that are helpful for any template approach:  
+#  - an OWNERS file to provide default contribution control
+#  - an .indexignore file to illustrate how to add content to the FBC contribution which should be 
+#    excluded from validation via `opm validate`
+.PHONY: framework
+framework: CATALOG_OWNERS
+	cp CATALOG_OWNERS $(OPERATOR_CATALOG_DIR)/OWNERS && \
+         echo "OWNERS" > $(OPERATOR_CATALOG_DIR)/.indexignore
+
+
+# basic target provides an example FBC generation from a `basic` template type.  
+# this example takes a single file as input and generates a well-formed FBC operator contribution as an output
+# the 'validate' target should be used next to validate the output
+.PHONY: basic
+basic: ${BINDIR}/opm ${OPERATOR_CATALOG_PRECURSOR_DIR}/basic-catalog-template.yaml clean
+	mkdir -p $(OPERATOR_CATALOG_DIR) && ${BINDIR}/opm alpha render-template basic -o yaml ${OPERATOR_CATALOG_PRECURSOR_DIR}/basic-catalog-template.yaml > $(OPERATOR_CATALOG_CONTRIBUTION)
+
+
+# semver target provides an example FBC generation from a `semver` template type.  
+# this example takes a single file as input and generates a well-formed FBC operator contribution as an output
+# the 'validate' target should be used next to validate the output
+.PHONY: semver
+semver: ${BINDIR}/opm ${OPERATOR_CATALOG_PRECURSOR_DIR}/semver-template.yaml clean
+	mkdir -p $(OPERATOR_CATALOG_DIR) && ${BINDIR}/opm alpha render-template semver -o yaml ${OPERATOR_CATALOG_PRECURSOR_DIR}/semver-template.yaml > $(OPERATOR_CATALOG_CONTRIBUTION)
+
+# composite target processes a composite template to generate the FBC contributions
+# `render-template composite` has `--validate` option enabled by default, 
+# so no subsequent validation is required
+.PHONY: composite
+composite: ${BINDIR}/opm
+	${BINDIR}/opm alpha render-template composite -f ${TOPDIR}/catalog-definitions.yaml -c ${OPERATOR_CATALOG_PRECURSOR_DIR}/contributions.yaml
+
+#
+# validate target illustrates FBC validation
+# all FBC must pass opm validation in order to be able to be used in a catalog
+.PHONY: validate
+validate: ${BINDIR}/opm $(OPERATOR_CATALOG_CONTRIBUTION) preverify
+	${BINDIR}/opm validate catalog && echo "catalog validation passed" || echo "catalog validation failed"
+
+
+# preverify target ensures that the operator name is consistent between the destination directory and the generated catalog
+# since the template will be modified outside the build process but needs to be consistent with the directory name
+.PHONY: preverify
+preverify: ${BINDIR}/$(YQ) $(OPERATOR_CATALOG_CONTRIBUTION)
+	./validate.sh -n $(OPERATOR_NAME) -f $(OPERATOR_CATALOG_CONTRIBUTION)
+
+
+.PHONY: clean
+clean:
+	rm -rf catalog
+
+
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+
+OPM_VERSION ?= v1.36.0
+${BINDIR}/opm:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm ${BINDIR}/opm
+
+YQ_VERSION=v4.22.1
+YQ_BINARY=yq_$(OS)_$(ARCH)
+${BINDIR}/$(YQ):
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	wget  https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -O ${BINDIR}/${YQ_BINARY} && chmod +x ${BINDIR}/${YQ_BINARY}
+

--- a/scripts/contributions.yaml.template
+++ b/scripts/contributions.yaml.template
@@ -1,0 +1,72 @@
+schema: olm.composite
+components:
+  - name: v4.10
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml
+  - name: v4.11
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml
+  - name: v4.12
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml
+  - name: v4.13
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml
+  - name: v4.14
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml
+  - name: v4.15
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml
+  - name: v4.16
+    destination:
+      path: %%OPERATOR_NAME%%
+    strategy:
+      name: basic
+      template:
+        schema: olm.builder.basic
+        config:
+          input: catalog-data/basic-catalog-template.yaml
+          output: catalog.yaml

--- a/scripts/fbc-onboard.sh
+++ b/scripts/fbc-onboard.sh
@@ -1,0 +1,124 @@
+#! /usr/bin/env bash
+#
+set -euo pipefail
+
+YQ=${YQ:-$(which yq)}
+OPM=${OPM:-$(which opm)}
+
+# cache curent dir as top of individual operator author hierarchy
+# we assume that everything below this is to be converted
+CWD=$(readlink -e .)
+if [ "$(basename $CWD)" != "community-operators-prod" ]; then
+    echo "error: this script should be run from the repo root dir (not $CWD)"
+    exit 255
+fi
+
+relative_curdir="."
+
+CATALOG_URI="registry.redhat.io/redhat/community-operator-index"
+CATALOG_VER="v4.15"
+
+# the location of where we cache catalog data to reduce the pull data
+CATALOG_CACHEDIR="$CWD/scripts/catalog-cache"
+CATALOG_CACHEFILE="$(basename $CATALOG_URI)-$CATALOG_VER.yaml"
+CATALOG_CACHEPATH="$CATALOG_CACHEDIR/$CATALOG_CACHEFILE"
+
+# the name of the location to which we render FBC
+CATALOG_DIR="catalog"
+# the name of the location to which we render template data precursors (templates, etc.)
+CATALOG_PRECURSOR_DIR="catalog-data"
+# the name of the location where per-operator config lives in this repo
+OPERATORS_DIR="operators"
+# the name of the basic catalog template file created in precursors dir
+PRECURSOR_FILE="basic-catalog-template.yaml"
+# the name of the CI integration file for the operator
+CI_FILE="ci.yaml"
+# the full path for the Makefile template that we'll set up for onboarding operators to use a basic catalog template
+MAKEFILE_TEMPLATE="$CWD/scripts/Makefile.template"
+CONTRIBUTIONS_TEMPLATE="$CWD/scripts/contributions.yaml.template"
+
+function usage() {
+    echo "usage: $0 [options] [operator-name1..operator-nameN]"
+    echo "where options are:"
+    echo " -h --help : this text"
+    exit 1
+}
+
+function cache_catalog() {
+    if [ ! -d "$CATALOG_CACHEDIR" ]; then
+        mkdir -p $CATALOG_CACHEDIR
+        if [ "$?" -ne "0" ]; then
+            echo "error: unable to create catalog cache directory"
+            exit 2
+        fi
+    fi
+    if [ -e $CATALOG_CACHEPATH ]; then
+        if [ $(find $CATALOG_CACHEDIR -mtime -1 -type f -name $CATALOG_CACHEFILE 2>/dev/null) ]; then
+            echo "catalog cache is fresh at $CATALOG_CACHEPATH"
+        fi
+    else
+        echo "caching catalog to $CATALOG_CACHEPATH"
+        set -x
+        # --migrate to keep the results small
+        $OPM render -o yaml --migrate "$CATALOG_URI:$CATALOG_VER" > $CATALOG_CACHEPATH
+        set +x
+        if [ ! -s "$CATALOG_CACHEPATH" ]; then
+            echo "error: unable to cache catalog"
+            exit 3
+        fi
+    fi
+}
+
+function scaffold_make() {
+    OPNAME="$1"
+    sed -e "s/%%OPERATOR_NAME%%/$OPNAME/" $MAKEFILE_TEMPLATE > $OPERATORS_DIR/$OPNAME/Makefile
+    sed -e "s/%%OPERATOR_NAME%%/$OPNAME/" $CONTRIBUTIONS_TEMPLATE> $OPERATORS_DIR/$OPNAME/$CATALOG_PRECURSOR_DIR/contributions.yaml
+
+}
+
+function mark_fbc() {
+    OPNAME="$1"
+    yq -i ".updateGraph = \"FBC\"" $OPERATORS_DIR/$OPNAME/$CI_FILE
+}
+
+function convert_operator() {
+    OPNAME="$1"
+    OPPATH="$OPERATORS_DIR/$OPNAME"
+    if [ ! -d "$OPPATH" ]; then
+        echo "specified operator does not exist: $OPNAME"
+        return
+    fi
+
+    if [ ! -d "$OPPATH/$CATALOG_PRECURSOR_DIR" ]; then
+        mkdir -p "$OPPATH/$CATALOG_PRECURSOR_DIR"
+    fi
+
+    set -x
+    $YQ eval "select(.name == \"$OPNAME\" or .package == \"$OPNAME\")" $CATALOG_CACHEPATH | \
+      $YQ eval 'select(.schema == "olm.bundle") = {"schema": .schema, "image": .image}' > $OPPATH/$CATALOG_PRECURSOR_DIR/$PRECURSOR_FILE
+    set +x
+
+    mark_fbc $OPNAME
+    scaffold_make $OPNAME
+}
+
+function main() {
+    cache_catalog
+
+    while [ "$#" -gt 0 ]; do
+        arg="$1"
+        shift
+
+        case "$arg" in
+            -h|--help)
+                usage
+                ;;
+            *)
+                convert_operator $arg
+                ;;
+        esac
+    done
+}
+
+main $*
+


### PR DESCRIPTION
To reduce complex processing flows in the pipeline for operator authors wishing to onboard to FBC, we prefer advertised interfaces and valid FBC instead of relying on specific tooling and knowledge of FBC "precursors".

This high-level catalog publishing flow [illustration](https://miro.com/app/board/uXjVP7EJ9Mk=/?moveToWidget=3458764544895458016&cot=14) breaks the FBC-to-catalog into three logical phases:

1. build the update graph FBC (possibly as a result of a new bundle version published)
2. validate and aggregate (non-FBC & FBC) contributions
3. publish the aggregate in an accessible registry

Before those steps can execute, operator authors need to be able to onboard to FBC.

This POC demonstrates the use of a script to fulfill an FBC onboarding process for one/more authors with clear messaging and interfaces, and provide capabilities to fulfill (1) above, external to any catalog construction pipeline. It will:

1. cache the (controlled by script vars) appropriate version of the catalog as FBC
2. extract the operator's catalog contribution from the catalog and convert to a [basic catalog template](https://olm.operatorframework.io/docs/reference/catalog-templates/#basic-template)
3. scaffold a [composite template](https://olm.operatorframework.io/docs/reference/catalog-templates/#composite-template) to generate FBC for all supported OCP versions
4. template a Makefile in the operator's subdirectory which will be configured by default to use the composite template to generate contributions via `catalog` make target.
5. mark the operator's ci.yaml file as FBC-onboarded by setting updateGraph property to "FBC".

Conventions:

1. uses yq/yaml
2. requires being executed from local repo root (and enforces it)
3. presumes the directory structure

```tree
operators/$operator_name
├── catalog-data
│   └── basic-catalog-template.yaml
└── ci.yaml
```


