### PR TITLE
Ignore FBC related directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ $RECYCLE.BIN/
 site
 results.json
 scripts/add-ocp-labels/vendor/
+
+# FBC related
+bin/


### PR DESCRIPTION
Part of FBC onboarding is downloading OPM tool to bin/ - this PR is to avoid accidentally push this folder with changes.
