### PR TITLE
[ISV-5341] fix broken links

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,20 +2,20 @@ Thanks for submitting your Operator. Please check the below list before you crea
 
 ### New Submissions
 
-* [ ] Are you familiar with our [contribution guidelines](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/contributing-via-pr.md)?
-* [ ] Are you familiar with our [operator pipeline](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/community-operator-pipeline.md)?
-* [ ] Have you tested your Operator with all Custom Resource Definitions [packaging](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/packaging-operator.md)?
-* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/operator-ci-yaml.md##Operator-versioning)?
+* [ ] Are you familiar with our [contribution guidelines](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/contributing-prerequisites/)?
+* [ ] Are you familiar with our [operator pipeline](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/pipelines_overview/)?
+* [ ] Have you tested your Operator with all Custom Resource Definitions [packaging](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)?
+* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
 * [ ] Have you considered whether you want to use [semantic versioning order](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md#semver-mode)?
-* [ ] Is your submission [signed](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/contributing-prerequisites.md#sign-your-work)?
-* [ ] Is operator [icon](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/packaging-operator.md#operator-icon) set?
+* [ ] Is your submission [signed](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/contributing-prerequisites/#sign-your-work)?
+* [ ] Is operator [icon](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#operator-icon) set?
 
 ### Your submission should not
 
 * [ ] Add more than one operator bundle per PR
 * [ ] Modify any operator
 * [ ] Rename an operator
-* [ ] Modify any files outside the above mentioned folders
+* [ ] Modify any files outside the above-mentioned folders
 * [ ] Contain more than one commit. **Please squash your commits.**
 
 ### Operator Description must contain (in order)
@@ -26,8 +26,8 @@ Thanks for submitting your Operator. Please check the below list before you crea
 
 ### Operator Metadata should contain
 
-* [ ] Human readable name and 1-liner description about your Operator
-* [ ] Valid [category name](https://github.com/redhat-openshift-ecosystem/community-operators-prod/blob/main/docs/packaging-operator.md#categories)<sup>1</sup>
+* [ ] Human-readable name and 1-liner description about your Operator
+* [ ] Valid [category](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories) name <sup>1</sup>
 * [ ] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
 * [ ] Links to the maintainer, source code and documentation
 * [ ] Example templates for all Custom Resource Definitions intended to be used


### PR DESCRIPTION
PR fixes non-existent links in the PR template.
2nd [PR](https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/750) fixes broken link in operator-pipelines repo.

---
Closes [ISV-5341](https://issues.redhat.com/browse/ISV-5341)