### PR TITLE
[ISV-5446] Configure allowed catalog bundle registries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,7 @@ tests:
     ignore_operators:
       - ^ibm-block-csi-operator-community
       - ^postgresql
+
+allowed_bundle_registries:
+  - quay.io/community-operator-pipeline-prod/
+  - quay.io/openshift-community-operators/


### PR DESCRIPTION
Configure image registries allowed for bundle images in catalog. Relates to the new static check in pipeline [check_bundle_images_in_fbc](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/docs/users/static_checks.md#check_bundle_images_in_fbc)

Closes ISV-5446