### PR TITLE
community-windows-machine-config-operator: mark 6.0.0 as only compatible with OpenShift 4.11

### DIFF
--- a/operators/community-windows-machine-config-operator/6.0.0/metadata/annotations.yaml
+++ b/operators/community-windows-machine-config-operator/6.0.0/metadata/annotations.yaml
@@ -9,7 +9,7 @@ annotations:
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.builder: operator-sdk-v2.0.0+git
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-  com.redhat.openshift.versions: "v4.11"
+  com.redhat.openshift.versions: "=v4.11"
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1


### PR DESCRIPTION
I'm running OKD 4.15, and discovered that community-windows-machine-config-operator 6.0.0 is available through the OperatorHub, but does only work with K8s 1.24 / 1.25

It looks like `com.redhat.openshift.versions: "v4.11""` means "compatible with 4.11 or later - other versions of community-windows-machine-config-operator, like 7.0.0 and 8.0.0 have it defined as `com.redhat.openshift.versions: "=v4.11"`, so I added the `=` for 6.0.0 as well.