### PR TITLE
Added missing "get" permission on nodes to Strimzi operator

### DIFF
--- a/operators/strimzi-kafka-operator/0.46.0/manifests/strimzi-cluster-operator.v0.46.0.clusterserviceversion.yaml
+++ b/operators/strimzi-kafka-operator/0.46.0/manifests/strimzi-cluster-operator.v0.46.0.clusterserviceversion.yaml
@@ -1156,8 +1156,11 @@ spec:
           # The cluster operator requires "list" permissions to view all nodes in a cluster
           # The listing is used to determine the node addresses when NodePort access is configured
           # These addresses are then exposed in the custom resource states
+          # The Kafka Brokers require "get" permissions to view the node they are on
+          # This information is used to generate a Rack ID that is used for High Availability configurations
           - nodes
           verbs:
+          - get
           - list
         serviceAccountName: strimzi-cluster-operator
       deployments:


### PR DESCRIPTION
This PR fixes a missing "get" permission within the CSV of the Strimzi operator 0.46.0

### Your submission should not

* [x] Add more than one operator bundle per PR
* [x] Modify any operator
* [x] Rename an operator
* [x] Modify any files outside the above-mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description of the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human-readable name and 1-liner description about your Operator
* [x] Valid [category](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories) name <sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo