### PR TITLE
[Hive] Add fbc.version_promotion_strategy

### DIFF
--- a/operators/hive-operator/ci.yaml
+++ b/operators/hive-operator/ci.yaml
@@ -1,18 +1,11 @@
 ---
 fbc:
   catalog_mapping:
-  - catalog_names:
-    - v4.12
-    - v4.13
-    - v4.14
-    - v4.15
-    - v4.16
-    - v4.17
-    - v4.18
-    - v4.19
+  - catalog_names: [v4.12, v4.13, v4.14, v4.15, v4.16, v4.17, v4.18, v4.19]
     template_name: basic.yaml
     type: olm.template.basic
   enabled: true
+  version_promotion_strategy: always
 packagemanifestClusterVersionLabel: auto
 reviewers:
 - 2uasimojo


### PR DESCRIPTION
- Set fbc.version_promotion_strategy to always
- Minor update to squash the OCP releases to a single line for catalog_names