### PR TITLE
Correction of the sha's of strimzi/kaniko-executor and strimzi/builda…

### DIFF
--- a/operators/strimzi-kafka-operator/0.49.1/manifests/strimzi-cluster-operator.v0.49.1.clusterserviceversion.yaml
+++ b/operators/strimzi-kafka-operator/0.49.1/manifests/strimzi-cluster-operator.v0.49.1.clusterserviceversion.yaml
@@ -1207,9 +1207,9 @@ spec:
                     - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
                       value: quay.io/strimzi/kafka-bridge@sha256:53034f64f0b672f10b5bacea1c7a25132f118df7fd5c9032c4dbf702ed93796a
                     - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-                      value: quay.io/strimzi/kaniko-executor@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4
+                      value: quay.io/strimzi/kaniko-executor@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e
                     - name: STRIMZI_DEFAULT_BUILDAH_IMAGE
-                      value: quay.io/strimzi/buildah@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e
+                      value: quay.io/strimzi/buildah@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4
                     - name: STRIMZI_DEFAULT_MAVEN_BUILDER
                       value: quay.io/strimzi/maven-builder@sha256:b8831c2aad621b80dce38484fae353cc5226bfc4dffb0f4c9d8b8d86e0fb3933
                     - name: STRIMZI_OPERATOR_NAMESPACE


### PR DESCRIPTION
This PR fixes the kaniko-executor and buildah sha of the Strimzi CSV manifest in version 0.49.1. 

When performing an 'oc mirror', the following error gets returned: 

`2025/12/10 14:54:29 [ERROR] : [Worker] error mirroring image docker://quay.io/strimzi/buildah@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e (Operator bundles: [strimzi-cluster-operator.v0.49.1] - Operators: [strimzi-kafka-operator]) error: initializing source docker://quay.io/strimzi/buildah@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e: reading manifest sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e in quay.io/strimzi/buildah: manifest unknown
969
2025/12/10 14:54:29 [ERROR] : [Worker] error mirroring image docker://quay.io/strimzi/kaniko-executor@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4 (Operator bundles: [strimzi-cluster-operator.v0.49.1] - Operators: [strimzi-kafka-operator]) error: initializing source docker://quay.io/strimzi/kaniko-executor@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4: reading manifest sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4 in quay.io/strimzi/kaniko-executor: manifest unknown`

The sha's of these 2 images are mixed up. See for reference: 
https://github.com/strimzi/strimzi-kafka-operator/releases/0.49.1

https://quay.io/repository/strimzi/kaniko-executor/manifest/sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e

https://quay.io/repository/strimzi/buildah/manifest/sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4