### PR TITLE
Fix mixed digests in related images in Strimzi 0.49.1

### DIFF
--- a/operators/strimzi-kafka-operator/0.49.1/manifests/strimzi-cluster-operator.v0.49.1.clusterserviceversion.yaml
+++ b/operators/strimzi-kafka-operator/0.49.1/manifests/strimzi-cluster-operator.v0.49.1.clusterserviceversion.yaml
@@ -1207,9 +1207,9 @@ spec:
                     - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
                       value: quay.io/strimzi/kafka-bridge@sha256:53034f64f0b672f10b5bacea1c7a25132f118df7fd5c9032c4dbf702ed93796a
                     - name: STRIMZI_DEFAULT_KANIKO_EXECUTOR_IMAGE
-                      value: quay.io/strimzi/kaniko-executor@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4
+                      value: quay.io/strimzi/kaniko-executor@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e
                     - name: STRIMZI_DEFAULT_BUILDAH_IMAGE
-                      value: quay.io/strimzi/buildah@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e
+                      value: quay.io/strimzi/buildah@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4
                     - name: STRIMZI_DEFAULT_MAVEN_BUILDER
                       value: quay.io/strimzi/maven-builder@sha256:b8831c2aad621b80dce38484fae353cc5226bfc4dffb0f4c9d8b8d86e0fb3933
                     - name: STRIMZI_OPERATOR_NAMESPACE
@@ -1269,9 +1269,9 @@ spec:
     - name: strimzi-bridge
       image: quay.io/strimzi/kafka-bridge@sha256:53034f64f0b672f10b5bacea1c7a25132f118df7fd5c9032c4dbf702ed93796a
     - name: strimzi-kaniko-executor
-      image: quay.io/strimzi/kaniko-executor@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4
+      image: quay.io/strimzi/kaniko-executor@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e
     - name: strimzi-buildah
-      image: quay.io/strimzi/buildah@sha256:a5088c14d7b8bf1d336669cba047b971bf3ece8969647dae2c1e3a07a7be0c5e
+      image: quay.io/strimzi/buildah@sha256:ba89470b45a49e5e09aaab91a5c3c03ecb14f9013d598bc14b3d756eb9a145b4
     - name: strimzi-maven-builder
       image: quay.io/strimzi/maven-builder@sha256:b8831c2aad621b80dce38484fae353cc5226bfc4dffb0f4c9d8b8d86e0fb3933
   keywords:


### PR DESCRIPTION
Two images in the Strimzi 0.49.1 submission are using wrong digests. This PR fixes them. This should address https://github.com/strimzi/strimzi-kafka-operator/issues/12230

### Your submission should not

* [x] Add more than one operator bundle per PR
* [ ] Modify any operator
* [x] Rename an operator
* [x] Modify any files outside the above-mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description of the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human-readable name and 1-liner description about your Operator
* [x] Valid [category](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories) name <sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo