### PR TITLE
arkmq-org-broker-operator 2.1.3: Fix missing container image digests

### DIFF
--- a/operators/arkmq-org-broker-operator/2.1.3/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
+++ b/operators/arkmq-org-broker-operator/2.1.3/manifests/arkmq-org-broker-operator.clusterserviceversion.yaml
@@ -5686,9 +5686,9 @@ spec:
                 - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2510
                   value: quay.io/arkmq-org/activemq-artemis-broker-kubernetes@sha256:f9de3d120d27f216eafe2b77038e742a7c1569bba0970455969620026dde7dfc
                 - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Init_2520
-                  value: quay.io/arkmq-org/activemq-artemis-broker-init@sha256:ec2616a67b7e462ad5571c78635cfe3d22c90ff4f6821b0ebbb61d65b9bafb66
+                  value: quay.io/arkmq-org/activemq-artemis-broker-init@sha256:4a5cf0c4b11c7ade4b7ac312daa697f1f8ba60a8b81f0b3e9a3e37c284cf9c1d
                 - name: RELATED_IMAGE_ActiveMQ_Artemis_Broker_Kubernetes_2520
-                  value: quay.io/arkmq-org/activemq-artemis-broker-kubernetes@sha256:fb725448599d6ad3d45b89c05338a7a911b3e9ed55840a4026e502ea36dadec1
+                  value: quay.io/arkmq-org/activemq-artemis-broker-kubernetes@sha256:cfcbdb91612ab0aaffd52d65336dfaaf10cecf98d859d517bd77b918800e049a
                 - name: OPERATOR_NAME
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
The ArkMQ Operator 2.1.3 points to some missing container image digests on quay.io.

I verified the correct image digests on:

- https://quay.io/repository/arkmq-org/activemq-artemis-broker-init?tab=tags
- https://quay.io/repository/arkmq-org/activemq-artemis-broker-kubernetes?tab=tags