### PR TITLE
operator koku-metrics-operator (4.4.0)

### DIFF
--- a/operators/koku-metrics-operator/4.4.0/manifests/costmanagement-metrics-cfg.openshift.io_costmanagementmetricsconfigs.yaml
+++ b/operators/koku-metrics-operator/4.4.0/manifests/costmanagement-metrics-cfg.openshift.io_costmanagementmetricsconfigs.yaml
@@ -1,0 +1,1065 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  creationTimestamp: null
+  labels:
+    app: koku-metrics-operator
+  name: costmanagementmetricsconfigs.costmanagement-metrics-cfg.openshift.io
+spec:
+  group: costmanagement-metrics-cfg.openshift.io
+  names:
+    kind: CostManagementMetricsConfig
+    listKind: CostManagementMetricsConfigList
+    plural: costmanagementmetricsconfigs
+    singular: costmanagementmetricsconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: CostManagementMetricsConfig is the Schema for the costmanagementmetricsconfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CostManagementMetricsConfigSpec defines the desired state
+              of CostManagementMetricsConfig.
+            properties:
+              api_url:
+                default: https://console.redhat.com
+                description: |-
+                  FOR DEVELOPMENT ONLY.
+                  APIURL is a field of CostManagementMetricsConfig to represent the url of the API endpoint for service interaction.
+                  The default is `https://console.redhat.com`.
+                type: string
+              authentication:
+                description: Authentication is a field of CostManagementMetricsConfig
+                  to represent the authentication object.
+                properties:
+                  secret_name:
+                    description: AuthenticationSecretName is a field of CostManagementMetricsConfig
+                      to represent the secret with the user and password used for
+                      uploads.
+                    type: string
+                  token_url:
+                    default: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+                    description: |-
+                      FOR DEVELOPMENT ONLY.
+                      TokenURL is a field of CostManagementMetricsConfig to represent the endpoint used to obtain the service account token.
+                      The default is `https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token`.
+                    type: string
+                  type:
+                    default: token
+                    description: |-
+                      AuthType is a field of CostManagementMetricsConfig to represent the authentication type to be used basic, service-account or token.
+                      Valid values are:
+                      - "basic" (deprecated) : Enables authentication using user and password from authentication secret.
+                      - "service-account" : Enables authentication using client_id and client_secret from the secret containing service account information.
+                      - "token" (default): Uses cluster token for authentication.
+                    enum:
+                    - token
+                    - basic
+                    - service-account
+                    type: string
+                required:
+                - type
+                type: object
+              clusterID:
+                description: |-
+                  ClusterID is a field of CostManagementMetricsConfig to represent the cluster UUID. Normally this value should not be
+                  specified. Only set this value if the clusterID cannot be obtained from the ClusterVersion.
+                type: string
+              clusterVersion:
+                description: |-
+                  ClusterVersion is a field of CostManagementMetricsConfig to represent the cluster version. Normally this value should not be
+                  specified. Only set this value if the clusterVersion cannot be obtained from the ClusterVersion.
+                type: string
+              packaging:
+                description: Packaging is a field of CostManagementMetricsConfig to
+                  represent the packaging object.
+                properties:
+                  max_reports_to_store:
+                    default: 30
+                    description: |-
+                      MaxReports is a field of CostManagementMetricsConfig to represent the maximum number of reports to store.
+                      The default is 30 reports which corresponds to approximately 7 days worth of data given the other default values.
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  max_size_MB:
+                    default: 100
+                    description: |-
+                      MaxSize is a field of CostManagementMetricsConfig to represent the max file size in megabytes that will be compressed for upload to Ingress.
+                      The default is 100.
+                    format: int64
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                required:
+                - max_reports_to_store
+                - max_size_MB
+                type: object
+              prometheus_config:
+                description: PrometheusConfig is a field of CostManagementMetricsConfig
+                  to represent the configuration of Prometheus connection.
+                properties:
+                  collect_previous_data:
+                    default: true
+                    description: |-
+                      CollectPreviousData is a field of CostManagementMetricsConfig to represent whether or not the operator will gather previous data upon CostManagementMetricsConfig
+                      creation. This toggle only changes operator behavior when a new CostManagementMetricsConfig is created. When `true`, the operator will gather all
+                      existing Prometheus data for the current month. The default is true.
+                    type: boolean
+                  context_timeout:
+                    default: 120
+                    description: |-
+                      ContextTimeout is a field of CostManagementMetricsConfig to represent how long a query to prometheus should run in seconds before timing out.
+                      The default is 120 seconds.
+                    format: int64
+                    maximum: 180
+                    minimum: 10
+                    type: integer
+                  disable_metrics_collection_cost_management:
+                    default: false
+                    description: |-
+                      DisableMetricsCollectionCostManagement is a field of CostManagementMetricsConfig to represent whether or not the operator will generate
+                      reports for cost-management metrics. The default is false.
+                    type: boolean
+                  disable_metrics_collection_resource_optimization:
+                    default: false
+                    description: |-
+                      DisableMetricsCollectionResourceOptimization is a field of CostManagementMetricsConfig to represent whether or not the operator will generate
+                      reports for resource-optimization metrics. The default is false.
+                    type: boolean
+                  service_address:
+                    default: https://thanos-querier.openshift-monitoring.svc:9091
+                    description: |-
+                      FOR DEVELOPMENT ONLY.
+                      SvcAddress is a field of CostManagementMetricsConfig to represent the thanos-querier address.
+                      The default is `https://thanos-querier.openshift-monitoring.svc:9091`.
+                    type: string
+                  skip_tls_verification:
+                    default: false
+                    description: |-
+                      FOR DEVELOPMENT ONLY.
+                      SkipTLSVerification is a field of CostManagementMetricsConfig to represent if the thanos-querier endpoint must be certificate validated.
+                      The default is false.
+                    type: boolean
+                required:
+                - service_address
+                - skip_tls_verification
+                type: object
+              source:
+                description: source represents the desired integration on console.redhat.com.
+                properties:
+                  check_cycle:
+                    default: 1440
+                    description: |-
+                      check_cycle is the number of minutes between each integration status check on console.redhat.com.
+                      The default is 1440 min (24 hours).
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  create_source:
+                    default: false
+                    description: create_source toggles the creation of the integration
+                      on console.redhat.com.
+                    type: boolean
+                  name:
+                    description: name is the desired name of the integration to create
+                      on console.redhat.com.
+                    type: string
+                  sources_path:
+                    default: /api/sources/v1.0/
+                    description: |-
+                      FOR DEVELOPMENT ONLY.
+                      sources_path is the prefix of the Sources API on console.redhat.com.
+                      The default is `/api/sources/v1.0/`.
+                    type: string
+                required:
+                - check_cycle
+                - create_source
+                - sources_path
+                type: object
+              upload:
+                description: Upload is a field of CostManagementMetricsConfig to represent
+                  the upload object.
+                properties:
+                  ingress_path:
+                    default: /api/ingress/v1/upload
+                    description: |-
+                      FOR DEVELOPMENT ONLY.
+                      IngressAPIPath is a field of CostManagementMetricsConfig to represent the path of the Ingress API service.
+                      The default is `/api/ingress/v1/upload`.
+                    type: string
+                  upload_cycle:
+                    default: 360
+                    description: |-
+                      UploadCycle is a field of CostManagementMetricsConfig to represent the number of minutes between each upload schedule.
+                      The default is 360 min (6 hours).
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  upload_toggle:
+                    default: true
+                    description: |-
+                      UploadToggle is a field of CostManagementMetricsConfig to represent if the operator is installed in a restricted-network.
+                      If `false`, the operator will not upload to console.redhat.com or check/create sources.
+                      The default is true.
+                    type: boolean
+                  upload_wait:
+                    description: UploadWait is a field of CostManagementMetricsConfig
+                      to represent the time to wait before sending an upload.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  validate_cert:
+                    default: true
+                    description: ValidateCert is a field of CostManagementMetricsConfig
+                      to represent if the Ingress endpoint must be certificate validated.
+                    type: boolean
+                required:
+                - ingress_path
+                - upload_cycle
+                - upload_toggle
+                - validate_cert
+                type: object
+              volume_claim_template:
+                description: VolumeClaimTemplate is a field of CostManagementMetricsConfig
+                  to represent a PVC template.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  metadata:
+                    description: EmbeddedMetadata contains metadata relevant to an
+                      EmbeddedResource.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          Name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                        type: string
+                    type: object
+                  spec:
+                    description: |-
+                      Spec defines the desired characteristics of a volume requested by a pod author.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          Users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                type: object
+            required:
+            - authentication
+            - packaging
+            - prometheus_config
+            - source
+            - upload
+            type: object
+          status:
+            description: CostManagementMetricsConfigStatus defines the observed state
+              of CostManagementMetricsConfig.
+            properties:
+              api_url:
+                description: APIURL is a field of CostManagementMetricsConfig to represent
+                  the url of the API endpoint for service interaction.
+                type: string
+              authentication:
+                description: Authentication is a field of CostManagementMetricsConfig
+                  to represent the authentication status.
+                properties:
+                  credentials_found:
+                    description: AuthenticationCredentialsFound is a field of CostManagementMetricsConfig
+                      to represent if used for uploads were found.
+                    type: boolean
+                  deprecation_notice:
+                    description: DeprecationNotice is a field of CostManagementMetricsConfig
+                      to represent a deprecation notice.
+                    type: string
+                  error:
+                    description: AuthErrorMessage is a field of CostManagementMetricsConfig
+                      to represent an `invalid credentials` error message.
+                    type: string
+                  last_credential_verification_time:
+                    description: LastVerificationTime is a field of CostManagementMetricsConfig
+                      to represent the last time credentials were verified.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  secret_name:
+                    description: AuthenticationSecretName is a field of CostManagementMetricsConfig
+                      to represent the secret with the user and password used for
+                      uploads.
+                    type: string
+                  token_url:
+                    description: TokenURL is a field of CostManagementMetricsConfig
+                      to represent the url used to generate a service account token.
+                    type: string
+                  type:
+                    description: AuthType is a field of CostManagementMetricsConfig
+                      to represent the authentication type to be used basic, service-account
+                      or token.
+                    enum:
+                    - token
+                    - basic
+                    - service-account
+                    type: string
+                  valid_basic_auth:
+                    description: ValidBasicAuth is a field of CostManagementMetricsConfig
+                      to represent if the given basic auth credentials are valid.
+                    type: boolean
+                type: object
+              clusterID:
+                description: ClusterID is a field of CostManagementMetricsConfig to
+                  represent the cluster UUID.
+                type: string
+              clusterVersion:
+                description: ClusterVersion is a field of CostManagementMetricsConfig
+                  to represent the cluster version.
+                type: string
+              operator_commit:
+                description: OperatorCommit is a field of CostManagementMetricsConfig
+                  that shows the commit hash of the operator.
+                type: string
+              packaging:
+                description: Packaging is a field of CostManagementMetricsConfig to
+                  represent the packaging status
+                properties:
+                  error:
+                    description: PackagingError is a field of CostManagementMetricsConfig
+                      to represent the error encountered packaging the reports.
+                    type: string
+                  last_successful_packaging_time:
+                    description: LastSuccessfulPackagingTime is a field of CostManagementMetricsConfig
+                      that shows the time of the last successful file packaging.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  max_reports_to_store:
+                    description: MaxReports is a field of CostManagementMetricsConfig
+                      to represent the maximum number of reports to store.
+                    format: int64
+                    type: integer
+                  max_size_MB:
+                    description: MaxSize is a field of CostManagementMetricsConfig
+                      to represent the max file size in megabytes that will be compressed
+                      for upload to Ingress.
+                    format: int64
+                    type: integer
+                  number_reports_stored:
+                    description: ReportCount is a field of CostManagementMetricsConfig
+                      to represent the number of reports in storage.
+                    format: int64
+                    type: integer
+                  packaged_files:
+                    description: PackagedFiles is a field of CostManagementMetricsConfig
+                      to represent the list of file packages in storage.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              persistent_volume_claim:
+                description: PersistentVolumeClaim is a field of CostManagementMetricsConfig
+                  to represent a PVC.
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  metadata:
+                    description: EmbeddedMetadata contains metadata relevant to an
+                      EmbeddedResource.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          Name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+                        type: string
+                    type: object
+                  spec:
+                    description: |-
+                      Spec defines the desired characteristics of a volume requested by a pod author.
+                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                    properties:
+                      accessModes:
+                        description: |-
+                          accessModes contains the desired access modes the volume should have.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      dataSource:
+                        description: |-
+                          dataSource field can be used to specify either:
+                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                          * An existing PVC (PersistentVolumeClaim)
+                          If the provisioner or an external controller can support the specified data source,
+                          it will create a new volume based on the contents of the specified data source.
+                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      dataSourceRef:
+                        description: |-
+                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                          volume is desired. This may be any object from a non-empty API group (non
+                          core object) or a PersistentVolumeClaim object.
+                          When this field is specified, volume binding will only succeed if the type of
+                          the specified object matches some installed volume populator or dynamic
+                          provisioner.
+                          This field will replace the functionality of the dataSource field and as such
+                          if both fields are non-empty, they must have the same value. For backwards
+                          compatibility, when namespace isn't specified in dataSourceRef,
+                          both fields (dataSource and dataSourceRef) will be set to the same
+                          value automatically if one of them is empty and the other is non-empty.
+                          When namespace is specified in dataSourceRef,
+                          dataSource isn't set to the same value and must be empty.
+                          There are three important differences between dataSource and dataSourceRef:
+                          * While dataSource only allows two specific types of objects, dataSourceRef
+                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                            preserves all values, and generates an error if a disallowed value is
+                            specified.
+                          * While dataSource only allows local objects, dataSourceRef allows objects
+                            in any namespaces.
+                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                        properties:
+                          apiGroup:
+                            description: |-
+                              APIGroup is the group for the resource being referenced.
+                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                              For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of resource being referenced
+                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: |-
+                          resources represents the minimum resources the volume should have.
+                          Users are allowed to specify resource requirements
+                          that are lower than previous value but must still be higher than capacity recorded in the
+                          status field of the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      selector:
+                        description: selector is a label query over volumes to consider
+                          for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      storageClassName:
+                        description: |-
+                          storageClassName is the name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                        type: string
+                      volumeAttributesClassName:
+                        description: |-
+                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                          If specified, the CSI driver will create or update the volume with the attributes defined
+                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
+                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                          exists.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                        type: string
+                      volumeMode:
+                        description: |-
+                          volumeMode defines what type of volume is required by the claim.
+                          Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: volumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                type: object
+              prometheus:
+                description: Prometheus represents the status of premetheus queries.
+                properties:
+                  configuration_error:
+                    description: ConfigError is a field of CostManagementMetricsConfigStatus
+                      to represent errors during prometheus configuration.
+                    type: string
+                  context_timeout:
+                    description: ContextTimeout is a field of CostManagementMetricsConfigState
+                      to represent how long a query to prometheus should run in seconds
+                      before timing out.
+                    format: int64
+                    type: integer
+                  disabled_metrics_collection_cost_management:
+                    default: false
+                    description: |-
+                      DisabledMetricsCollectionCostManagement is a field of CostManagementMetricsConfigStatus to represent whether or not collecting
+                      cost-management metrics is disabled. The default is false.
+                    type: boolean
+                  disabled_metrics_collection_resource_optimization:
+                    default: true
+                    description: |-
+                      DisabledMetricsCollectionResourceOptimization is a field of CostManagementMetricsConfigStatus to represent whether or not collecting
+                      resource-optimization metrics is disabled. The default is true.
+                    type: boolean
+                  last_query_start_time:
+                    description: LastQueryStartTime is a field of CostManagementMetricsConfigStatus
+                      to represent the last time queries were started.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  last_query_success_time:
+                    description: LastQuerySuccessTime is a field of CostManagementMetricsConfigStatus
+                      to represent the last time queries were successful.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  previous_data_collected:
+                    default: false
+                    description: |-
+                      PreviousDataCollected is a field of CostManagementMetricsConfigStatus to represent whether or not the operator gathered the available Prometheus
+                      data upon CostManagementMetricsConfig creation.
+                    type: boolean
+                  prometheus_configured:
+                    description: PrometheusConfigured is a field of CostManagementMetricsConfigStatus
+                      to represent if the operator is configured to connect to prometheus.
+                    type: boolean
+                  prometheus_connected:
+                    description: PrometheusConnected is a field of CostManagementMetricsConfigStatus
+                      to represent if prometheus can be queried.
+                    type: boolean
+                  prometheus_connection_error:
+                    description: ConnectionError is a field of CostManagementMetricsConfigStatus
+                      to represent errors during prometheus test query.
+                    type: string
+                  service_address:
+                    description: SvcAddress is the internal thanos-querier address.
+                    type: string
+                  skip_tls_verification:
+                    description: SkipTLSVerification is a field of CostManagementMetricsConfigStatus
+                      to represent if the thanos-querier endpoint must be certificate
+                      validated.
+                    type: boolean
+                required:
+                - prometheus_configured
+                - prometheus_connected
+                type: object
+              reports:
+                description: Reports represents the status of report generation.
+                properties:
+                  data_collected:
+                    description: DataCollected is a field of CostManagementMetricsConfigStatus
+                      to represent whether or not data was collected for the last
+                      query.
+                    type: boolean
+                  data_collection_message:
+                    description: DataCollectionMessage is a field of CostManagementMetricsConfigStatus
+                      to represent a message associated with the data_collected status.
+                    type: string
+                  last_hour_queried:
+                    description: LastHourQueried is a field of CostManagementMetricsConfigStatus
+                      to represent the time range for which metrics were last queried.
+                    type: string
+                  report_month:
+                    description: ReportMonth is a field of CostManagementMetricsConfigStatus
+                      to represent the month for which reports are being generated.
+                    type: string
+                type: object
+              source:
+                description: source represents the observed state of the integration
+                  on console.redhat.com.
+                properties:
+                  check_cycle:
+                    description: |-
+                      check_cycle is the number of minutes between each integration status check on console.redhat.com.
+                      The default is 1440 min (24 hours).
+                    format: int64
+                    type: integer
+                  create_source:
+                    description: |-
+                      create_source represents the toggle used during the creation of the integration on console.redhat.com.
+                      An Integration will not be created if upload_toggle is `false`.
+                    type: boolean
+                  error:
+                    description: error represents any errors encountered when creating
+                      the integration.
+                    type: string
+                  last_check_time:
+                    description: last_check_time is the time that the last integration
+                      status check was attempted.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  name:
+                    description: name represents the name of the integration that
+                      the operator attempted to create on console.redhat.com.
+                    type: string
+                  source_defined:
+                    description: source_defined represents whether the defined integration
+                      name exists on console.redhat.com.
+                    type: boolean
+                  sources_path:
+                    description: sources_path is the prefix of the Sources API on
+                      console.redhat.com.
+                    type: string
+                type: object
+              storage:
+                description: Storage is a field
+                properties:
+                  volume_mounted:
+                    description: VolumeMounted is a bool to indicate if storage volume
+                      was mounted.
+                    type: boolean
+                  volume_type:
+                    description: VolumeType is the string representation of the volume
+                      type.
+                    type: string
+                type: object
+              upload:
+                description: Upload is a field of CostManagementMetricsConfig to represent
+                  the upload object.
+                properties:
+                  error:
+                    description: UploadError is a field of CostManagementMetricsConfigStatus
+                      to represent the error encountered uploading reports.
+                    type: string
+                  ingress_path:
+                    description: IngressAPIPath is a field of CostManagementMetricsConfig
+                      to represent the path of the Ingress API service.
+                    type: string
+                  last_payload_files:
+                    description: LastPayloadFiles is a field of CostManagementMetricsConfig
+                      to represent the list of files in the last payload that was
+                      sent.
+                    items:
+                      type: string
+                    type: array
+                  last_payload_manifest_id:
+                    description: LastPayloadManifest is a field of CostManagementMetricsConfig
+                      that shows the manifestID of the last payload.
+                    type: string
+                  last_payload_name:
+                    description: LastPayloadName is a field of CostManagementMetricsConfig
+                      that shows the name of the last payload file.
+                    type: string
+                  last_payload_request_id:
+                    description: LastPayloadRequestID is a field of CostManagementMetricsConfig
+                      that shows the insights request id of the last payload.
+                    type: string
+                  last_successful_upload_time:
+                    description: LastSuccessfulUploadTime is a field of CostManagementMetricsConfig
+                      that shows the time of the last successful upload.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  last_upload_status:
+                    description: LastUploadStatus is a field of CostManagementMetricsConfig
+                      that shows the http status of the last upload.
+                    type: string
+                  upload:
+                    description: |-
+                      UploadToggle is a field of CostManagementMetricsConfig to represent if the operator should upload to console.redhat.com.
+                      The default is true
+                    type: boolean
+                  upload_cycle:
+                    description: |-
+                      UploadCycle is a field of CostManagementMetricsConfig to represent the number of minutes between each upload schedule.
+                      The default is 360 min (6 hours).
+                    format: int64
+                    type: integer
+                  upload_wait:
+                    description: UploadWait is a field of CostManagementMetricsConfig
+                      to represent the time to wait before sending an upload.
+                    format: int64
+                    type: integer
+                  validate_cert:
+                    description: ValidateCert is a field of CostManagementMetricsConfig
+                      to represent if the Ingress endpoint must be certificate validated.
+                    type: boolean
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/koku-metrics-operator/4.4.0/manifests/koku-metrics-operator.clusterserviceversion.yaml
+++ b/operators/koku-metrics-operator/4.4.0/manifests/koku-metrics-operator.clusterserviceversion.yaml
@@ -1,0 +1,741 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "costmanagement-metrics-cfg.openshift.io/v1beta1",
+          "kind": "CostManagementMetricsConfig",
+          "metadata": {
+            "name": "costmanagementmetricscfg-sample-v1beta1"
+          },
+          "spec": {
+            "authentication": {
+              "type": "token"
+            },
+            "packaging": {
+              "max_reports_to_store": 30,
+              "max_size_MB": 100
+            },
+            "prometheus_config": {
+              "collect_previous_data": true,
+              "context_timeout": 120,
+              "disable_metrics_collection_cost_management": false,
+              "disable_metrics_collection_resource_optimization": false
+            },
+            "source": {
+              "check_cycle": 1440,
+              "create_source": false,
+              "name": ""
+            },
+            "upload": {
+              "upload_cycle": 360,
+              "upload_toggle": true
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Monitoring
+    certified: "false"
+    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:abc4888c0c7ea7f8601f8c6e240f58094f3f525d73d7c2fa2302e4c6bcc2b940
+    createdAt: "2026-04-09T13:19:35Z"
+    description: A Golang-based OpenShift Operator that generates and uploads OpenShift usage metrics to cost management.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "costmanagement-metrics-cfg.openshift.io/v1beta1",
+        "kind": "CostManagementMetricsConfig",
+        "metadata": {
+          "name": "costmanagementmetricscfg-sample-v1beta1"
+        },
+        "spec": {
+          "authentication": {
+            "token_url": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+            "type": "token"
+          },
+          "api_url": "https://console.redhat.com/",
+          "packaging": {
+            "max_reports_to_store": 30,
+            "max_size_MB": 100
+          },
+          "upload": {
+            "ingress_path": "/api/ingress/v1/upload",
+            "upload_cycle": 360,
+            "upload_toggle": true,
+            "validate_cert": true
+          },
+          "prometheus_config": {
+            "collect_previous_data": true,
+            "context_timeout": 120,
+            "disable_metrics_collection_cost_management": false,
+            "disable_metrics_collection_resource_optimization": false,
+            "service_address": "https://thanos-querier.openshift-monitoring.svc:9091",
+            "skip_tls_verification": false
+          },
+          "source": {
+            "check_cycle": 1440,
+            "create_source": false,
+            "name": "",
+            "sources_path": "/api/sources/v1.0/"
+          }
+        }
+      }
+    operatorframework.io/suggested-namespace: koku-metrics-operator
+    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.41.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/project-koku/koku-metrics-operator
+    support: Cost Management
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+  name: koku-metrics-operator.v4.4.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: CostManagementMetricsConfig is the Schema for the costmanagementmetricsconfig API
+        displayName: Cost Management Metrics Config
+        kind: CostManagementMetricsConfig
+        name: costmanagementmetricsconfigs.costmanagement-metrics-cfg.openshift.io
+        version: v1beta1
+  description: |
+    # Koku Metrics Operator
+    ## Introduction
+    The `koku-metrics-operator` is a component of the [cost managment](https://docs.redhat.com/en/documentation/cost_management_service) service for Openshift. The operator runs on the latest supported versions of Openshift. This operator obtains OpenShift usage data by querying Prometheus every hour to create metric reports that it uploads to Cost Management at [console.redhat.com](https://console.redhat.com) to be processed. For more information, reach out to <costmanagement@redhat.com>.
+
+    This operator is capable of functioning within a disconnected/restricted network (aka air-gapped mode). In this mode, the operator will store the packaged reports for manual retrieval instead of being uploaded to Cost Management. Documentation for installing an operator within a restricted network can be found [here](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/operators/administrator-tasks#olm-restricted-networks).
+
+    ## Features and Capabilities
+    #### Metrics collection:
+    The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics required for Cost Management by:
+    * Querying Prometheus to gather the necessary metrics for Cost Management.
+    * Writing the results of Prometheus queries to CSV report files.
+    * Packaging the CSV report files into tarballs.
+
+    #### Additional Capabilities:
+    * Resource Optimization metrics collection.
+    * The operator can be configured to gather all previous data within the configured retention period or a maximum of 90 days. The default data collection period is the 14 previous days. This setting is only applicable to newly created KokuMetricsConfigs.
+    * The operator can be configured to automatically upload the packaged reports to Cost Management through Red Hat Insights Ingress service.
+    * The operator can create an integration in console.redhat.com. An integration is required for Cost Management to process the uploaded packages.
+    * PersistentVolumeClaim (PVC) configuration: The KokuMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
+    * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
+
+    ## New in v4.4.0:
+    * Enabled gathering and reporting NVIDIA MIG (Multi-Instance GPU) metrics for cost management.
+    * Updated dependencies.
+
+    ## New in v4.3.1:
+    * Updated Go to 1.25.7.
+    * Updated Kubernetes, Prometheus, and Operator Framework dependencies.
+    * Added toolchain directive to go.mod for deterministic builds.
+
+    ## New in v4.3.0:
+    * Enabled gathering and reporting NVIDIA GPU metrics for cost management.
+
+    ## New in v4.2.0:
+    * Enabled gathering and reporting NVIDIA GPU metrics for resource optimization.
+    * (Bugfix) Fixed custom CA certificate validation and configuration issues.
+    * (Bugfix) Fixed issue where ROS queries were missing workload metadata for namespaces labeled only with the legacy `insights_cost_management_optimizations` label.
+
+    ## New in v4.1.0:
+    * Enabled gathering and reporting namespace metrics to provide more granular data for resource optimization.
+    * Updated CSV report filenames to be more descriptive, replacing the previous generic UID-based names with content-reflective names.
+    * Introduced a new generic label, `cost_management_optimizations`, for resource optimization while ensuring backward compatibility with the older `insights_cost_management_optimizations` label.
+
+    ## New in v4.0.0:
+    * **Virtual Machine Metrics:** Adds capabilities for collecting metrics and generating reports for running virtual machines within your OpenShift environment.
+    * **Progress towards FIPS 140 Compliance:** The operator is using the Go Cryptographic Module v1.0.0 to progress toward FIPS 140 compliance. Although this module is not validated at the time of this release, the operator aims to meet stricter security standards when the module does successfully achieve FIPS validation.
+    * **API Name Change:** The Custom Resource Definition (CRD) for configuring the upstream `Koku Metrics Operator` was renamed from `KokuMetricsConfig` to `CostManagementMetricsConfig`.
+
+    ### NOTE:
+      * The API name change impacts only users of the upstream (community) Koku Metrics Operator.
+      * The downstream (Red Hat-supported) Cost Management Metrics Operator is not impacted by this change and users should continue using their existing configurations.
+
+    **Important Upgrade Instructions:**
+
+      If you are upgrading the upstream Koku Metrics Operator to version 4.0.0 or higher, you must manually migrate your configuration. The operator will no longer recognize existing `KokuMetricsConfig` resources.
+
+      To successfully upgrade and retain your operator's configuration, complete the following steps. You can use the provided `oc` commands replacing the angle brackets (`< >`) with your specific values:
+
+      1. Backup existing configuration (recommended):
+
+         Before you upgrade, retrieve the details of your current `KokuMetricsConfig` instance to help you recreate it with the new API name.
+
+         ```
+         oc get kokumetricsconfig -n koku-metrics-operator <your-config-name> -o yaml > koku-metrics-config-backup.yaml
+         ```
+
+      2. Delete the previous `KokuMetricsConfig` instance (recommended):
+
+          After the operator is upgraded to `version 4.0.0`, delete any existing `KokuMetricsConfig` resources.
+
+          ```
+          oc delete kokumetricsconfig -n koku-metrics-operator <your-config-name>
+          ```
+
+      3. Create the new `CostManagementMetricsConfig` instance:
+
+          Using the information from your backup (or a new configuration), create a new `CostManagementMetricsConfig` instance. Adjust the spec section based on your specific needs. For more information about configurations, [refer to the configurable parameters](#configurable-parameters).
+
+      4. Apply your new configuration:
+
+          ```
+          oc apply -f <your-costmanagementmetricsconfig-file>.yaml -n koku-metrics-operator
+          ```
+
+    ## New in v3.3.2:
+    * Leader election settings are now configurable via environment variables. These variables can be modified in the operator [Subscription](https://github.com/operator-framework/operator-lifecycle-manager/blob/5a01f50258003e248bd5630df0837fe0bb0f1cb7/doc/design/subscription-config.md). The values should be specified as durations in seconds in the format `<number-of-seconds>s`. The default values for `LEADER_ELECTION_LEASE_DURATION`, `LEADER_ELECTION_RENEW_DEADLINE`, and `LEADER_ELECTION_RETRY_PERIOD` are '60s', '30s', and '5s', respectively.
+
+      ```
+      kind: Subscription
+      metadata:
+      ...
+      spec:
+        ...
+        config:
+          env:
+          - name: LEADER_ELECTION_LEASE_DURATION
+            value: "60s"
+          - name: LEADER_ELECTION_RENEW_DEADLINE
+            value: "30s"
+          - name: LEADER_ELECTION_RETRY_PERIOD
+            value: "5s"
+      ```
+
+    ## New in v3.3.1:
+    * Optimize memory usage when reading CSV files.
+
+    ## New in v3.3.0:
+    * Storage reports now contain `node`, `csi_driver`, and `csi_volume_handle` fields.
+    * The PVC capacity is now populated using the `kube_persistentvolume_capacity_bytes` metric instead of `kubelet_volume_stats_capacity_bytes`.
+    * To receive resource optimization recommendations for your namespaces, you must now first enable each namespace. To enable a namespace, label it with `insights_cost_management_optimizations='true'`. In the CLI, run:
+      ```
+        oc label namespace NAMESPACE insights_cost_management_optimizations="true" --overwrite=true
+      ```
+    * __DEPRECATION NOTICE__: Basic authentication is deprecated and will not be supported beyond December 31, 2024. If the default token authentication method cannot be used, you must switch to [service account](https://console.redhat.com/iam/service-accounts) authentication ([more on creating a service account](https://access.redhat.com/articles/7036194)). Once you have created your service account, follow [this documentation](https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html-single/integrating_openshift_container_platform_data_into_cost_management/index#service-account-authentication_adding-an-ocp-int) on how to configure your operator to use service account authentication. Service-accounts must also be used if manually uploading payloads to console.redhat.com.
+
+    ## New in v3.2.1:
+    * The minimum supported configuration for `upload_cycle` is now 60 (minutes).
+    * (Bugfix) many-to-many matching not allowed query fix.
+    * (Bugfix) Sequentially collect data during initial install.
+
+    ## New in v3.2.0:
+    * Support for amd64, arm64, ppc64le, s390x architectures.
+    * add liveness and readiness probes to controller Pod.
+    * update pod security settings so that the controller Pod can run in Restricted mode [more info](https://sdk.operatorframework.io/docs/best-practices/pod-security-standards/).
+
+    ## New in v3.1.0:
+    * Add service-account authentication type.
+    * __Deprecation Notice:__ Basic authentication is deprecated and will be removed in a future version of the operator.
+
+    ## New in v3.0.0:
+    * Daily report generation: Operator versions prior to v3.0.0 generated sequential reports. Now, reports are generated starting at 0:00 UTC. Any payloads generated throughout a given day will contain all data starting from 0:00 UTC. Once the next day starts, the previous day's reports are packaged, and the new report again starts at 0:00 UTC for the current day.
+    * Failed query retry: In an attempt to prevent missing data, the operator will retry queries from the last successful query time, up to 5 times.
+
+    ## New in v2.0.0:
+    * Adds metrics and report generation for resource optimization. This feature will collect additional usage metrics and create a new report in the payload. These metrics are enabled by default, but can be disabled by setting `disable_metrics_collection_resource_optimization` to `true`.
+    * Collect all available Prometheus data upon CR creation. This feature only applies to newly created KokuMetricsConfigs. The operator will check the monitoring stack configuration in the `openshift-monitoring` namespace. The operator will use the `retention` period set in the `cluster-monitoring-config` ConfigMap if defined, up to a maximum of 90 days. Otherwise it will fall back to collecting 14 days of data, if available. This data collection may be disabled by setting `collect_previous_data` to `false`. Turning this feature off results in the operator collecting metrics from the time the KokuMetricsConfig is created, forward.
+
+    ## Limitations and Pre-Requisites
+    #### Limitations (Potential for metrics data loss)
+    * An integration **must** exist in console.redhat.com for an uploaded payload to be processed by Cost Management. The operator sends the payload to the Red Hat Insights Ingress service which usually returns successfully, but the operator does not currently confirm with Cost Management that the payload was processed. After Ingress accepts the uploaded payload, it is deleted from the operator. If the data within the payload is not processed, a gap will be introduced in the usage metrics. Data may be recollected by deleting the `KokuMetricsConfig`, creating a new `KokuMetricsConfig`, and setting `collect_previous_data: true`. This re-collection of data will gather all data stored in Prometheus, up to 90 days.
+
+    **Note** The following limitations are specific to operators configured to run in a restricted network:
+    * The `koku-metrics-operator` will not be able to generate new reports if the PVC storage is full. If this occurs, the reports must be manually deleted from the PVC so that the operator can function as normal.
+    * The default report retention is 30 reports (about one week's worth of data). The reports must be manually downloaded and uploaded to console.redhat.com every week, or they will be deleted and the data will be lost.
+
+    #### Storage configuration prerequisite
+    The operator will attempt to create and use the following PVC when installed:
+
+          volume_claim_template:
+            apiVersion: v1
+            kind: PersistentVolumeClaim
+            metadata:
+              name: koku-metrics-operator-data
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 10Gi
+
+    If a different PVC should be utilized, a valid PVC should be specified in the KokuMetricsConfig CR as described in the appropriate section below. The PVC to be used may exist already, or the operator will attempt to create it.
+
+    To use the default specification, the follow assumptions must be met:
+    1. A default StorageClass is defined.
+    2. Dynamic provisioning for that default StorageClass is enabled.
+
+    If these assumptions are not met, the operator will not deploy correctly. In these cases, storage must be manually configured. After configuring storage, a valid PVC template should be supplied in the `volume_claim_template` spec of the KokuMetricsConfig CR.
+
+    ## Configurable parameters:
+      * `authentication`:
+        * `type: token` -> The authentication method for connecting to `console.redhat.com`. The default and preferred method is `token`. `basic` (deprecated) and `service-account` authentication methods are used when the openshift-config pull-secret does not contain a token for `console.redhat.com`.
+        * `secret_name` -> The Secret used by the operator when the authentication type is `basic` (deprecated) or `service-account`. This parameter is required **only if** the authentication type is `basic` (deprecated) or `service-account`.
+      * `packaging`:
+        * `max_reports_to_store: 30` -> The number of reports to store when configured in air-gapped mode. The default is 30, with a minimum of 1 and no maximum. When the operator is not configured in air-gapped mode, this parameter has no effect. Reports are removed as soon as they are uploaded.
+        * `max_size: 100` -> The maximum size for packaged files in Megabytes prior to compression. The default is 100, with a minimum of 1 and maximum of 100.
+      * `prometheus_config`:
+        * `collect_previous_data: true` -> Toggle for collecting all available data in Prometheus **upon KokuMetricsConfig creation** (This parameter will start to appear in KokuMetricsConfigs that were created prior to v2.0.0 but will not have any effect unless the KokuMetricsConfig is deleted and recreated). The default is `true`. The operator will first look for a `retention` period in the `cluster-monitoring-config` ConfigMap in the `openshift-monitoring` namespace and gather data over this time period up to a maximum of 90 days. If this configuration is not set, the default is 14 days. (New in v2.0.0)
+        * `disable_metrics_collection_cost_management: false` -> Toggle for disabling the collection of metrics for Cost Management. The default is false. (New in v2.0.0)
+        * `disable_metrics_collection_resource_optimization: false` -> Toggle for disabling the collection of metrics for Resource Optimization. The default is false. (New in v2.0.0)
+        * `context_timeout: 120` -> The time in seconds before Prometheus queries timeout due to exceeding context timeout. The default is 120, with a minimum of 10 and maximum of 180.
+      * `source`:
+        * `name: ''` -> The name of the integration the operator will create in `console.redhat.com`. If the name value is empty, the default intergration name is the **cluster id**.
+        * `create_source: false` -> Toggle for whether or not the operator will create the integration in `console.redhat.com`. The default is False. This parameter should be switched to True when an integration does not already exist in `console.redhat.com` for this cluster.
+        * `check_cycle: 1440` -> The time in minutes to wait between checking if an integration exists for this cluster. The default is 1440 minutes (24 hrs).
+      * `upload`:
+        * `upload_cycle: 360` -> The time in minutes between payload uploads. The default is 360 (6 hours), minimum is 60 (1 hour).
+        * `upload_toggle: true` -> Toggle to turn upload on or off -> true means upload, false means do not upload (false == air-gapped mode). The default is `true`.
+        * `upload_wait` -> The amount of time (in seconds) to pause before uploading a payload. The default is a random number between 0 and 35. This is used to decrease service load, but may be set to `0` if desired.
+      * `volume_claim_template` -> see the "Storage configuration prerequisite" section above.
+
+    ## Configure the koku-metrics-operator
+    **Note** There are separate instructions for configuring the `koku-metrics-operator` to run in a restricted network.
+    ##### Configure authentication
+    The default authentication for the operator is `token`. No further steps are required to configure token authentication. If `basic` (deprecated) or `service-account` is the preferred authentication method, a Secret which holds the credentials must be created:
+    1. On the left navigation pane, select `Workloads` -> `Secrets` -> select Project: `koku-metrics-operator` -> `Create` -> `Key/Value Secret`
+    2. Give the Secret a name and add 2 keys (all lowercase) for the respective authentication type. The values for these keys correspond to console.redhat.com credentials:
+        * basic auth (deprecated): `username` and `password`
+        * service-account auth: `client_id` and `client_secret`
+
+    3. Select `Create`.
+    ##### Create the KokuMetricsConfig
+    Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
+    1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `KokuMetricsConfig` -> `Create Instance`.
+    2. For `basic` (deprecated) or `service-account` authentication, edit the following values in the spec:
+        * Replace `authentication: type:` with `basic` or `service-account`.
+        * Add the `secret_name` field under `authentication`, and set it equal to the name of the authentication Secret that was created above. The spec should look similar to the following:
+
+            * for basic auth type (deprecated)
+            ```
+              authentication:
+                secret_name: SECRET-NAME
+                type: basic
+            ```
+
+            * for service-account auth type
+            ```
+              authentication:
+                secret_name: SECRET-NAME
+                type: service-account
+            ```
+
+    3. To configure the koku-metrics-operator to create a cost management integration, edit the following values in the `source` field:
+        * Replace the `name` field value with the preferred name of the integration to be created.
+        * Replace the `create_source` field value with `true`.
+
+        **Note:** if the integration already exists, replace the empty string value of the `name` field with the existing name, and leave `create_source` as false. This will allow the operator to confirm that the integration exists.
+
+    4. If not specified, the operator will create a default PersistentVolumeClaim called `koku-metrics-operator-data` with 10Gi of storage. To configure the koku-metrics-operator to use or create a different PVC, edit the following in the spec:
+        * Add the desired configuration to the `volume_claim_template` field in the spec:
+
+          ```
+            volume_claim_template:
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: <insert-name>
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 10Gi
+          ```
+
+        **Note:** If using the YAML View, the `volume_claim_template` field must be added to the spec
+    5. Select `Create`.
+
+    # Restricted Network Usage (disconnected/air-gapped mode)
+    ## Installation
+    To install the `koku-metrics-operator` in a restricted network, follow the [olm documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operators/administrator-tasks#olm-restricted-networks). The operator is found in the `community-operators` Catalog in the `registry.redhat.io/redhat/community-operator-index:latest` Index. If pruning the index before pushing to the mirrored registry, keep the `koku-metrics-operator` package.
+
+    Within a restricted network, the operator queries prometheus to gather the necessary usage metrics, writes the query results to CSV files, and packages the reports for storage in the PVC. These reports then need to be manually downloaded from the cluster and uploaded to [console.redhat.com](https://console.redhat.com).
+
+    ## Configure the koku-metrics-operator for a restricted network
+    ##### Create the KokuMetricsConfig
+    Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
+    1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `KokuMetricsConfig` -> `Create Instance`.
+    2. Specify the desired storage. If not specified, the operator will create a default Persistent Volume Claim called `koku-metrics-operator-data` with 10Gi of storage. To configure the koku-metrics-operator to use or create a different PVC, edit the following in the spec:
+        * Add the desired configuration to the `volume_claim_template` field in the spec (below is only a template. Any _valid_ `PersistentVolumeClaim` may be defined here):
+
+          ```
+            volume_claim_template:
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: <insert-name>
+              spec:
+                storageClassName: <insert-class-name>
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 10Gi
+          ```
+
+        **Note:** If using the YAML View, the `volume_claim_template` field must be added to the spec
+    3. (Optional) Specify the desired report retention. The operator will retain 30 reports by default. This corresponds to approximately one week's worth of data if using the default packaging cycle. To modify the number of retained reports:
+        * Change the `packaging` spec field `max_reports_to_store` to the desired number of reports to retain. Once this max number is reached, the operator will start removing the oldest packages remaining on the PVC:
+
+          ```
+            packaging:
+              max_size_MB: 100
+              max_reports_to_store: 30
+          ```
+
+        **Note:** The number of retained reports directly affects the frequency that reports must be manually downloaded from the PVC. Take caution in setting this to a higher number of reports, as the operator cannot write data to the PVC if the storage is full.
+    4. To configure the operator to perform in a restricted network, set the `upload_toggle` to `false`:
+
+      ```
+        upload:
+          upload_cycle: 360
+          upload_toggle: false
+      ```
+
+    5. Select `Create`.
+
+    ## Download reports from the Operator & clean up the PVC
+    If the `koku-metrics-operator` is configured to run in a restricted network, the metric reports will not automatically upload to cost managment. Instead, they need to be manually copied from the PVC for upload to [console.redhat.com](https://console.redhat.com). The default configuration saves one week of reports which means the process of downloading and uploading reports should be repeated weekly to prevent loss of metrics data. To download the reports, complete the following steps:
+    1. Create the following Pod, ensuring the `claimName` matches the PVC containing the report data:
+
+      ```
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          name: volume-shell
+          namespace: koku-metrics-operator
+          labels:
+            app: koku-metrics-operator
+        spec:
+          volumes:
+          - name: koku-metrics-operator-reports
+            persistentVolumeClaim:
+              claimName: koku-metrics-operator-data
+          containers:
+          - name: volume-shell
+            image: busybox
+            command: ['sleep', 'infinity']
+            volumeMounts:
+            - name: koku-metrics-operator-reports
+              mountPath: /tmp/koku-metrics-operator-reports
+      ```
+
+    2. Use rsync to copy all of the files ready for upload from the PVC to a local folder:
+
+      ```
+      $ oc rsync volume-shell:/tmp/koku-metrics-operator-reports/upload local/path/to/save/folder
+      ```
+
+    3. Once confirming that the files have been successfully copied, use rsh to connect to the pod and delete the contents of the upload folder so that they are no longer in storage:
+
+      ```
+      $ oc rsh volume-shell
+      $ rm /tmp/koku-metrics-operator-reports/upload/*
+      ```
+
+    4. (Optional) Delete the pod that was used to connect to the PVC:
+
+      ```
+      $ oc delete -f volume-shell.yaml
+      ```
+
+    ## Create an Integration
+    In a restricted network, the `koku-metrics-operator` cannot automatically create an integration. This process must be done manually. In the console.redhat.com platform, open the [Integrations menu](https://console.redhat.com/settings/integrations/) to begin adding an OpenShift integration to Cost Management:
+
+    Prerequisites:
+    * The cluster identifier which can be found in the KokuMetricsConfig CR, the cluster Overview page, or the cluster Help > About.
+
+    Creating an integration:
+    1. Navigate to the Integrations menu
+    2. Select the `Red Hat` tab
+    3. Create a new `Red Hat Openshift Container Platform` integration:
+        * give the integration a unique name
+        * add the Cost Management application
+        * add the cluster identifier
+    4. In the Source wizard, review the details and click `Finish` to create the source.
+
+    ## Upload the reports to cost managment
+    Uploading reports to cost managment is done through curl:
+
+        $ curl -vvvv -F "file=@FILE_NAME.tar.gz;type=application/vnd.redhat.hccm.tar+tgz" https://console.redhat.com/api/ingress/v1/upload -H "Authorization: Bearer ${ACCESS_TOKEN}"
+
+    where `FILE_NAME` is the name of the report to upload. The `ACCESS_TOKEN` is acquired using a service account. See documentation on [creating a service account](https://docs.redhat.com/en/documentation/cost_management_service/1-latest/html-single/integrating_openshift_container_platform_data_into_cost_management/index#creating_a_service_account).
+  displayName: Koku Metrics Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzMDAgMzAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAzMDAgMzAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0VFMDAwMDt9Cjwvc3R5bGU+Cjx0aXRsZT5Db3N0LWljb248L3RpdGxlPgo8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KPGc+Cgk8Zz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjM5LjAzNzAzMzEsMTE3LjI3NTE3N2MtMy4yNjU4MDgxLTQxLjk4OTA1MTgtMzguMjU2NjgzMy03NC42NDcyMDE1LTgxLjE3ODgzMy03NC42NDcyMDE1CgkJCWMtMjcuNTI2MTUzNiwwLTUzLjE4NjEyNjcsMTMuOTk2MzQ5My02OC4xMTU1NzAxLDM3LjMyMzYwMDhjLTEuODY2MTgwNCwwLTMuNzMyMzUzMi0wLjQ2NjU0NTEtNi4wNjUwNzg3LTAuNDY2NTQ1MQoJCQljLTM0LjUyNDMzMDEsMC02Mi45ODM1Nzc3LDI3Ljk5MjY5ODctNjIuOTgzNTc3Nyw2Mi45ODM1NjYzczI3Ljk5MjY5ODcsNjIuOTgzNTY2Myw2Mi45ODM1Nzc3LDYyLjk4MzU2NjNoMTYuMzI5MDcxCgkJCWMzLjczMjM2MDgsMCw2Ljk5ODE3NjYtMy4yNjU4MDgxLDYuOTk4MTc2Ni02Ljk5ODE2ODlzLTMuMjY1ODE1Ny02Ljk5ODE2ODktNi45OTgxNzY2LTYuOTk4MTY4OWgtMTYuMzI5MDcxCgkJCWMtMjcuMDU5NjEyMywwLTQ4LjUyMDY3OTUtMjEuOTI3NjI3Ni00OC41MjA2Nzk1LTQ4LjUyMDY3NTdzMjEuOTI3NjEyMy00OC41MjA2ODMzLDQ4LjUyMDY3OTUtNDguNTIwNjgzMwoJCQljMi43OTkyNzA2LDAsNS41OTg1NDEzLDAuNDY2NTQ1MSw4LjM5NzgwNDMsMC45MzMwOTAyYzIuNzk5MjcwNiwwLjQ2NjU0NTEsNi4wNjUwNzg3LTAuOTMzMDkwMiw3LjQ2NDcyMTctMy43MzIzNjA4CgkJCWMxMi4xMzAxNzI3LTIwLjk5NDUyOTcsMzQuNTI0MzMwMS0zNC4wNTc3ODg4LDU4LjMxODEyMjktMzQuMDU3Nzg4OGMzNi44NTcwNzA5LDAsNjcuMTgyNDk1MSwzMC4zMjU0MjA0LDY3LjE4MjQ5NTEsNjcuMTgyNDc5OQoJCQljMCwzLjczMjM1MzIsMy4yNjU4MDgxLDYuOTk4MTc2Niw2Ljk5ODE2ODksNi45OTgxNzY2YzE2LjMyOTA3MSwwLDI5Ljg1ODkwMiwxMy41Mjk4MDA0LDI5Ljg1ODkwMiwyOS44NTg4NzE1CgkJCXMtMTMuNTI5ODMwOSwyOS44NTg4ODY3LTI5Ljg1ODkwMiwyOS44NTg4ODY3Yy0zLjczMjM2MDgsMC02Ljk5ODE2ODksMy4yNjU4MDgxLTYuOTk4MTY4OSw2Ljk5ODE2ODkKCQkJczMuMjY1ODA4MSw2Ljk5ODE2ODksNi45OTgxNjg5LDYuOTk4MTY4OWMyNC4yNjAzMzAyLDAsNDQuMzIxNzYyMS0yMC4wNjE0MTY2LDQ0LjMyMTc2MjEtNDQuMzIxNzYyMQoJCQlDMjc2LjM2MDYyNjIsMTM5LjIwMjc4OTMsMjYwLjAzMTU1NTIsMTIwLjU0MDk5MjcsMjM5LjAzNzAzMzEsMTE3LjI3NTE3N3oiLz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjA2Ljg0NTQyODUsMjIwLjg0ODE3NWM3LjQ2NDcwNjQtOC44NjQzNjQ2LDExLjY2MzYyLTIwLjUyNzk4NDYsMTEuNjYzNjItMzIuNjU4MTU3MwoJCQljMC0yOC45MjU3OTY1LTIzLjMyNzI0LTUyLjI1MzAzNjUtNTIuMjUzMDM2NS01Mi4yNTMwMzY1cy01Mi4yNTMwNDQxLDIzLjMyNzI0LTUyLjI1MzA0NDEsNTIuMjUzMDM2NQoJCQlzMjMuMzI3MjQ3Niw1Mi4yNTMwNTE4LDUyLjI1MzA0NDEsNTIuMjUzMDUxOGMxMS4xOTcwODI1LDAsMjEuOTI3NjEyMy0zLjczMjM2MDgsMzAuMzI1NDI0Mi05Ljc5NzQzOTZsMzEuNzI1MDUxOSwzMC43OTE5NjE3CgkJCWMxLjM5OTYyNzcsMS4zOTk2Mjc3LDMuMjY1ODIzNCwxLjg2NjE4MDQsNS4xMzE5ODg1LDEuODY2MTgwNGMxLjg2NjE5NTcsMCwzLjczMjM2MDgtMC45MzMwNzUsNS4xMzE5ODg1LTIuMzMyNzMzMgoJCQljMi43OTkyNzA2LTIuNzk5MjU1NCwyLjc5OTI3MDYtNy40NjQ3MDY0LDAtMTAuMjYzOTc3MUwyMDYuODQ1NDI4NSwyMjAuODQ4MTc1eiBNMTI4LjQ2NTg2NjEsMTg4LjE5MDAxNzcKCQkJYzAtMjAuOTk0NTIyMSwxNy4yNjIxNzY1LTM4LjI1NjY5ODYsMzguMjU2Njk4Ni0zOC4yNTY2OTg2czM4LjI1NjY5ODYsMTcuMjYyMTc2NSwzOC4yNTY2OTg2LDM4LjI1NjY5ODYKCQkJcy0xNy4yNjIxNzY1LDM4LjI1NjY5ODYtMzguMjU2Njk4NiwzOC4yNTY2OTg2UzEyOC40NjU4NjYxLDIwOS4xODQ1Mzk4LDEyOC40NjU4NjYxLDE4OC4xOTAwMTc3eiIvPgoJPC9nPgoJPGc+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTE3NC4yODA2Mzk2LDE4NS44NzM2MTE1YzIuMjE2Mjc4MSwwLjY4NjUzODcsNC4xMTAwMzExLDEuODcwNzEyMyw1LjY3NjYzNTcsMy41NTI1MDU1CgkJCWMxLjU2NjYwNDYsMS42ODE4MDg1LDIuNTk4NzA5MSwzLjY0OTI2MTUsMy4wOTE3MzU4LDUuOTAyNDA0OGMwLjQ5NzYxOTYsMi4yNTMxNDMzLDAuMzYzOTk4NCw0LjUyOTMyNzQtMC40MDA4Nzg5LDYuODE5MzM1OQoJCQljLTAuOTE2OTE1OSwyLjUyMDM4NTctMi40ODM1MjA1LDQuNTI5MzEyMS00LjY5OTc5ODYsNi4wMTc1OTM0Yy0yLjIxNjI2MjgsMS40ODgyODEyLTQuNjk1MjA1NywyLjI3MTU3NTktNy40NTA1NzY4LDIuMzQ5ODk5MwoJCQl2NS41MDE1NTY0YzAsMC41MzQ0ODQ5LTAuMTcwNDcxMiwwLjk3MjIxMzctMC41MTE0NTk0LDEuMzE3Nzc5NWMtMC4zNDU1NjU4LDAuMzQ1NTgxMS0wLjc4MzI5NDcsMC41MTYwNjc1LTEuMzIyMzg3NywwLjUxNjA2NzUKCQkJaC0zLjY2NzY5NDFjLTAuNTM0NTAwMSwwLTAuOTcyMjEzNy0wLjE3MDQ4NjUtMS4zMTc3Nzk1LTAuNTE2MDY3NWMtMC4zNDA5NzI5LTAuMzQ1NTY1OC0wLjUxNjA2NzUtMC43ODMyOTQ3LTAuNTE2MDY3NS0xLjMxNzc3OTUKCQkJdi01LjUwMTU1NjRjLTMuNjY3Njk0MSwwLTYuOTg5ODIyNC0xLjE0NzI5MzEtOS45Njg2NTg0LTMuNDM3MzAxNmMtMC4zODI0NDYzLTAuMzgyNDMxLTAuNjEyODIzNS0wLjg0MzIwMDctMC42ODg4NDI4LTEuMzc3NzAwOAoJCQljLTAuMDc2MDM0NS0wLjUzNDQ4NDksMC4xMTUxODg2LTEuMDMyMTA0NSwwLjU3MzYzODktMS40ODgyNTA3bDMuODk1NzgyNS0zLjg5ODA4NjUKCQkJYzAuMzA4NzAwNi0wLjIzMDM5MjUsMC42NjgxMDYxLTAuMzgyNDMxLDEuMDkyMDEwNS0wLjQ1NjE2MTVjMC40MTkyOTYzLTAuMDc4MzIzNCwwLjgyMDE1OTksMC4wMzY4NSwxLjIwMjYwNjIsMC4zNDA5NzI5CgkJCWMxLjE0NzI5MzEsMC43NjQ4NzczLDIuNDQyMDQ3MSwxLjE0NzMwODMsMy44OTM0NjMxLDEuMTQ3MzA4M2g3LjY4MDk1NGMwLjkxNjk0NjQsMCwxLjcwMDI0MTEtMC4zMjI1NDAzLDIuMzQ5ODk5My0wLjk3MjIxMzcKCQkJYzAuNjQ5Njg4Ny0wLjY0OTY4ODcsMC45NzIyMjktMS40NzQ0NTY4LDAuOTcyMjI5LTIuNDY1MTAzMWMwLTAuNjg2NTU0LTAuMjI1NzY5LTEuMzM2MjI3NC0wLjY4NjUzODctMS45NDkwMzU2CgkJCWMtMC40NTYxNjE1LTAuNjEyODIzNS0xLjAzMjExOTgtMS4wMzIxMTk4LTEuNzE4NjQzMi0xLjI2MjQ5NjlsLTExLjgwNDg0MDEtMy40MzczMTY5CgkJCWMtMi41OTg2OTM4LTAuNzY0ODc3My00Ljc3MzUyOTEtMi4xMzc5NTQ3LTYuNTMzNjQ1Ni00LjEyODQ0ODVjLTEuNzU3ODEyNS0xLjk4NTkwMDktMi43ODc2NDM0LTQuMjc1OTI0Ny0zLjA5NDAzOTktNi44NzQ2MzM4CgkJCWMtMC4xNTIwNTM4LTIuNDQ2NjU1MywwLjMwNjM5NjUtNC43MTgyMzEyLDEuMzc1Mzk2Ny02LjgxOTMzNTljMS4wNjg5Njk3LTIuMTAxMDg5NSwyLjU5ODcwOTEtMy43ODI4ODI3LDQuNTg0NjEtNS4wNDUzNzk2CgkJCWMxLjk4NTkwMDktMS4yNTc4ODg4LDQuMjAyMTc5LTEuODg5MTI5Niw2LjY0ODg0OTUtMS44ODkxMjk2aDAuMjI1NzY5di01LjUwMTU0MTEKCQkJYzAtMC41MzQ1MDAxLDAuMTc1MDk0Ni0wLjk3MjIyOSwwLjUxNjA2NzUtMS4zMTc3OTQ4YzAuMzQ1NTY1OC0wLjM0NTU4MTEsMC43ODMyNzk0LTAuNTE2MDUyMiwxLjMxNzc3OTUtMC41MTYwNTIyaDMuNjY3Njk0MQoJCQljMC41MzkwOTMsMCwwLjk3NjgyMTksMC4xNzA0NzEyLDEuMzIyMzg3NywwLjUxNjA1MjJjMC4zNDA5ODgyLDAuMzQ1NTY1OCwwLjUxMTQ1OTQsMC43ODMyOTQ3LDAuNTExNDU5NCwxLjMxNzc5NDh2NS41MDE1NDExCgkJCWMzLjY2NzY5NDEsMCw2Ljk1NzU2NTMsMS4xNDcyOTMxLDkuODYwMzgyMSwzLjQzNzMwMTZjMC40NTYxNzY4LDAuMzgyNDQ2MywwLjcyMzQxOTIsMC44NDMyMDA3LDAuODAxNzQyNiwxLjM3NzY4NTUKCQkJYzAuMDczNzE1MiwwLjUzNDUwMDEtMC4xMTUyMDM5LDAuOTkwNjQ2NC0wLjU3MTM1MDEsMS4zNzMwNzc0bC0zLjg5ODA4NjUsNC4wMTMyNzUxCgkJCWMtMC4zMDg3MTU4LDAuMjMwMzkyNS0wLjY2ODEwNjEsMC4zODI0MzEtMS4wOTIwMTA1LDAuNDU2MTYxNWMtMC40MTkyOTYzLDAuMDc4MzIzNC0wLjgyMDE1OTksMC0xLjIwMjU5MDktMC4yMjU3NjkKCQkJYy0xLjE0MjcxNTUtMC44NDMyMDA3LTIuNDQyMDc3Ni0xLjI2MjQ5NjktMy44OTgwODY1LTEuMjYyNDk2OWgtNy42NzYzNjExYy0wLjkxNjkxNTksMC0xLjcwMDIyNTgsMC4zMjI1MjUtMi4zNDk4OTkzLDAuOTcyMjEzNwoJCQljLTAuNjQ5Njg4NywwLjY0OTY3MzUtMC45NzY4MjE5LDEuNDc0NDQxNS0wLjk3NjgyMTksMi40NjUwODc5YzAsMC42ODY1NTQsMC4yMzAzOTI1LDEuMzM2MjEyMiwwLjY5MTE0NjksMS45NDkwMzU2CgkJCWMwLjQ1NjE2MTUsMC42MTI4MjM1LDEuMDMyMTE5OCwxLjAzMjExOTgsMS43MTg2NTg0LDEuMjYyNDk2OUwxNzQuMjgwNjM5NiwxODUuODczNjExNXoiLz4KCTwvZz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - namespaces
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheuses/api
+              verbs:
+                - create
+                - get
+                - update
+          serviceAccountName: koku-metrics-controller-manager
+      deployments:
+        - label:
+            app: koku-metrics-operator
+            control-plane: controller-manager
+          name: koku-metrics-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: koku-metrics-operator
+                control-plane: controller-manager
+            strategy:
+              type: Recreate
+            template:
+              metadata:
+                labels:
+                  app: koku-metrics-operator
+                  control-plane: controller-manager
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - arm64
+                                - ppc64le
+                                - s390x
+                            - key: kubernetes.io/os
+                              operator: In
+                              values:
+                                - linux
+                containers:
+                  - args:
+                      - --leader-elect
+                    command:
+                      - /manager
+                    env:
+                      - name: LEADER_ELECTION_LEASE_DURATION
+                        value: 60s
+                      - name: LEADER_ELECTION_RENEW_DEADLINE
+                        value: 30s
+                      - name: LEADER_ELECTION_RETRY_PERIOD
+                        value: 5s
+                      - name: IN_CLUSTER
+                        value: "true"
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: quay.io/project-koku/koku-metrics-operator@sha256:abc4888c0c7ea7f8601f8c6e240f58094f3f525d73d7c2fa2302e4c6bcc2b940
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 500Mi
+                      requests:
+                        cpu: 100m
+                        memory: 20Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    terminationMessagePolicy: FallbackToLogsOnError
+                    volumeMounts:
+                      - mountPath: /tmp/koku-metrics-operator-reports
+                        name: koku-metrics-operator-reports
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: koku-metrics-controller-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - name: koku-metrics-operator-reports
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - endpoints
+                - events
+                - persistentvolumeclaims
+                - pods
+                - secrets
+                - serviceaccounts
+                - services
+                - services/finalizers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - costmanagement-metrics-cfg.openshift.io
+              resources:
+                - costmanagementmetricsconfigs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - costmanagement-metrics-cfg.openshift.io
+              resources:
+                - costmanagementmetricsconfigs/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - clusterserviceversions
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+          serviceAccountName: koku-metrics-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - cost
+    - management
+    - usage
+    - monitor
+  links:
+    - name: Koku Metrics Operator source code repository
+      url: https://github.com/project-koku/koku-metrics-operator
+  maintainers:
+    - email: costmanagement@redhat.com
+      name: costmanagement
+  maturity: alpha
+  minKubeVersion: 1.24.0
+  provider:
+    name: Red Hat
+  version: 4.4.0
+  relatedImages:
+    - name: koku-metrics-operator
+      image: quay.io/project-koku/koku-metrics-operator@sha256:abc4888c0c7ea7f8601f8c6e240f58094f3f525d73d7c2fa2302e4c6bcc2b940
+  replaces: koku-metrics-operator.v4.3.1

--- a/operators/koku-metrics-operator/4.4.0/metadata/annotations.yaml
+++ b/operators/koku-metrics-operator/4.4.0/metadata/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: koku-metrics-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha,beta
+  operators.operatorframework.io.bundle.channel.default.v1: beta
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.1
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  # OpenShift specific annotations.
+  com.redhat.openshift.versions: "4.12"

--- a/operators/koku-metrics-operator/4.4.0/release-config.yaml
+++ b/operators/koku-metrics-operator/4.4.0/release-config.yaml
@@ -1,0 +1,5 @@
+---
+catalog_templates:
+  - template_name: template.yaml
+    channels: [beta, alpha]
+    replaces: koku-metrics-operator.v4.3.1

--- a/operators/koku-metrics-operator/4.4.0/tests/scorecard/config.yaml
+++ b/operators/koku-metrics-operator/4.4.0/tests/scorecard/config.yaml
@@ -1,0 +1,40 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.10.1
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.10.1
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.10.1
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/operators/koku-metrics-operator/ci.yaml
+++ b/operators/koku-metrics-operator/ci.yaml
@@ -14,6 +14,7 @@ fbc:
         - "v4.18"
         - v4.19
         - v4.20
+        - v4.21
       type: olm.template.basic
 reviewers:
   - djnakabaale


### PR DESCRIPTION
## Summary

Add koku-metrics-operator v4.4.0 bundle.

### New in v4.4.0:
* Enabled gathering and reporting NVIDIA MIG (Multi-Instance GPU) metrics for cost management.
* Updated dependencies.

### Upgrade path
Replaces `koku-metrics-operator.v4.3.1`.

### References
- Release: https://github.com/project-koku/koku-metrics-operator/releases/tag/v4.4.0
- Previous bundle PR: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/6824

Made with [Cursor](https://cursor.com)