### PR TITLE
Fix invalid olm.skipRange semver in percona-server-mongodb-operator

### DIFF
--- a/operators/percona-server-mongodb-operator/1.14.0/manifests/percona-server-mongodb-operator.v1.14.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.14.0/manifests/percona-server-mongodb-operator.v1.14.0.clusterserviceversion.yaml
@@ -213,7 +213,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.14.0
+    olm.skipRange: <1.14.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.15.0/manifests/percona-server-mongodb-operator.v1.15.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.15.0/manifests/percona-server-mongodb-operator.v1.15.0.clusterserviceversion.yaml
@@ -214,7 +214,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.15.0
+    olm.skipRange: <1.15.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.16.0/manifests/percona-server-mongodb-operator.v1.16.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.16.0/manifests/percona-server-mongodb-operator.v1.16.0.clusterserviceversion.yaml
@@ -235,7 +235,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.16.0
+    olm.skipRange: <1.16.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.16.1/manifests/percona-server-mongodb-operator.v1.16.1.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.16.1/manifests/percona-server-mongodb-operator.v1.16.1.clusterserviceversion.yaml
@@ -235,7 +235,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.16.1
+    olm.skipRange: <1.16.1
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.17.0/manifests/percona-server-mongodb-operator.v1.17.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.17.0/manifests/percona-server-mongodb-operator.v1.17.0.clusterserviceversion.yaml
@@ -230,7 +230,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.17.0
+    olm.skipRange: <1.17.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+


### PR DESCRIPTION
## Summary
- Remove `v` prefix from version in `olm.skipRange` annotations across 5 CSV versions
- `<vX.Y.Z` is not valid semver range syntax; the correct form is `<X.Y.Z`
- Affected versions: 1.14.0, 1.15.0, 1.16.0, 1.16.1, 1.17.0