### PR TITLE
Fix invalid olm.skipRange semver in project-quay

### DIFF
--- a/operators/project-quay/v3.10.19/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/v3.10.19/manifests/quay-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    olm.skipRange: ">=3.6.x <v3.10.19"
+    olm.skipRange: ">=3.6.x <3.10.19"
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.10.19

--- a/operators/project-quay/v3.12.15/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/v3.12.15/manifests/quay-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    olm.skipRange: ">=3.6.x <v3.12.15"
+    olm.skipRange: ">=3.6.x <3.12.15"
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.12.15

--- a/operators/project-quay/v3.9.19/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/v3.9.19/manifests/quay-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    olm.skipRange: ">=3.6.x <v3.9.19"
+    olm.skipRange: ">=3.6.x <3.9.19"
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.9.19


### PR DESCRIPTION
## Summary
- Remove `v` prefix from version in `olm.skipRange` annotations across 3 CSV versions
- `<vX.Y.Z` is not valid semver range syntax; the correct form is `<X.Y.Z`
- Affected versions: v3.9.19, v3.10.19, v3.12.15