### PR TITLE
operator jhipster-online-operator (1.1.2)

### DIFF
--- a/operators/jhipster-online-operator/0.1.0/metadata/annotations.yaml
+++ b/operators/jhipster-online-operator/0.1.0/metadata/annotations.yaml
@@ -12,4 +12,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: v4.12-v4.18
+  com.redhat.openshift.versions: "v4.12"

--- a/operators/jhipster-online-operator/0.1.0/metadata/annotations.yaml
+++ b/operators/jhipster-online-operator/0.1.0/metadata/annotations.yaml
@@ -12,4 +12,4 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
-  com.redhat.openshift.versions: "v4.12"
+  com.redhat.openshift.versions: v4.12-v4.18

--- a/operators/jhipster-online-operator/1.1.2/manifests/controller-manager-metrics-service_v1_service.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jhipster-online-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: jhipster-online-operator
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jhipster-online-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: jhipster-online-operator
+    control-plane: controller-manager
+  name: jhipster-online-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jhipster-online-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: jhipster-online-operator
+  name: jhipster-online-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator.clusterserviceversion.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator.clusterserviceversion.yaml
@@ -1,0 +1,821 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "maximilianopizarro.github.io/v1alpha1",
+          "kind": "JhipsterOnline",
+          "metadata": {
+            "name": "demo"
+          },
+          "spec": {
+            "replicaCount": 1,
+            "image": {
+              "repository": "quay.io/maximilianopizarro/jhipster-online",
+              "tag": "2.41.1-quarkus",
+              "pullPolicy": "Always"
+            },
+            "env": {
+              "JAVA_APP_JAR": "/deployments/jhonline.war",
+              "APPLICATION_GITHUB_CLIENT-ID": "YOUR_GITHUB_CLIENT_ID",
+              "APPLICATION_GITHUB_CLIENT-SECRET": "YOUR_GITHUB_CLIENT_SECRET",
+              "APPLICATION_GITHUB_HOST": "https://github.com",
+              "APPLICATION_JHIPSTER-CMD_CMD": "jhipster-quarkus",
+              "SPRING_DATASOURCE_URL": "jdbc:mariadb://mariadb:3306/jhipsteronline",
+              "SPRING_DATASOURCE_USERNAME": "jhipster",
+              "SPRING_DATASOURCE_PASSWORD": "jhipster"
+            },
+            "service": { "type": "ClusterIP", "port": 8080 },
+            "route": { "enabled": true },
+            "ingress": { "enabled": false },
+            "mariadb": { "enabled": true },
+            "openshift": { "grantEditRoleToServiceAccount": true },
+            "jhipster8Worker": { "enabled": true, "port": 8081, "timeoutSeconds": 600 },
+            "pyhipsterWorker": { "enabled": true, "port": 8082, "timeoutSeconds": 600 },
+            "mcpWorker": { "enabled": true, "port": 8083, "timeoutSeconds": 120 },
+            "resources": {
+              "requests": { "cpu": "100m", "memory": "768Mi" },
+              "limits": { "cpu": "1", "memory": "2Gi" }
+            }
+          }
+        },
+        {
+          "apiVersion": "maximilianopizarro.github.io/v1alpha1",
+          "kind": "Jhipster8Worker",
+          "metadata": {
+            "name": "jhipster8-worker"
+          },
+          "spec": {
+            "enabled": true,
+            "instanceBaseName": "demo",
+            "replicas": 1,
+            "port": 8081,
+            "timeoutSeconds": 600,
+            "image": {
+              "repository": "quay.io/maximilianopizarro/jhipster-online-jhipster8-worker",
+              "tag": "2.41.1-jhipster8-worker",
+              "pullPolicy": "IfNotPresent"
+            },
+            "service": { "type": "ClusterIP" },
+            "resources": {
+              "requests": { "cpu": "100m", "memory": "256Mi" },
+              "limits": { "cpu": "500m", "memory": "1Gi" }
+            }
+          }
+        },
+        {
+          "apiVersion": "maximilianopizarro.github.io/v1alpha1",
+          "kind": "PyhipsterWorker",
+          "metadata": {
+            "name": "pyhipster-worker"
+          },
+          "spec": {
+            "enabled": true,
+            "instanceBaseName": "demo",
+            "replicas": 1,
+            "port": 8082,
+            "timeoutSeconds": 600,
+            "image": {
+              "repository": "quay.io/maximilianopizarro/jhipster-online-pyhipster-worker",
+              "tag": "2.41.1-pyhipster-worker",
+              "pullPolicy": "IfNotPresent"
+            },
+            "service": { "type": "ClusterIP" },
+            "resources": {
+              "requests": { "cpu": "100m", "memory": "256Mi" },
+              "limits": { "cpu": "500m", "memory": "512Mi" }
+            }
+          }
+        },
+        {
+          "apiVersion": "maximilianopizarro.github.io/v1alpha1",
+          "kind": "McpWorker",
+          "metadata": {
+            "name": "mcp-worker"
+          },
+          "spec": {
+            "enabled": true,
+            "instanceBaseName": "demo",
+            "replicas": 1,
+            "port": 8083,
+            "timeoutSeconds": 120,
+            "image": {
+              "repository": "quay.io/maximilianopizarro/jhipster-online-mcp-worker",
+              "tag": "2.41.1-mcp-worker",
+              "pullPolicy": "IfNotPresent"
+            },
+            "service": { "type": "ClusterIP" },
+            "resources": {
+              "requests": { "cpu": "100m", "memory": "128Mi" },
+              "limits": { "cpu": "500m", "memory": "512Mi" }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: quay.io/maximilianopizarro/jhipster-online-operator:v1.1.2
+    createdAt: "2026-05-14T22:21:49Z"
+    description: Kubernetes operator for JHipster Online 2.41.1 — web-based code
+      generation platform with JHipster 9, Quarkus, JDL Studio, JDL AI, and optional
+      JHipster 8 / PyHipster / MCP HTTP workers. Deploys on OpenShift 4.12+ or
+      Kubernetes 1.25+.
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://github.com/maximilianoPizarro/jhipster-online-operator
+    support: Maximiliano Pizarro
+  name: jhipster-online-operator.v1.1.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: HTTP worker running generator-jhipster 8.11 for .NET Core, Node/NestJS,
+        and Azure Container Apps stacks. Set instanceBaseName to match the JhipsterOnline
+        CR name for automatic service discovery. Port 8081 by default.
+      displayName: JHipster 8 Worker
+      kind: Jhipster8Worker
+      name: jhipster8workers.maximilianopizarro.github.io
+      version: v1alpha1
+      specDescriptors:
+        - path: enabled
+          description: Enable or disable the worker
+          displayName: Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: instanceBaseName
+          description: Must match the metadata.name of the JhipsterOnline CR
+          displayName: Instance Base Name
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: replicas
+          description: Number of worker replicas
+          displayName: Replicas
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:podCount
+        - path: port
+          description: HTTP listen port
+          displayName: Port
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: timeoutSeconds
+          description: Generation timeout in seconds
+          displayName: Timeout (seconds)
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: image.repository
+          description: Container image repository
+          displayName: Image Repository
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: image.tag
+          description: Container image tag
+          displayName: Image Tag
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.requests.cpu
+          description: CPU request
+          displayName: CPU Request
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.requests.memory
+          description: Memory request
+          displayName: Memory Request
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.limits.cpu
+          description: CPU limit
+          displayName: CPU Limit
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.limits.memory
+          description: Memory limit
+          displayName: Memory Limit
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+    - description: Main JHipster Online 2.41.1 application instance. Deploys the Quarkus/Spring
+        Boot web app with JDL Studio sidecar, optional in-cluster MariaDB, OpenShift Route,
+        and JDL AI integration. The spec maps directly to Helm chart values.
+      displayName: JHipster Online
+      kind: JhipsterOnline
+      name: jhipsteronlines.maximilianopizarro.github.io
+      version: v1alpha1
+      specDescriptors:
+        - path: replicaCount
+          description: Number of application replicas
+          displayName: Replica Count
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:podCount
+        - path: image.repository
+          description: Main application container image
+          displayName: Image Repository
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: image.tag
+          description: Image tag (2.41.1-quarkus or 2.41.1-spring-boot)
+          displayName: Image Tag
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: image.pullPolicy
+          description: Image pull policy
+          displayName: Pull Policy
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:imagePullPolicy
+        - path: route.enabled
+          description: Create an OpenShift Route with TLS edge termination
+          displayName: Route Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: mariadb.enabled
+          description: Deploy in-cluster MariaDB 10.3
+          displayName: MariaDB Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: openshift.grantEditRoleToServiceAccount
+          description: Grant edit ClusterRole to the application ServiceAccount (required for in-cluster deploy)
+          displayName: Grant Edit Role
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: jhipster8Worker.enabled
+          description: Enable JHipster 8 worker flags on main pod
+          displayName: JH8 Worker Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: pyhipsterWorker.enabled
+          description: Enable PyHipster worker flags on main pod
+          displayName: PyHipster Worker Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: mcpWorker.enabled
+          description: Enable MCP worker flags on main pod
+          displayName: MCP Worker Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: service.type
+          description: Kubernetes service type
+          displayName: Service Type
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: service.port
+          description: Service port
+          displayName: Service Port
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: resources.requests.cpu
+          description: CPU request for the main application
+          displayName: CPU Request
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.requests.memory
+          description: Memory request for the main application
+          displayName: Memory Request
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.limits.cpu
+          description: CPU limit for the main application
+          displayName: CPU Limit
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.limits.memory
+          description: Memory limit for the main application
+          displayName: Memory Limit
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: env.APPLICATION_GITHUB_CLIENT-ID
+          description: GitHub OAuth Client ID
+          displayName: GitHub Client ID
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: env.APPLICATION_GITHUB_CLIENT-SECRET
+          description: GitHub OAuth Client Secret
+          displayName: GitHub Client Secret
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:password
+        - path: env.APPLICATION_JDL_AI_ENABLED
+          description: Enable JDL AI assistant (requires completions URL)
+          displayName: JDL AI Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: env.APPLICATION_JDL_AI_API_KEY
+          description: Bearer token for AI model endpoints (oc whoami -t for Sandbox)
+          displayName: JDL AI API Key
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:password
+    - description: Node.js HTTP worker for MCP server generation (POST /generate, /preview).
+        Set instanceBaseName to match the JhipsterOnline CR name for automatic service
+        discovery. Port 8083, timeout 120s by default.
+      displayName: MCP Worker
+      kind: McpWorker
+      name: mcpworkers.maximilianopizarro.github.io
+      version: v1alpha1
+      specDescriptors:
+        - path: enabled
+          description: Enable or disable the worker
+          displayName: Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: instanceBaseName
+          description: Must match the metadata.name of the JhipsterOnline CR
+          displayName: Instance Base Name
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: replicas
+          description: Number of worker replicas
+          displayName: Replicas
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:podCount
+        - path: port
+          description: HTTP listen port
+          displayName: Port
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: timeoutSeconds
+          description: Generation timeout in seconds
+          displayName: Timeout (seconds)
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: image.repository
+          description: Container image repository
+          displayName: Image Repository
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: image.tag
+          description: Container image tag
+          displayName: Image Tag
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.requests.memory
+          description: Memory request
+          displayName: Memory Request
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.limits.memory
+          description: Memory limit
+          displayName: Memory Limit
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+    - description: HTTP worker running generator-pyhipster 0.0.9 for Python/Flask project
+        generation. Set instanceBaseName to match the JhipsterOnline CR name for automatic
+        service discovery. Port 8082 by default.
+      displayName: PyHipster Worker
+      kind: PyhipsterWorker
+      name: pyhipsterworkers.maximilianopizarro.github.io
+      version: v1alpha1
+      specDescriptors:
+        - path: enabled
+          description: Enable or disable the worker
+          displayName: Enabled
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - path: instanceBaseName
+          description: Must match the metadata.name of the JhipsterOnline CR
+          displayName: Instance Base Name
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: replicas
+          description: Number of worker replicas
+          displayName: Replicas
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:podCount
+        - path: port
+          description: HTTP listen port
+          displayName: Port
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: timeoutSeconds
+          description: Generation timeout in seconds
+          displayName: Timeout (seconds)
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:number
+        - path: image.repository
+          description: Container image repository
+          displayName: Image Repository
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: image.tag
+          description: Container image tag
+          displayName: Image Tag
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.requests.memory
+          description: Memory request
+          displayName: Memory Request
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+        - path: resources.limits.memory
+          description: Memory limit
+          displayName: Memory Limit
+          x-descriptors:
+            - urn:alm:descriptor:com.tectonic.ui:text
+  description: |
+    ## JHipster Online Operator
+
+    This operator manages the full lifecycle of **[JHipster Online](https://github.com/redhat-developer-demos/jhipster-online)** on
+    Red Hat OpenShift (4.12+) and Kubernetes (1.25+).
+
+    JHipster Online is a **web-based code generation platform** that lets developers
+    create full-stack applications using **JDL (JHipster Domain Language)** models
+    and push the generated code directly to a GitHub repository — no local JHipster
+    installation required.
+
+    ### Key Features
+
+    - **Multi-framework generation** — Spring Boot, Quarkus, Micronaut, .NET, Node/NestJS, Python, Rust, and MCP server projects
+    - **JDL Studio** — built-in visual editor for JHipster Domain Language models (nginx sidecar on port 8081)
+    - **JDL AI Assistant** — AI-assisted JDL drafting with lexical + semantic RAG, powered by in-cluster vLLM models (Granite, Nemotron, Qwen)
+    - **Editor AI** — in-app assist for Helm YAML and JDL (complete, explain, fix, generate-from-prompt)
+    - **GitHub OAuth integration** — authenticate users and push generated code to repositories
+    - **In-cluster deploy** — generated apps can be deployed directly on the same cluster via Fabric8 + Helm
+    - **Dark mode** — CSS custom properties and navbar toggle
+
+    ### Architecture
+
+    The operator uses **four Helm charts** (one per CRD) to deploy the platform components:
+
+    | Custom Resource | Component | Port | Purpose |
+    |-----------------|-----------|------|---------|
+    | **JhipsterOnline** | Main app + JDL Studio + MariaDB | 8080 | Quarkus/Spring Boot app with JH9 generators, JDL AI, in-cluster deploy |
+    | **Jhipster8Worker** | JH8 HTTP worker | 8081 | generator-jhipster 8.11 for .NET, Node/NestJS, Azure Container Apps |
+    | **PyhipsterWorker** | PyHipster HTTP worker | 8082 | generator-pyhipster 0.0.9 for Python/Flask projects |
+    | **McpWorker** | MCP HTTP worker | 8083 | Node.js MCP server generation (POST /generate, /preview) |
+
+    Worker CRs use `instanceBaseName` to reference the main `JhipsterOnline` CR name,
+    enabling automatic service discovery wiring between the main app and its workers.
+
+    ### Stack Compatibility (JHipster Online 2.41.1)
+
+    **Main pod (JHipster 9):** Spring Boot (default), Quarkus, Micronaut, Rust (experimental)
+
+    **JHipster 8 worker:** .NET Core, Node/NestJS, Azure Container Apps
+
+    **PyHipster worker:** Python / Flask
+
+    **MCP worker:** MCP server projects (Node.js)
+
+    ### Container Images
+
+    | Component | Image | Tag |
+    |-----------|-------|-----|
+    | Main app | `quay.io/maximilianopizarro/jhipster-online` | `2.41.1-quarkus` |
+    | JH8 worker | `quay.io/maximilianopizarro/jhipster-online-jhipster8-worker` | `2.41.1-jhipster8-worker` |
+    | PyHipster worker | `quay.io/maximilianopizarro/jhipster-online-pyhipster-worker` | `2.41.1-pyhipster-worker` |
+    | MCP worker | `quay.io/maximilianopizarro/jhipster-online-mcp-worker` | `2.41.1-mcp-worker` |
+    | JDL Studio | `quay.io/maximilianopizarro/jdl-studio` | `latest` |
+    | MariaDB | `registry.redhat.io/rhel8/mariadb-103` | (default) |
+    | Operator | `quay.io/maximilianopizarro/jhipster-online-operator` | `v1.1.2` |
+
+    Runtime base: **UBI8 OpenJDK 21**, Node 22.19, Maven 3.9.15.
+
+    ### Quick Start
+
+    1. Create a `JhipsterOnline` CR (the main application with MariaDB and Route)
+    2. Create a `Jhipster8Worker` CR for .NET/Node/Azure stacks
+    3. Create a `PyhipsterWorker` CR for Python generation
+    4. Create a `McpWorker` CR for MCP server generation
+
+    Use the pre-filled examples in each tab above. Set your GitHub OAuth credentials
+    in the `JhipsterOnline` spec under `env.APPLICATION_GITHUB_CLIENT-ID` and
+    `env.APPLICATION_GITHUB_CLIENT-SECRET`.
+
+    ### Prerequisites
+
+    - OpenShift 4.12+ or Kubernetes 1.25+
+    - Cluster-admin privileges for CRD installation
+    - (Optional) GitHub OAuth app for code push
+    - (Optional) KServe/vLLM models in `sandbox-shared-models` for JDL AI
+
+    ### JDL AI Assistant Configuration
+
+    The operator supports **AI-assisted JDL drafting** via OpenAI-compatible endpoints
+    (vLLM, KServe, Ollama, OpenAI). Configure via `env` in the `JhipsterOnline` CR spec:
+
+    **Enable AI** (add to `spec.env`):
+
+        APPLICATION_JDL_AI_ENABLED: "true"
+        APPLICATION_JDL_AI_API_KEY: "<your-token>"
+
+    **Available models on Developer Sandbox** (pre-configured in default values):
+
+    | Model | ID | Context |
+    |-------|----|---------|
+    | IBM Granite 3.1 8B | `granite-31-8b` | 65K |
+    | NVIDIA Nemotron Nano 9B v2 | `nemotron-nano-9b-v2` | 65K |
+    | Qwen3 8B | `qwen3-8b` | 40K |
+
+    **Multi-model configuration** (add to `spec.env`):
+
+        APPLICATION_JDL_AI_DEFAULT_MODEL_ID: "granite-31-8b"
+        APPLICATION_JDL_AI_MODELS_0_ID: "granite-31-8b"
+        APPLICATION_JDL_AI_MODELS_0_LABEL: "IBM Granite 3.1 8B (FP8)"
+        APPLICATION_JDL_AI_MODELS_0_MODEL: "isvc-granite-31-8b-fp8"
+        APPLICATION_JDL_AI_MODELS_0_API_URL: "https://isvc-granite-31-8b-fp8-predictor.sandbox-shared-models.svc.cluster.local:8443/v1/chat/completions"
+
+    **RAG settings**: `APPLICATION_JDL_AI_RAG_ENABLED` (default true, lexical),
+    `APPLICATION_JDL_AI_RAG_SEMANTIC_ENABLED` (false, requires embeddings URL),
+    `APPLICATION_JDL_AI_RAG_TOP_K` (6), `APPLICATION_JDL_AI_RAG_MAX_CHARS` (14000).
+
+    **Timeouts**: `APPLICATION_JDL_AI_CONNECT_TIMEOUT_MS` (15000),
+    `APPLICATION_JDL_AI_READ_TIMEOUT_MS` (120000).
+
+    **Single external model** (Ollama, OpenAI, custom vLLM route):
+
+        APPLICATION_JDL_AI_ENABLED: "true"
+        APPLICATION_JDL_AI_MODELS_0_ID: "my-model"
+        APPLICATION_JDL_AI_MODELS_0_LABEL: "My vLLM"
+        APPLICATION_JDL_AI_MODELS_0_MODEL: "my-serving-model"
+        APPLICATION_JDL_AI_MODELS_0_API_URL: "https://my-model.apps.example.com/v1/chat/completions"
+
+    For Sandbox quick start: `APPLICATION_JDL_AI_API_KEY` = `oc whoami -t`.
+    For production: use Kubernetes Secrets or External Secrets Operator.
+
+    ### Links
+
+    - [Source (Application)](https://github.com/redhat-developer-demos/jhipster-online)
+    - [Source (Operator)](https://github.com/maximilianoPizarro/jhipster-online-operator)
+    - [Helm Chart](https://maximilianopizarro.github.io/jhipster-online-helm-chart/)
+    - [Container Images (Quay.io)](https://quay.io/repository/maximilianopizarro/jhipster-online)
+    - [Architecture (Upstream)](https://github.com/redhat-developer-demos/jhipster-online/blob/main/ARCHITECTURE.md)
+  displayName: JHipster Online Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAIxUlEQVR42u1Za4xdVRX+1tr7nPuYaadQ26YiPngFZxShY9Ba7J1ieKW0FMiZQCLBRKF/EGIpwYaQM5cYWzrEKMYEJGpNTNR7FdpaARWYGWpBKy2iaUmUKOKTtlCnM72Pc/beyx/n3um0HduZcmfAeL5/59zHXu/Ht4EUKVKkSJEiRYoUKVKkSJEiRYr/M9CEb8OQC+jh5GGw8bIHADB/734pd+4RFIvunaRHGArt7QLt2zNIADC/q0cAoPncg0FXnIzMQVBSkz21EA7ooFRSEKEZV1mEgpKooCSTlnci3ehYz6NYdJ+4a/O7c8q/zFl3gYidBycQpjcJ9BqzetkSvzx0/1WvHvfnAVDuDRxAMm1Kl8Eol1Eu99ojYgu/lHnpHKeli0Q+KHDvheB0ERCz2k+sfhfVRp54/N4lfwnDkMdHAh35k+SDpWseXaO93L3s+XMapwIgUOOrzhm4qFYToj+AaQc7+jkpf/vTGy57Y8wYpZLq3BNIsUgtSZMwFN7bBSr30pjSwdd2z6tHKEDoCogsAeRcnclrZg0RSeQWAJRIbuLaqItr921dd3F/GAo3ZaOm98rlXltYs/VzmfaOR+LqIYizZkInAEzMzMoHaw/iHFxc2y/gASYqM43+4qn7e4ePeKzMpxYVQkEJ3LmnT5oeuzL81Wy/PXc5ifQK5FLt5+YSMZypw8YRRMQSQSaSmoi133Ya6iMHP7t1Xfe3g5Koci9ZAoQAwse/UMpm2P+j0pmF1kRCBHXCYBQRApwQEbNSyssCENio/jciegxw33tm44qd4+vFUF+PBZ3EECJU6BtUQ8VlYw5Y+cBvLyKHmwG5XvnZ9xAIJqrCWWOJSATCBKL/WtQTga3ys2Tj2mvx3/ef/+TXr4oAgJreX7p262Kt9HPOxA4EnmJuiiAJKdZaKS8LG1UBYIiZH8llzGPbiisrY4bAoDuuixyjePfDL3hnHORrSKlb4OxlOtdOtl6FNZFthC6DiKYqJ2uPYOxHN6/r3hUEJaX3dc4jAFDAEuVlxZnIATQ1AxARIYkYMbEYE1sQtPLzBSIuHK7KK8vufvxbzrpNQ8Vl/2rWiXIQOAAo9A2qISIzBJjl67efpr2OT+OQW60ymS4AMPXDiCuHDEQUEalTb5ZktZ/XkT20BMCufZ0B6fl790uSJbJUxJJM2azHGwOABgATVS1EoLR/jvKy641U1iy7e9t3jLEPlXuv+XPzJ0OAubZ/x3wnbauJcIvysmc6U0dcG3EAN9NRg956t5WkRCwF8OD8LiT9u/vWrflZs9wrrL2Fzpipp8DJT3WAOFJaKz8HG1UPEfGmqql8ZcHczlHR8e1Eslpn8gtMM8wJRFONxJOKAae0zzau/zXOd5z75B3n1TUAtHe4TmZ/obORgFp7aKPZMkAs1oipjlhiNVv52duzzt7suFLzs3MWxLVRRK0I8xOPvexMJKy9M3OV0fMBvMQAwEKLlZ8FBHZ6B1YiEGkRK3Fl2LD2OljpBVHl30ZsLI0wn+6p0nqZNlixiwEkoe4glyTDw4yN7okhrBFnZkzx8c0AQrgEADgISz4JLnImAjAN4X/yiJjRPUIg7EwEgnQXBkTrA9XMuSC839kYLS9+Jy5IgIyNyjxz6y+xMxFA/IGOnb85m52lRcrLeOKcm9llTixrj1lpFhE7k2c7sU552YxYWsSAdIMUTjqits7zFhDx8x3KxvVXrTH/yLTNUQJxApkZJwgJsQIxdTORfBhiMe07vYiIiNV+VrHyyUa1bxwarlwIFy+Ko+p3tZ9j7eUYEIPprsgkJOIAwQUaoLOcs6ATLBItUN6Q0lr7OWXj2vPWubuf7V+xHQB2AcMAPrNqw+4fQqsNfn7OBXF1BM5ZO23zgIDEGgjhbBbIPDiH6ajGzdzWuVkaoNdNXLttILvzkmf7V2wPSiUFCCXMTklt/uKiJw6OvPmxuFq5B6yG/fxs1Yya6eg+4iwgmEc9d252rVZeAAsBedk8u7huRPCQietf3v7V6/85nn84ilEqlVS5N3l33fqdZzkv0wfQTaw04trhaRqNxVFh7RbT3ORa4HEHItF+VkEEztotJPa+Z/pX7k5W4VAPFYvmRL4phANjK/HK/l1LGbqPPX+ZWJssVy00hACWCnduOcCK54pzglOsA0llB7SXVSCGs9EvRdyXBjeu+NlRq+8kO00Yhry3q4uaEXHtxhcDIV6n/OxFzkQwUe2tGkKIFYmzb1Jh7ZYhpTOftHFNaGqLkIiIA8A6kycAcCb+tTj0Dz6w/MdNLg/oQ/EUKfQgKKlyKTFcIRzQHe1zbiLiNVpnP+RsDBNVHYCm3DSV0Nd+HrZefZ567txys862bYrrozGBvMk0MwIcmLX283A2hogbgsiDAxuvfnSMzwvKfGyenyqa/B0AXPn5xzOZMxfeSEy3sfK7AYKpHwYA06DG+OSeQ+znZnlRfXQ1FcIBjdHhn2ba514ejb7RyE9iNLiChFslIYiASCsvA1Ye4nq1Qkxbyck3n+m/euAor7VI8WPrQ1ASHmOGw5BXtV23AiS3isgVOtumXFSHjWsCIiuSUNkk0iC0SUREAHHZWe/y6iMHdmTOzl9KgFDhjs0dnPE3Kc+/BqDEq842JmcFVhoggqkfFiLaRUI/IoXy0xuu/tMY+9vbOo9Phi0eT5EvX7/7I1qrGyBuFbE6X/s5OGuO6CECYgXl+QAr2Hp1wEaVG39yz+LXm6ywAEBh7bYrWdEN4tzFEDdPQJaAfSB6GUQ7NNHAU/cv//2xNy0zo/hEqXH0/UP3wy947xvOXGzIfgrOLQHkPBGZC4EmVgeI6UUGvv/YXRf+oOk4alq1cYkg4+4GZ8eVYftc/6qRia7EJmR23yaEofAgBnk8ld6oHf7hV3eeTspX1D7/4LbVZ1TGs9DHdaUgKKlkQju+GhfCAZ1U9XcyhE4ka6KfqMl0DEqWo7fh0rPFBoEIIQz5f1+XFClSpEiRIkWKFClSpEiRIkWr8B8GYpv/ixVYNwAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - secrets
+          - configmaps
+          - events
+          - services
+          - persistentvolumeclaims
+          - deployments
+          - statefulsets
+          - replicasets
+          - daemonsets
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          - replicasets
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - bind
+          resourceNames:
+          - edit
+          - view
+          - admin
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - maximilianopizarro.github.io
+          resources:
+          - jhipsteronlines
+          - jhipsteronlines/status
+          - jhipsteronlines/finalizers
+          - jhipster8workers
+          - jhipster8workers/status
+          - jhipster8workers/finalizers
+          - pyhipsterworkers
+          - pyhipsterworkers/status
+          - pyhipsterworkers/finalizers
+          - mcpworkers
+          - mcpworkers/status
+          - mcpworkers/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: jhipster-online-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: jhipster-online-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: jhipster-online-operator
+          control-plane: controller-manager
+        name: jhipster-online-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: quay.io/brancz/kube-rbac-proxy:v0.18.1
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                - --leader-election-id=jhipster-online-operator
+                image: quay.io/maximilianopizarro/jhipster-online-operator:v1.1.2
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 2Gi
+                  requests:
+                    cpu: 100m
+                    memory: 1Gi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: jhipster-online-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: jhipster-online-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - java
+  - spring-boot
+  - jhipster
+  - quarkus
+  - openshift
+  - kubernetes
+  - code-generation
+  links:
+  - name: JHipster Online Operator
+    url: https://github.com/maximilianoPizarro/jhipster-online-operator
+  - name: Helm Chart
+    url: https://maximilianopizarro.github.io/jhipster-online-helm-chart/
+  maintainers:
+  - email: maximiliano.pizarro.5@gmail.com
+    name: Maximiliano Pizarro
+  maturity: alpha
+  minKubeVersion: 1.25.0
+  provider:
+    name: maximilianopizarro
+    url: https://github.com/maximilianoPizarro
+  version: 1.1.2

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator.clusterserviceversion.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator.clusterserviceversion.yaml
@@ -818,4 +818,5 @@ spec:
   provider:
     name: maximilianopizarro
     url: https://github.com/maximilianoPizarro
+  replaces: jhipster-online-operator.v0.1.0
   version: 1.1.2

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator.clusterserviceversion.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipster-online-operator.clusterserviceversion.yaml
@@ -818,5 +818,4 @@ spec:
   provider:
     name: maximilianopizarro
     url: https://github.com/maximilianoPizarro
-  replaces: jhipster-online-operator.v0.1.0
   version: 1.1.2

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipsteronline-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipsteronline-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jhipster-online-operator
+    app.kubernetes.io/instance: jhipsteronline-editor-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: jhipster-online-operator
+  name: jhipsteronline-editor-role
+rules:
+- apiGroups:
+  - maximilianopizarro.github.io
+  resources:
+  - jhipsteronlines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - maximilianopizarro.github.io
+  resources:
+  - jhipsteronlines/status
+  verbs:
+  - get

--- a/operators/jhipster-online-operator/1.1.2/manifests/jhipsteronline-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/jhipsteronline-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jhipster-online-operator
+    app.kubernetes.io/instance: jhipsteronline-viewer-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: jhipster-online-operator
+  name: jhipsteronline-viewer-role
+rules:
+- apiGroups:
+  - maximilianopizarro.github.io
+  resources:
+  - jhipsteronlines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - maximilianopizarro.github.io
+  resources:
+  - jhipsteronlines/status
+  verbs:
+  - get

--- a/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_jhipster8workers.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_jhipster8workers.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: jhipster8workers.maximilianopizarro.github.io
+spec:
+  group: maximilianopizarro.github.io
+  names:
+    kind: Jhipster8Worker
+    listKind: Jhipster8WorkerList
+    plural: jhipster8workers
+    singular: jhipster8worker
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JHipster 8 HTTP worker (generator-jhipster 8.x stacks). Deploys
+          Deployment + ClusterIP Service named like the main jhipster-online release
+          plus "-jhipster8-worker". instanceBaseName must match the JhipsterOnline
+          CR metadata.name in the same namespace.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              affinity:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              enabled:
+                type: boolean
+              image:
+                properties:
+                  pullPolicy:
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              instanceBaseName:
+                description: Must equal the JhipsterOnline CR metadata.name in this
+                  namespace.
+                minLength: 1
+                type: string
+              nodeSelector:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              port:
+                maximum: 65535
+                minimum: 1
+                type: integer
+              replicas:
+                minimum: 0
+                type: integer
+              resources:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              service:
+                properties:
+                  type:
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+              serviceAccountName:
+                type: string
+              timeoutSeconds:
+                minimum: 1
+                type: integer
+              tolerations:
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+            required:
+            - instanceBaseName
+            - image
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_jhipsteronlines.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_jhipsteronlines.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: jhipsteronlines.maximilianopizarro.github.io
+spec:
+  group: maximilianopizarro.github.io
+  names:
+    kind: JhipsterOnline
+    listKind: JhipsterOnlineList
+    plural: jhipsteronlines
+    singular: jhipsteronline
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JHipster Online main application instance. The spec is passed
+          to the bundled Helm chart (jhipster-online 1.1.2) as values. Optional HTTP
+          workers are separate CRs (Jhipster8Worker, PyhipsterWorker, McpWorker);
+          use the same metadata.name on the main instance and worker CRs so worker
+          Services match APPLICATION_*WORKER_* URLs on the main pod. For a minimal
+          working install set image (repository, tag), env (GitHub OAuth, datasource,
+          generator mode), and tune route/mariadb as needed. See chart values.yaml
+          for all keys.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Helm values for jhipster-online. Typically set image.repository,
+              image.tag, env.*, route.enabled, mariadb.enabled, and jhipster8Worker/pyhipsterWorker/mcpWorker.enabled
+              to true when the corresponding worker CRs are deployed.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Observed state (Helm operator).
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_mcpworkers.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_mcpworkers.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: mcpworkers.maximilianopizarro.github.io
+spec:
+  group: maximilianopizarro.github.io
+  names:
+    kind: McpWorker
+    listKind: McpWorkerList
+    plural: mcpworkers
+    singular: mcpworker
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MCP HTTP worker (Node). Deploys Deployment + Service named like
+          the main jhipster-online release plus "-mcp-worker". instanceBaseName must
+          match the JhipsterOnline CR metadata.name in the same namespace.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              affinity:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              enabled:
+                type: boolean
+              image:
+                properties:
+                  pullPolicy:
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              instanceBaseName:
+                minLength: 1
+                type: string
+              nodeSelector:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              port:
+                maximum: 65535
+                minimum: 1
+                type: integer
+              replicas:
+                minimum: 0
+                type: integer
+              resources:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              service:
+                properties:
+                  type:
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+              serviceAccountName:
+                type: string
+              timeoutSeconds:
+                minimum: 1
+                type: integer
+              tolerations:
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+            required:
+            - instanceBaseName
+            - image
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_pyhipsterworkers.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/maximilianopizarro.github.io_pyhipsterworkers.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: pyhipsterworkers.maximilianopizarro.github.io
+spec:
+  group: maximilianopizarro.github.io
+  names:
+    kind: PyhipsterWorker
+    listKind: PyhipsterWorkerList
+    plural: pyhipsterworkers
+    singular: pyhipsterworker
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PyHipster HTTP worker. Deploys Deployment + Service named like
+          the main jhipster-online release plus "-pyhipster-worker". instanceBaseName
+          must match the JhipsterOnline CR metadata.name in the same namespace.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              affinity:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              enabled:
+                type: boolean
+              image:
+                properties:
+                  pullPolicy:
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                required:
+                - repository
+                - tag
+                type: object
+              imagePullSecrets:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              instanceBaseName:
+                minLength: 1
+                type: string
+              nodeSelector:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              port:
+                maximum: 65535
+                minimum: 1
+                type: integer
+              replicas:
+                minimum: 0
+                type: integer
+              resources:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              service:
+                properties:
+                  type:
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+              serviceAccountName:
+                type: string
+              timeoutSeconds:
+                minimum: 1
+                type: integer
+              tolerations:
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+            required:
+            - instanceBaseName
+            - image
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/jhipster-online-operator/1.1.2/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/jhipster-online-operator/1.1.2/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jhipster-online-operator
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: jhipster-online-operator
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/jhipster-online-operator/1.1.2/metadata/annotations.yaml
+++ b/operators/jhipster-online-operator/1.1.2/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: jhipster-online-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # OpenShift versions compatibility.
+  com.redhat.openshift.versions: "v4.12"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/jhipster-online-operator/ci.yaml
+++ b/operators/jhipster-online-operator/ci.yaml
@@ -1,0 +1,1 @@
+updateGraph: replaces-mode

--- a/operators/jhipster-online-operator/ci.yaml
+++ b/operators/jhipster-online-operator/ci.yaml
@@ -1,1 +1,1 @@
-updateGraph: replaces-mode
+updateGraph: semver-mode


### PR DESCRIPTION
### New Submission

- Are you submitting a new operator?

### Significant Update

- [x] Are you making a significant update to an existing operator? (e.g. upgrade the operator to a new major version)

### Checklist

- [x] Have you updated the `replaces` field?
- [x] Is your CSV pointing to correct images?
- [x] Does your operator deploy correctly?
- [x] Have you tested your operator update path?

### Your submission

#### Operator Description

JHipster Online Operator v1.1.2 — Kubernetes operator for JHipster Online 2.41.1, a web-based code generation platform with JHipster 9, Quarkus, JDL Studio, JDL AI, and optional JHipster 8 / PyHipster / MCP HTTP workers.

#### What changed in v1.1.2

* **4 Custom Resource kinds**: `JhipsterOnline`, `Jhipster8Worker`, `PyhipsterWorker`, `McpWorker` (3 new worker CRDs since v0.1.0)
* **Multi-framework generation**: Spring Boot, Quarkus, Micronaut, .NET, Node/NestJS, Python, Rust, and MCP server projects
* **JDL AI Assistant**: AI-assisted JDL drafting with lexical + semantic RAG, powered by in-cluster vLLM models (Granite, Nemotron, Qwen)
* **Editor AI**: in-app assist for Helm YAML and JDL (complete, explain, fix, generate-from-prompt)
* **Dark mode** with CSS custom properties and navbar toggle
* **In-cluster deploy** of generated apps via Fabric8 + Helm
* `replaces: jhipster-online-operator.v0.1.0`

#### Container Images

| Component        | Image                                                       | Tag                     |
| ---------------- | ----------------------------------------------------------- | ----------------------- |
| Main app         | quay.io/maximilianopizarro/jhipster-online                  | 2.41.1-quarkus          |
| JH8 worker       | quay.io/maximilianopizarro/jhipster-online-jhipster8-worker | 2.41.1-jhipster8-worker |
| PyHipster worker | quay.io/maximilianopizarro/jhipster-online-pyhipster-worker | 2.41.1-pyhipster-worker |
| MCP worker       | quay.io/maximilianopizarro/jhipster-online-mcp-worker       | 2.41.1-mcp-worker       |
| Operator         | quay.io/maximilianopizarro/jhipster-online-operator         | v1.1.2                  |

#### Links

* [Source (Operator)](https://github.com/maximilianoPizarro/jhipster-online-operator)
* [Source (Application)](https://github.com/maximilianoPizarro/jhipster-online-quarkus)
* [Helm Chart](https://github.com/maximilianoPizarro/jhipster-online-operator/tree/main/helm-charts)

Made with Cursor

Made with [Cursor](https://cursor.com)