### PR TITLE
operator project-quay (3.9.19)

### DIFF
--- a/operators/project-quay/3.9.19/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.9.19/manifests/quay-operator.clusterserviceversion.yaml
@@ -1,0 +1,283 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    olm.skipRange: ">=3.6.x <3.9.19"
+    capabilities: Full Lifecycle
+    categories: Integration & Delivery
+    containerImage: quay.io/projectquay/quay-operator:v3.9.19
+    createdAt: 2026-03-24T21:31:25Z
+    support: Project Quay
+    description: Opinionated deployment of Quay on Kubernetes.
+    quay-version: v3.9.19
+    repository: https://github.com/quay/quay-operator
+    tectonic-visibility: ocs
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "quay.redhat.com/v1",
+          "kind": "QuayRegistry",
+          "metadata": {
+            "name": "example-registry"
+          },
+          "spec": {
+            "components": [
+              {"kind": "clair", "managed": true},
+              {"kind": "postgres", "managed": true},
+              {"kind": "objectstorage", "managed": true},
+              {"kind": "redis", "managed": true},
+              {"kind": "horizontalpodautoscaler", "managed": true},
+              {"kind": "route", "managed": true},
+              {"kind": "mirror", "managed": true},
+              {"kind": "monitoring", "managed": true},
+              {"kind": "tls", "managed": true},
+              {"kind": "quay", "managed": true},
+              {"kind": "clairpostgres", "managed": true}
+            ]
+          }
+        }
+      ]
+    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware", "fips"]'
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+  name: quay-operator.v3.9.19
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+      - description: Represents a full Quay registry installation.
+        displayName: Quay Registry
+        kind: QuayRegistry
+        name: quayregistries.quay.redhat.com
+        version: v1
+        resources:
+          - kind: Deployment
+          - kind: ReplicaSet
+          - kind: Pod
+          - kind: Secret
+          - Kind: Job
+          - kind: ConfigMap
+          - kind: ServiceAccount
+          - kind: PersistentVolumeClaim
+          - kind: Ingress
+          - kind: Route
+          - kind: Role
+          - kind: Rolebinding
+          - kind: HorizontalPodAutoscaler
+          - kind: ServiceMonitor
+          - kind: PrometheusRule
+        specDescriptors:
+          - path: configBundleSecret
+            displayName: Config Bundle Secret
+            description: Name of the Quay config secret containing base configuration and custom SSL certificates.
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Secret'
+          - path: components
+            displayName: Components
+            description: Declares how the Operator should handle supplemental Quay services.
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+          - path: components[0].kind
+            displayName: Kind
+            description: The unique name of this type of component.
+          - path: components[0].managed
+            displayName: Managed
+            description: Indicates whether lifecycle of this component is managed by the Operator or externally.
+        statusDescriptors:
+          - path: currentVersion
+            displayName: Current Version
+            description: The currently installed version of all Quay components.
+          - path: conditions
+            displayName: Conditions
+            description: Observed conditions of Quay components.
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+          - path: configEditorCredentialsSecret
+            displayName: Config Editor Credentials Secret
+            description: Name of the secret containing credentials for the Quay config editor.
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:Secret'
+          - path: registryEndpoint
+            displayName: Registry Endpoint
+            description: Externally accessible URL for container pull/push and web frontend.
+            x-descriptors:
+              - 'urn:alm:descriptor:org.w3:link'
+          - path: configEditorEndpoint
+            displayName: Config Editor Endpoint
+            description: Externally accessible URL for the config editor UI.
+            x-descriptors:
+              - 'urn:alm:descriptor:org.w3:link'
+  description: Opinionated deployment of Quay on Kubernetes.
+  displayName: Quay
+  install:
+    spec:
+      deployments:
+        - name: quay-operator-tng
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: quay-operator-alm-owned
+            template:
+              metadata:
+                labels:
+                  name: quay-operator-alm-owned
+                name: quay-operator-alm-owned
+              spec:
+                containers:
+                  - name: quay-operator
+                    image: quay.io/projectquay/quay-operator:v3.9.19
+                    command:
+                      - /workspace/manager
+                      - '--namespace=$(WATCH_NAMESPACE)'
+                    env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: MY_POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: QUAY_VERSION
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['quay-version']
+                      - name: QUAY_DEFAULT_BRANDING
+                        value: upstream
+                      - name: RELATED_IMAGE_COMPONENT_QUAY
+                        value: quay.io/projectquay/quay:v3.9.19
+                      - name: RELATED_IMAGE_COMPONENT_CLAIR
+                        value: quay.io/projectquay/clair:4.8.0
+                      - name: RELATED_IMAGE_COMPONENT_BUILDER
+                        value: quay.io/projectquay/quay-builder:v3.9.19
+                      - name: RELATED_IMAGE_COMPONENT_BUILDER_QEMU
+                        value: quay.io/projectquay/quay-builder-qemu:main
+                      - name: RELATED_IMAGE_COMPONENT_POSTGRES
+                        value: quay.io/sclorg/postgresql-13-c9s@sha256:18c6f18763b3f2c27a71b3806864bd1093bd452f1c42ccf26e38c9d0926caaa0
+                      - name: RELATED_IMAGE_COMPONENT_POSTGRES_PREVIOUS
+                        value: centos/postgresql-10-centos7@sha256:f826fcb2983eef2c49e9e9a9d9d61ab403254b50cff85a7caa949fd8474fd558
+                      - name: RELATED_IMAGE_COMPONENT_REDIS
+                        value: redis@sha256:352c1fdadc91926edda08f45aeb3f27f37194c2f14101229c0523a11195c96e3
+                serviceAccountName: quay-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - quay.redhat.com
+              resources:
+                - quayregistries
+                - quayregistries/status
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - secrets
+                - configmaps
+                - serviceaccounts
+                - persistentvolumeclaims
+                - events
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - watch
+                - list
+                - update
+                - patch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+              verbs:
+                - '*'
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+              verbs:
+                - '*'
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - '*'
+            - apiGroups:
+                - objectbucket.io
+              resources:
+                - objectbucketclaims
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheusrules
+                - servicemonitors
+              verbs:
+                - '*'
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - '*'
+          serviceAccountName: quay-operator
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - open source
+    - containers
+    - registry
+  labels:
+    alm-owner-quay-operator: quay-operator
+    operated-by: quay-operator
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAUAAAACECAYAAADhnvK8AAAAAXNSR0IArs4c6QAAAAlwSFlzAAAuIwAALiMBeKU/dgAAQABJREFUeAHtfQl4XMWRf3W/OXRYki0fsuX7AIMvjIUPGQwyt7lCNthAAqyNhQ0s7JI9kt1kd/9KNtn9YLMhG7IEG5v7SHAS7vuwABtjG9lcBozv+75lHTPzXv9/9cYjaUYz772ZN7Jk+7U/eWb6qK6u7q6urq6uJvKCRwGPAh4FPAp4FPAo4FHAo4BHAY8CHgU8CngU8CjgUcCjgEcBjwIeBTwKeBTwKOBRwKOARwGPAh4FPAp4FPAo4FHAo4BHAY8CHgU8CngU8CjgUcCjgEcBjwIeBTwKeBTwKOBRwKOARwGPAh4FPAp4FPAo4FHAo4BHAY8CHgU8CngU8CjgUaADUUB0IFyaUamo8lGgNtgc4eJbUacwLagKuYAQX3TK3UHSg774yAx/FY1roAXT9AxLn7rFBkzPoY1Hw0QLPNqduqMgKy3PzkTOCirNQPz6zjFSz5tAShnNsel/M4SQxV1L1u9S6lUSQqUPoVUJGWgQlwtp9HeHm0EykCd7nmG8v4Hos1a1tEdERYWP6od0pUiDJMqLx0CGFBmBCDUcaKBVVN+ujOfsGd0pL/dC6inW0Me0Ih5R75dHgfQo0PEY4JApwXBY/6UwGi8mw90Cr+XmUOmIkZvHL65b8RLR9vRIkyT3xJl9ww0Nc0j4SsgNbzYM6tS1O/UaNvql4jnquprZAtJMO4faQYNJo8fIl4OFQm8mvBDYJfjrSVO7yFf8KU0IvUdHpn5LqxbUtgvGPvl91PsbUr6lNOXuC+j1BxrbBY9YpWWz8rAwyHajRwwP7zMjCnQ8Btil33lE6gIVcTmuIxHqPHQoFZ8xvN/hgwduBHV+jT83UqCgsLhF+UQJ6S531OAvJWcOo9xu3S/V8jaPA16LM+q9rBYK5JE0JmDRmUMkmiUrRX5U0wN/pxMZs0gE76Ii/wNUdvXvqebluqyi4ASYJneQQRtIGOto8043/emkNvs8/sg0ChYVIuNv7TN7OToaBToWAyyb5ScRuYvIx5POVRCBAPU5ZywJ8DwptZnlb2x5dMnlffdnDHTs9BLS5AwyXM45SLU5XbtRyYgR2JWLHE3z3VGxcOHS6smTIxnjlo2CQlfm8qD8r9Cyh15JCrLi7j7U2PhjMsR/kSxhWj6aNF9bRn788AIqn7mCVN5uWjXf5UqUBUSVNpl01Q2QPAaYBXIebxDQ93Sg4A+PIald5mp7yc2B9Fc8cBB1xl+ksYFI852Za2jfc9FSQVrgRnCsgZCCXIBBUTDQnmedTcHCzhQJNZKQ8ho6eNoId0CzWFroqQ+fqh/YSocP/AOkr+Uk1T9Sn6m5WazZKShFS+avpaUPHHZaoG3zqSBWWZfblbbF0IOemgIdRwI0lfDanSRFrlsGKHw+6jV2HHipRgaYIUs2hq7uGP/avj8uvaJr+hPnvDuYW1WS4ZJc0BsGu3ShXqPPxhkK1GzQBcpgXoGu18+m59RdNE00695S91n7pqxaEKJxs/4E4v6K+hb2pq20tgmhITgh57DW1MsJKptVSDKUS9KnKCL3U83ceF0nn+b20vIoogfMcsIIk1ZfR0sW4KAlZRA06uY8Kt7SSNXVqaVm3k2EajtRTiCKkzPY0UqT4bVbHqWNj2E1PRbKwfwPQ2tKPF6xKg6f2omoezQxJ2KgrcdfPRDDzft0TAGXM9pxPfYZ64cMgzh0LTMFV0GPUOHAwdR18GlgelF+YkTCJAL+0blGwxWA/Ye04YdC38MkHobDgbSLxhXQDeoxYiTlFncFY47yAiPcQEKjaZOD23+zkGh1XP6O+kNFtpHwS2z9OsehWFx3cfR31et0zq7TyB+ejtPj8eD0EfIZ/4i0z4/lZ+bYlXKMiygiLkW/D4QUxSZZm0kFF9KIytfpy0N7k542l/8wh4wjt9GhoSBXdfIT9LJZRTi0mUD5hVeQipwJuFCtyK2k57xDZTe+SjXP7kMclsXEUCXp7E1dKc93KfC6CLqTAcjBmG2kHuot6jrrbTC2/TRkip8inf+KCkRXLNZnIE8jFXSeRSoUNSsT6hDa93grhp9Ynfe73SnQQbbAUzUMstuxxYQyOcm4TINM2FJS77Kx5IMOEGLWsZIK4KUQEfqbqc+p9LZt595aALxuTwOF5Fkh/fk6FVDpmLHAq5mRKpYC/bnFOICYSVWqg/RH8iY0xfpkARYqyD2iWSLiREE3gVbTaeKWYeSLPElKnA/m9xmYzyYwk2Z93Zg7B5OP5pCusd6sBNvp9/H3Hr7nofx/UifxJE3sPBK/W9PDOIIxIv6HgkY50luH4TOLya/+HfXNx4I1BHW/j/yvmrsKKf6D/AUPUtlNPVsXBPbnbjiTgv7HSRe/xja/Gwn1gYmXos6A92sw8d9R+Q87U9chQTDYa1DiGsApAXz80RT8XQHJGExXTKKCEKRDL3R0CnQMCfCcrqMwUW5wL/3pVDRoCHXDCWtM+ot1gBEJQWgJlO+lHd9F3DOxeNtPXbsBk3JMS6ZlW6ZVBjBi8IteY8ZQfvcewC1+52bgxFtJ3/TJIzY/vpBgadeRA2/9DHE5FpcNpLQtcagKrR7xoyAo/wrM4wVsP39L1Q/Gm8ucXzmQQpGnQFM/mMsNtHhuNRhIbKUiHHDgVFzei03lszS+8npaOi8mNUar0rCd1nUQLIkd0vgfFILh/Q/KTwADu52W9H6NqKp5SzHxtrFgTo+SP+dXNGD6zPgt7awR6KOngQs2tvp1tHjeIlTYjNe4ykk4BJsG6dMPnPbT1KlsjgOZtQj5jO3U9/A083fsvwWekXaMFB35s/UKe7yxZd2fL1yJCdGl5XhLHw1IedD59RpTRv5gEPOjeeyasPAbFm2aIdXsioW7oa9xEEbe0QWT4jZMiujWxkGRpFnA/PwFBdTrrDFITsCLY7BV1/yB7kZu4K+hC2xfyUEkEi7WIkjpZbO6kdH5CjCZyWAyT2CLdyiWan4q1uH5RkPa2kB9D93bivkRtpiN4k7Q8zQwsXvA/BbGMT8GsmT+MpD7bwG/Ez5/BN1aVD8YV1GKH0bB5UiBukL/Z1ryME6yWzA/LvLRw8uxJf45vn0XukfeGkcD16HoR2TI7uiMvwPz+xAJ8R21DHFLSv8OzG+XWYgZXJTJcT5lfo/FecwvStcT4P/2lwAbhpyGwX4dS0iuAvRrBX37UzfY/hn4niyw3k1q/nI6Gr4Q6S8lyxMXlxu+HKv+GACMi077B4SVHsNGUH5JSSvJNAaLpUIp6MaL83Y/9A7R+lj8cf1k3iewpSubznqtaJDMkAN+bP+guDQmoq+uR8IHkLAeimVp+lTYwhv6UQpo9x9jDk1J5pexu3uAqd2CrelfiBlKqrBk7hc0fuYjYLT/SDldfoFs36TK2hTPhx5aBMxVLabeh8H8UgSV/wapukNo50XIsdLMFSwajHJ/Bbx+TUvn16QoiegEhpo6o5dyglCgnRkgpApDTCdN9HC7xRTgHj3PHkOB3DzS+eQ3WWApUEo/2NkdZS9vf6fm6tLUJ3XD74SUGJqNLRMYgIuAOv15nagXcGMxMhWbV8wAA8E+ekP9TVRV9Qv8JefiLlCxLSqweTXoBvC7cojQUP5ja2pAZypUHqQj6CnxW9ALpOp/Tx8/EZWEWgIV5IP0t4UWzfu2ZXTz98bRsPHsAX3ngua4FN8M/XnyaT8lnwLTdcAAfQZWFwEFq/gHWp7vxxY3uS3priMh6ulfj3axjjEaAupcbB8C0Dj+ORblfZ4aFGhfBnh+UT8KY8K5lf5wkJBX0ou6D4Puz+YU2QhDCpS+Cwr1MCvR303ZzQUNkBKZEbiU/iA9doVUWlDaO6X0F8NBQXJVPt/NF066a/57VLUtFn/cPnmnL9Q2MMG1LApGuTU+DXEEBh8bSNM+p0W/t5FOcdSUKvjUGaBnCLDtT7uNwAZ05kGAwum7gyBUf6DMhyg9qNR/pWUJnYJg5gVNeRSNAF6HIOWua4rzvpwSFGhPBigpJH4AkayfO/MSFkqIesK2LgenrCmlv1h3Yjsq/cFcwwjPrnh0w+LqGQPjTzI5H9/vFASzBnKuf4rBj/tUpOXA1A0nv3ylNpX0FyuidDBnf3CIXteAbaa6n7lRLO24fAJdMrRnafmclzOvD5JjqmDAbIRNRiI58QcjyfIXlB6l+q216IeiZMmt4gzzpBZDiU9n1eRW6S0jpBaCZU7Lw6Yi1HOU/P3qW2bzvp/8FGg/Blh+ey+IRLdgq+WOypAezatlI0fZSn+xisxTV803BReYzkbcklh806eGO7FKXmiaTjRFZvAF9rDFQ0+jon59HePGdcKJza2TXtv55IdX0J4ManVXRBoumb5V9ZJVDj7SD9nX0XjID/VDALpGSIwOgpKNpsgq1X/D6NNCjwdYQsPSFjjcDJXLspX7Rp4PqSXY5gLet5OEAu3HAA2YGkjJ1souSAnmCQZaMmo05RTiwBYSlJPAtndaILeTrkdml32iPqk5p4U3FvM2QwPs/mDhj71g5gF3kIN+6oX7yFLzRW+kOABmGm37/cNkKHItsj/soMiJk0WpjejzIAVz+wDpHZaIR3b1wkFwZ4jNGyzzxRI1bN2VjKDLfLT8QWzh0wnGJpj0FNHRYHeU2pJOyWje4yypp4+gVyIFBWSK+LaNngSfbkLNdMVfGENIf8HOXagnGGC622gDpmRC+q4u2LJteFxjexzFfWS2c3PD/AAxolPn/oOoy4CBtrq/uPrxg08fYNFz2+jnN3ROTDuhf0v6FK1roLDiE1jr4M/HwYTAykHLrDMeS80JgHEZ62FbeCWxaVU6QUjcbRa40xs6L51iZt6oZqN95lHayHoFEinQPh3XqMGCXhuRLtOKRz4q/fHVsryusNBIYfoSX6b5Fx84CJ+/GKeMM+GNJTph2JRCF2yTCAW5m605pD84tCktK4OkiauoaW7zWQqEYfSYokBgSjPGJ8G3I4fW4bChGqZFP6CxM/qmbNGom2EtLmaS0D+jQNeoqUrKzMcSogbXf0TfXUZHTi+zyx6X7vPVQEexGkxwBo27hfWUyQPvDniMtAwKukNSzuxKW5bzvncIChx/Blg2FQpncRtan1pZ7oQ0END8BYWmYwEn2ZPl4UMHWCBfFz48YrCZLkPDoR/CfWQ3zA+QoPsr6NuXugw5HfM9A5USGCbMejRIgrMrnnNotJ2sgR0tjh0paPQ/aFwxVoZ/ognTB8QzFJhFld/em/Jz/gajYxgONO6jxfcdcdwMEXkEdopbKKB+RmNvG24eZrUszJLh2beW0oTKMxHdPP4W/f4AFqn7gdc5RDmzzTzUUooEXuMrS6g77pILfWhLkNBTrkedA4mN5puCWbYZflO896WjUSC9rUI2sPcXXQ4GeI473R8QgXlK9zOHqfySniLx2ptTNM0bGMEgADTcQnf/9ue07PMZwK2YYWcewLx8UpWOOUcEcAJseyqdoqKouY5Wrneqn4wsL6fI1rGi+UCe/1mFj+YtpPG33Qdd4N/C8UEe+WAUPXb6djAf5vp8T/BKfH4HffAQ7gq/YAWqVdrHj22kcbf9GJLcfbir+9+wN3wGjOtruEcL4Xhdo1rqRQExGdJeMW6Y3Akvzs0HLNqhZyhSNIJ8Pjh99XWn8UNeIzVot1mHJrpBJJ+MTcHVwO0+xH3ZXLf+JlbR6ykvMhNM9x0wSIj/Gm6U9F5GS59ucdDSXML71nEocHwZILsMUmI2Fl/NFQnMKSb39hw5qg7asn64HJoxOAO6OlzfurGf7FK9mQ9mkty/Tw84rIFz8zbB9q+zoRK8paQDiKVADca5If/tMNp+19JoOx24qfIqH+7x6p9CNxt/vS1V/mTxgnCYIPOSJbWIU9Tv4O9oaxeccCtecKpwSXs3dHcwghTdwbxCYDT3Ur8+j+AxK2enWi2A07KH36Txs46CeHeAGd0DyW4/+f1gRPDbR6Iz2DO37zncMIkX89kF16U3/ysdlpuBw/eAAwywtT0oz3gVo0w94v+PcnwvtqyO8nLeprrwk0ibgTvEF+EwBfhjS+zvfAfyeQwwjlgd78fxZYD5XS7AADzX9QED80+98cXCgYO+xlbxXpA1Y4bKW1TN5+8fCdf/F7ZcpZAaXPaSFqFQ469zOncpNyLGjSxlZhp002hbToYh3ATAeC9TOI7KDczZTJsOTaeIb6Oj/MkyGcF5FGiwY4DwcmU6CniGJt7+Dg4ucHtDDQI4OOzBCawBZ6tL523Fg0eZh6VzF1H51BoSxaNx53gkmBl8EsoGMOfVVN/wKX362MGkwN96Evo8up8mzvwLFCxjoMvoCwYNRqlvguuuZVT92M5W5Vj3OPWHP6YtDRVIOw3NgH8zsYp67d7SKq8X0eEoYL1dySa67EVEdX4OEtZVrraYJsa4mXC09rLvPvXMuv1bdi7B9bZB7HIuowD3WeG6OvXZk4+J2m3bwEpdqEUFyirja/p2ZfnFz742Fqz0RWzP8yARZIQaF9ICcH8Xql+QI3vf/PoVAvZqp3iYeHsPMLWNIPQ9YJRzT3FqeM13SQEXsz3NmkNdIMXAySR2FO4ChD2l3qNAxSfPnyV2a8J4UvP5MgYqwbT2fvOV4Zr5caMEPDoL9TgdqDnUJ9hjka7ri4Tmd9VcduOlNP/ldfomSCRegFIVSyDfU3Z7UuXR0qOAe4WXMxqy+YDPmA0GkYvB66xMslym9KfqMP7xItnsqH5I+J40wo3boXhOVsImDg+9NdSrHTU1PKls8toks/Rn6JvxaPoznPOxyaJBRvQ5iMZVOxNxGwDJk02jbc0Pp6zBShhtu+Omyas4wWI1+PyDfaCSB04wxD10OyAFjo8E2K12NE7PpkC/45IELP0Zi6n/wQ9igN67omSdEuKPsLtLm4PxmyH713xrHNm2BZ4CM2GgMSzMT7yqpp7BLYQtsVhVGHxLb2xcwW+UuAl8dQ879WsLtmyMN9p2A/REKsueeWJ/KoLDCUjaEbn+RGqCh2vHpEDbM0A2HDW027BqF7qSsliIEgoKZnoISvS4S+uQsh4Fk9ibnhQoKBJuUNtq4CPT0DMX0bhfTX+pajtOCB9v2c3Vk3vUgsnOwd3ekFspUPoCxcIXnFFRdcxou2VFJ/v3TvUXUUHjDeaflHdC1F5IXetXn+zN9trX9hRoewboM86E+PId18bFfNBrGDVws/5WIlkWXtbzK6gWn+c7t06D9Ek6uH6DcXjjBolrG06LpcgHGzZFf6IP5qxJzBCo3f8KHj76SvjcSZh8z1lJMS0y9rRBiXWc9L+FHwbqvpuhsZmOhWQt1Cn/TNET25O+6V4D25YCbcwAYUFPxLZe3cC9Mm+JKZ8pPOohH27tZh1gYargMyLzlIocRB4H9cDzZyhMWyH94dlMO9Nda3gmbsY+2IHNT5bxzWnD92N//TB8EOKY2sycLJttHJvTyECgp1/Jv8ZW20kjbWGeMBnEgfth2HwzFtGbKSc0kxY98tkJg7uHaIemQNtOpHGdB2PVvj4r0p9SX0H1k/JGRPHVfVdQKPy69NtLc7ipQYe2bDIOrV0jYQToroPYJtEwXqIlc1rcDogHKXX5Zz3UuIY9HLgJCp6uIQX+oOKFjf3cwDmOZTG+qo79ubAwZyPlRXM3w43+Btji4VDJCx4FskMBl7PfCgkMfLHlZmwv2e+fVUbrtKjQxG6OHsZ7DftTZV4AE5RJr22Zo+k6risJ3DhJfSaicPtje80K+CYOSVx9SgXSPp5xM3BzQhqwR0vtEund75TsOv+VbY/7Nd8v4YIrYy5ous33B/obvuANaN+9LPnaI3lcckQfKw9qeC4zkI+Fih+3D+B1qlzYEEcJLGfBRChcB08wYbwZUg9vObVUd7QW19HYR6CL7UGq9pm7j1SJLeL3oBcrUH9VNnAArKlpCBWuX45j3DGeuqcxDri91dxWq/YKeNTRqNopXBNmhoa4Lboi+jWNNnG9jGPmdHQx+1shHh9x3vo+FA7eZEnm+BIpfvF40tdAfrB9r6Fn7eEle3M7vycCwWtgGpMUHkthBzdvNvZ/+xV0fxnzoihslv6U/gb1nfIJffxo0vpikQElntXDjbOF5huYkYOEGCDzihxNv+QPW554m2h7LLpdPofizeRCgg89rSeusg2Frvd0EGQIxNRSSP5w5RXJx+n6MSKzCYCvjvx0EGZM27DwrKdO/m9owu2rKWzspJzIblr8iHPHB1YNNp/HzBtnlaU5DdoZ2roNN0++bo7L8Fv5D7uQqnVor4kbQ1t/uJS23h93oJdWzWXTh5KffSumw3vQLfK0vXgh79OUdQ2/M5/qjHE0QXfIzEFDOXgNfTR/U0qYThPKbx+NOdXVUXZVLCjYuBFPdLXSvTsqj0xtxQAF7rDegAkxwNWtD24FGxcrGBcvnb/LrlELpg0Pnf/6ljkwErsY5ZLfwMA83LlyhYrUN7iX/hSu1yt9Li2YZivivnN16eaKl7Y/gzv5PwEDxMqVWTBftvMFhobz+BUz+l1mUFyWGj29M86k+oKZwbjdfxGEiXFgan3wBzvFY00zZZJEwQRpsZabSfx+SGQbBXzLKKy9B8cFH1Fd3Rb64hl3Nn6q00BIoU+iMvsJLGFUHcFD7ET/4JIqaMrBkWDsTzsyKVWQhruHK2gr7k9nFCDh+rSfoJ3wXemoxmgt/DaDYXxOfaZeTVvjrSma0OgZyqda9V9Y2AY4stwQoKEunkD5H+HPSrJsqiLplyF3F5Je91ssmkMx5xMHT0IRJEsYwzcE/h4JHYwBjp1eAuY3PQHj9H/y+GXj4gjeqXAYSo70Wbg7d9vHmj94Id+iaBlY+qvdsdPY+/WXuHeqtUzK4DvWDhV+n/r3X+TQZScZOfrjIhKegbpLXakFeLz7aGbFy6v/UH310L0ZIJ9ZETZoL2ociLovh0SOR8IJj53gl/kMCMa9Ey868cOaDZr7o2B/wANDFzXUKX8BjZ/xGu1S6+MeLk8HY6EDrurZzG2tCjOPNGCilYXATlWJXziMb2RryLwKKDhXAJ6ZhnMLSsC4LwHt4XnGrr4WlZhZxUTqlz8UzDe5FPgu3j6eUAnPNvJfME5jS1YLIIlfAVTQdVRx569wSNn6vnRi9lS/ux45Dyd95RhX9pMTtvC4Evkt5fneSwXOSTz3fvaD1Hgwn+loQljXHjUuroEC3GFYME3Ua7AVxDqHPXB83/Gb3zs/XaHCtbXY/sanOQQfzWYWxQA2aA48lsRzWQtAH1zad43S1QLpT99ouyVY8w1hLTCKRP6VLePb9Ds7Cu1eNwXupH4DdeevMPHKwTjAaFj4zXzRN8syDMXvD8txAHUfUfABKgleRWfPwPY60yCYI6OwzR9fzUz5GHy6dbM5lE19TfhIHOvjbZJMQ1jAY7YsidLfaZ2cD+2VWi5FApdYVh3QHgPsHdhJIZsNfHMMaP2oofEyS5iWiZBoJXaNpqcoHk82dfKdWqEedcVwUUv2GSBPFAGvygnMx7LtyRKjhN+RaFycLGtiXKMefAMu4FbG3cDAVYqj+/Yau1Z9lgXpjxco42Pqqb2bWLfdb5+U841QCGYz9otcSlg8ydAKGFjPGv/amuxILykrQ8L4yj4kcm7Dm52/x7i8zGRWTqQ9K5jJ0kyYfM9XXYi/h7A1voPKbumXLOspHgcaiSn4y3AV5/GjT4l3RptAUbZpVepPjuexaUwmbqAhUyAFZxDG4YlcQ13iyGKEd4Yqspn80rx2mkFtTUWyzwBF8AroDs5yL/2Zq2lS4+Im7FN8Wfyd7kfAXuYKqYVjHchjZefnn6nQwUPupT+WLhVOfl+eyyeYaYV3lpesUkbkpXSMtpNVwLpAmPCMy1OF1it5ssLpxJXN6oeJBiej9HNMiJ7u+9VB5aZESLyQ/jsFcn6Kg5IBDkqdOlnG/Q2c9qoLHDGLZFQxr6SKs0lEBiVLbopTxiPYZ+5zJMuYMOW51L10WFP5dL4Ifs7UB7UFS3+2ARxcPmuaRtlmtc6QXQZYfktvsOZ/wZ87uLywKWMtOuh+a/RTpxp5/gWQtN7ltzlY93dk23Zjx7Kl7k9+WT1hRN6EXvKl1LVbpFQJuAkM34eDkM14lMkio01SVO/jg/H3v058c2cPm9yZJY+vLMObKY9iu3sXJhsOOBwNzszqalUKdfG22OD3mY3HIYXiwMULUQo0XAbzsgGZ9wfzD19n6Om/Z0nRZfM/Ryc8ZO5KLTNyIkuVeEtHF7iqWJXe/DffYWFHyQ7Glyn9qa/hSTwrB4DpIWpHBD34V9ja4SEMBw2xgsXu0YmehWnJJqtsVml8DxfSynysXg28T9j52QoVOnqEN45WxazTzKLwRiNxI6UmfekvBvySawauMYzQn4Ub34MAxm+awORneCAUviYGO2ufUcnvp6DfZHNwmzqZrEF3CIiHAU8sOh///Ru2bIMdFjyZs2GzKfGshFv1FeaowGGW+QxsKnLBzjSsPYVT461gbqkyNcezhzKBFxUnbunbHOngmwhWoE1DsOA5yMwDwngKJlNZMQHLHgOciJe8hJpurtpOmpEqT1T620K6D/t7l4a+nfLfEfAwXLd/P+356ksYZrvQu5n4cnl4o5H6+6nQdxJfJYQhlXwcrq52YpvupEjyPDzeIJkpqc0475WDXZJnyiC2YnoO7tveBehwXotpki7z4z7kldr84++xP47D97QCGskTQ+K1Nz+coPKzCqdyGF+JeWac72D7ay2FRJnVKOrSMMSSnIMOQBdIzzs7LmCmChvQCDw/OQ0VVdgGqRswLrDDQD9bBZM3qI1o+x+tsqWTlj0GqOdcBQYD9+M2jbDFjlEy/kRXlWRs2xOronpyl4NKE4/sWLlCbzyEpyDcSH8MVKhG0o152TDYVZ16r8LDRy/BMDqGbkafLAXCIWyZTzvq4gQuoeoG/6UYyNMRaz8oWxY1GR0ilIAphPgY9HoRY/pZ80+IF8BKP8L3HWaRtBghxpRhnhL/gDoVXtWyylPuu1Aw8PZB1WTB3wTsUwnGWZY05nkq8UKjMdmShvx8ATv5FcYea3jHoAiov5S6vtWLfKkqqd90OsZKBaTMVDma43lBJTC/K/ttbI509y07DHDk97uASLcCufQmTCLuZoepXRjsT1BVlQOKJAJo/furZ57euPOzlTgyd8n9zDu/6hMKBt9uXUv6MdWTRUTXfI9AF7jfzYlw1F5UBkmXlee+uAfvGbsMZbPwAhrdA2YF+7I0usAcnLiZosQfYKD6C+hvfwYYVdDV/AzwqqAbqsKc5e8/x4B/EpNps6MJ1dQcc2HFOJP3RJ+tbEo4tb4oc/ubetXkflBiK5jQfNDaugNZGOfTZH4u1CpE5OdY+F9zJAWyZKnh1UepRluBbE7z4/BD4uaH2b/N0YnfmDcYxg68F/1UtngDV2Hd8EQkUv3Oz78ElCzLivSn9Bcpr9+qVFWlF18ld371Be4GQ8xyyf/QQbi1gFMxfkM2S6FAHPm0Ts97A4+nf99wcV9a8auPmq/cJ0MVQO1lV+j5dAxI7VwHW6zmanhwCvoETO5x8kfeJn+/dVRdlfx+1lTYe23r8jbgw9QFnm3IwCNZNoM/VpNps6eVUcCYiqj/jUWfMp8saBDoZkkvZoDhb8DY3sCXA/jsmjI/S11KjKWjg/rhfvD6lHSsmRumcyvn49GwawGvKCU8EwD6UmidSDOuw88l+EvdueNx84PqrzOFk9S5jqGFdlHkeRpw+BtafiwqCx8M1V2ogLdepSoxAXKs2mpbiSn9GfuRD8aNKSaPLZCEDOUbT8dpFyaLCTwhMY2fpu7Q+AKPqL+SRinbrK9fcVojJGe48dIPYxDY5k+VwZQCJa7+GbIST2jmpcpnG29OMNhwCgo47ksmrZLY7kLK6186F+qB1Zb9x1uqj+auo5zej+KWwc+A0/vOu4dnCYyvhZxBo6BzPtVCft5ZaPtASwaE7sAhXQ31O7QDzG21tdQGekpIX8I3yZaURsEn2BHA7tXBODUZtLqaRt1ubciuHZ2A9gy3XWzN6av2YXw/duxFQVt0nWZw0BobUHWNeOpSTrRthA2YY4R9nYpzV9pmdZYBdx5930dWnEhZ7wTswZl7wcfoo4d22+dNL0ehkkvh6+89NtdxE6K6QK2iSJOZm4vk50/C6j3GcV/ywBRiHWzF/gNM7dV0bsWYTHLpvLcxSbFVxjOSThcAsyswafJysOs41YLC6S/UHRZCFcY6bpiIZSajkLTUdnHh02RpXGFrurIETht0MQ91481lG7qbfaQNoJzwBRY5JR6+h/QnHAhOYFNCf40G9P7MAl5GSe4YYNmsPDSA3d3nW3eKDW5RDn/INFt5/YFGm9zOksdVDgDVbnSW2SKXOTEVthQ+W280FlBSJr18dWkd9CvQ1+gYWJl3h4LuRUlZqBt6ZcWjGzCo0g2w3VJqKga3zQQ7BpcngZCNWFt+B2njzXRra8q/dG412v4b/Eb77WbWsVLm/WNjmuVNhqYKTpIvo27Ox2JxsaVelumnYxelG1+ZrVb6YuS33lxyssLd4HM397SlVFBfhMVxMZR8tlkxjlhSx5XYFG7JxleWYvfDt4qsYUV5w2GMkUfSWmCtoTalZj7jGESOgfuoWoWjE5ymKpN9ARqGsQSPci9NlppRnBCsXB1kOWCcAOYOYHf3Sx7Kit1RsipzffUfGBF9hdvbIXjkhE+EL6Ue/jOS1WMZF50AafQlJoHCdcBA+GmX2xK2NVuAiVDtaHvFjYjeOphIEg+XnyqhIO9MrDhnWDMMzCOhVsMMZZdJlojvU/QR1CtWRAIDEqIXhRzsHNhdmSTY1sIawhIm6jP7SFXQuBLoF5MFAUsDrbf9/ESb+BnccGBZMihu49wxQB16P6GcSQxWmDIx+cGjgm8dOxawAmemKdUJneSufSYgZoBw3slssI0C7H1YF9hgO6hs6ufFFH+5EfKhT9IMIRxiCdnLeTPh2FSpefTho3vSrKl19pq5h7DFmYu6G1onJosxJ21X6K8mJks9KePCOjMM650WL9ZCLoeRftikQUFoG8bUauuFxaSlhvE3BWXs2BpyGO9AwlxhLwUyXA1eoRoub9UfA6bztnca4q1FSRMbvngApuvi4kGr+ltEuGMQRugLcPrlaGgLkBl8NVcLbTzVDh6ZQenkRZR4FeqQnY63VcmhIBb6Q6ldS+Uzi1NmcZlQavjLcC3ubFeOUoGD9OFQ39AX5QQC36SNkibPw+Rx1pGmVGysp4Ce+dY3EUGVXw1pYBVwSExJ/psvd0s5KXniSRbLDgYkS0xgKlbB1IOoj5qy8PMBhoAe0IamvHIKeQHxHWO7sARe2TWWAh14YRXIpeDmjA3rW4YecgQqnBCVElsmJH7n4agvgR+5DxJTsvXbhjI21Sx7AiczfGEa0oCrgA6QEMM1cYutMtZpPfm9vwSRX7Re/RwAYx2JkGVQAF/mIHfaWSoWKrxQ4r8VTLYbP4KecTCZErYm0Ce+c0nxofTgQE9jqHPQj86KmQueeDcr0l+sxqUP8FbtzbQWLMMow80QnFif5KGkxxC0cLQlw2Bpibe7YZXg408tsd1mmgxQ9CfROMYRJQ16BbhgsbJZL83xDDObBjEsDq6g72HxKrIdb+x0xMBjYzw22ii4Y4CMVI56FQT+zJYYdg2IdsJ1VL79dLusjtLZlEZEHgWR4c3CXrJPDZOZAm/zqZLY1XqWg3F400gIXleRntxszml1AqfIeDRpeZ7U0zfUPs9fCOZzmuUEa4mIqViPLGwZlZ3vYiG21c4IwZNLqQFU2NXa1CI7iLUvlLBvMhZyG4ZhTuU1VKhvjUPWj+2qIid6wAAOQ3gbbB+WwmGq0J9ARpsVG3NHaLAbxA4qFsb9DYyetWtYV2MZmLkqYyVeA8zeLiNJhe4ZIOuA2GW9cOkgzjw6F70hwdwEPN1wrOZm9u2/Evq715wKNs0FE76xFCg12CzlVSSkuPuJ5y2lFrgFdtoleJzdBSyTXGFDqEdevap/+obakTycAPLTpQ6CWZVxFL4BP3eQO70sfpjDGAaMdx0OS8mTq7FPepWcYLn5lkbU+YE14kwzA2Yvia/mGUWbkbDWfifEzMq4kM7FOy9OQiAHB1fsscluqpo88mriZxQ4GKEKtOc0ewaILbZhPEa85W7D4HCk2WAQVn8BsjAVcQsOzjAlnCqaJiw2dTpJhrfmvB7dnvXn4FzAbsWxhGeuVnlYkiphgAtFdHZCxVs7TscNvev4zV83wXT8Gol8bgj5SkZwhIJJghN7LIaOAa/UDsrzZ/9UvI72AvwW+0nFePCEhV90fovkZA51Q/pCuMCbK3bCFlZpJRa1IgXb7ykH9oAMX8CTk4H7/E7CBw9uwTh4BoXMyZGyCMOV8kwK+McjPx9LXo+8MHq1KMZ8RMGUh2+FtXFwy7Gi6K2EaxrBD8uwG3IXwWRSYhDAMJGyEs6pvCu323CoINzo10xMuGmygoJ5E8yfLv/D7Q08HEU/gGTZBw5SM4cGfoRRpRvwmffhFb0yO5GNwNGpU+/CPDgFXnWrfvBo5kinKGmeXuKOcDpB4dnVkzvgoEfifrYFw4guSodJC9ckJYWmFqG8FYAoPxICz5jCK7PTEBDPoiAWLBs2omC8LXGNbmLlYDDAC1hUtQ7gI4Z6ipY/ttM6n/tUG8zTqCBH+yMatsGWGLYgwRhIuwmieKltVpsMV+NamD8YuKW0bJzPn5eHq+HWY8ASXJQ5F8D2rJKm4HEgl+GCl3cNIJ+8wXIldFCH0Pw4+A19G1LGXxxkT55F80EvY7eViRVFPoN245cLYsZgJflk6TIdXKQB3E/SUFUlIWBBL2dzkd1Mhv3fLkjPyYKhL4dEhYMEmz7mHpV0KZX/MDcZmFZxix7G1tr4sy1cwg5HqYtgqX8nYFg/GmVKf2odntR9rlV9bRCRPQZY/dAmSFl/AI7uJgYzGgmDz7D4K7ftrRNiPDpncmHPntTltKFggO62mubKJbRLaW9tmVvcpNSn4fBjMD/SnnHAeIbghqvEkaeWXN13W8ZwyEjPx56kttPLSEpPh6nImc4qc+K0X8mXt5egh8+DKYgNDuY0/ijlK3r7CjYDwNfYitrAYUYlRpJ+yOlBJCQ13+OYF7ssmWBUeOA7zLc4YA/wQKn/kVb+H+Pc5sGOIukgoEiGnkYDYXzpEqzCEZCQ02lS5q+CTXltTRDbwkolZKFAx5eOgXf3nBzoSVzw52hHFsMpwgw317AueWtPKR40ugmrMlhY5viwS32c/G7wS8ULT+ZBKRgQphEMGKe2VdDx2l5aAdu2kzUE1AQwrV62YxZLIFbChSnJsJavl7J+EMPNKvBQlBK7HN+FVtni0vJW4+BKvWLPXPlqHHumiSsd/8PkG8w/dPARy5zx5Vz8csmpEmr+ePBqrCB/siV0QrFWP/lAWYhRsB+6slWaw4gGVTAaD0dfzk9IGrpBRX37yqLBQxROmR1CSJUN5RVdQ0E1PFUOu/hwOPRdGC2f6Ur6QyV46wQGKfof3rmy3wa7Oq3TbRTZiYWldKG0TASW8BveshNirH9Km9sE1qU7cCpUQQbx9tfG2I6Zmr4fTHKFZWMM4wMsuHaiZJTtKLwY59S+sro6Av3eo4ANyd2OwVpxP2DPJ8oKB6pLBnxr2ZYsJmaXAVIVKy8ftxWJHTUALrKlvJUq7okenzsqE83ExsWGitwK85Li6LZXQWgLUunZ55AWwJu8bqVAicevdfXXxL7t0gyTXtsBuzU5HSigrM2AsIDNDz0Z4dB2iN1PYeBkDojrSLe8YocJbRT4ZDedYMD4+2QM5ZVdMI8qwFisW8fbWkVfUO5a6wMDnx8MEjaxdkzKPKCAR6BOxf2tK26RujfvE8B+24EU2KJQ4lduB3ud1sE/wEeOU8gyAwTW+Wu+BBN82R0xuPVYrKQcS/W1F6dLC1G7bbiUvu9ge9hUlB2Odh40UBQOGOBeCjQHJV7UWt/ltKYKHH7B7J4ifdpZBlzZuwl8aw3r5Z8/qFvkfrXEC03p4WK0od4Nd7jTC62347oPHsBdrC7p1d82uSNyDET8/rYM0GRoOOVlScwqBL+Bp3X4tLTTA7JwIAhb1cgFVuDi0niLrSQ8Gqkj9gw2rmTzD/Mgx3iVwv4vmiPb/lv2GSB3hA/X45SCohxTNNPAMo2CbZpStxE7XXUYqmBcbAjjryEhxRsXo2P9wRzRa/QYPECvQQp0CDBZNh4kUvQlTb+JkUyWJVlcxfMbOhuGUQm64NpG5giwThODeXfECD1O06bZb2uSIdMyTsJzcDpBCUgnbRSUSu9UV4iDrTAR9SH0LwjssGvYJKmjBWn6/gtYowW0lYGnAS30fzEA5lZVVjujCeBK3ApJZ4dTX78YyCyyZbAxfOI+UZ+hDuLa2yNNjhzi0tvuBwSSNgi781dQccObpMkb3Z28mlLguVQbngQsX3eC6dsvbT8t4A98TyXR9bEusPi0oaKgtC8d2rwR1jZp72CbUTANPMX1NO62+Xh+ZkNzgsU3n/9izRcYaz5qbpHNLomdp0ZC9a9onfpn5zaG0PbaSxrHsDLbDVMGNtHI0rstLdrL1+fTs+tTik1y4oPPB4kEimTleDttw2jiwaf8JdhbtWPNBpTTLbYoLYHybYyIje+/WH4FFYACzcpnXh6LSv6Jp2Z1HHZJnVdeG4bPem44K9hcxH2xNTm8hNjPnzxK42+dD9CT8ZcDAAkZLH6aC3rkXcqDuc5xDm3DAFkkLp8JkVjiEEMUpkWMlgQwu0rmo9Nug21SNbFVu1XASu57dev3SQb68TsZrQImbyAvV5SUlemHt26WEMJ4wmUWWIITEoadOrv1udcOSMXC3Z3EUdgQ8tMBLqU/Q9cPSF0+shAPK9nV6yhdRbbjeRisNg5nr6JSen0fS+WwLctimHJ3gPbX93HOjDGZlQ7cE4KgMKQJHgDOdJVSZekkWQIOb6pASqvAY07BDN4XSKG/hMdrIU6HWGQFBd2FMahUAAv5D8GwbCoFKI06QSCxH/HRsY3rkepclPqjNRItUiO+d7D7g3coeOlxPMaBjsIrdpLmtbrG1wJ0W33N/hY4hmlIW4JHTN7PTCSOAeFPDAIp8YBO3diWscm+V7yws7+Q/hutJpDCnOk+9AyR36tXFuwCwc4MebMjo+26yHnCp52XatFP1p5kcVHD58jbOf46KJ6zFHR+zc0pMzMnJd6mre+dpdqbweyvZ8cGgOtEeuCJA+lHBLY0A4h9C/FCCQ/Tsd92nyI7Ok1FRXY1NaULaiBfcWv9JWcIG5eBAebaksEkk4ATA8LcgMmM3Z8yRjTVb/fF1LPwKXQa6gHTryPUXwTm7pT4rPtjz9WHDy+yQ6kt0tuOAZoODOU8dA462fFIbN1GcyXhl6ggPU2tst6q+I3rpCaHWN2tVZACg/kFsudZozHGbIdYa3xaxvB2UIPRdkR+t2V04vfy57bkohl4OgAOLblMhoHHJFxmHQE555kPKmUIp1UxXy22wLC/srlwYJbjSScglRONagXHdYQxDIsd+toJA2Q8cCMlt7G1BNiYW4tU/rMP3B9KdU9L35USqoDU5GSsm3kOUsPBhlagzFsY8tK0RqbZBm6H3Z9DujJSJiyahCdInTnJiDWkkb1DKQdOErgAMz+Iy0o+QasWOOuvWD1Z+mw7BsgIavpCbAeWOJpYlg3ijtWm0MZtZ6XKNumNjb0wMW8x79jajB72u9dj2EjK7daDDxNSgXQWz0bbpCyNtnPztbE4+b3Ire6PX/eEzvv9A/u0j5wh5zDXkgX12IJ85WzyAiYbrBrqAofQnWdT8nwAd6aYZb2REl9T9YDW2/Ca0gYMAZhUOB3eMGvak+9eClTGIEeNNe3dwLxjnpvjCh0dgvky0nYbHVemDX4wAxSyHwXxxm86YSW8Qwla75z2OMTR9GXpVJHNvE5HSGZ18hsC7DZdCeg6nKyMKaqJSgTd4CRhBlVUJdVbyojvWjCIYU6Mi00psKhIlpw12sBESWNZTIKfabStnZXKaHvqc6sCOk5+hekXLXNmy74KgGo9ND3zPr+l59EkmLiLUvyGq8M+MieHqKDz7sjeaTCf9AtW/DttBuNqLE1uMwY7MiE2OYPEfQJXYI38eqCLwONSE0NNyckWDHBXlBw/pV8M5lHgnA62lWWega8aGRLb4DSDIue6aSiioE5xZxOWJnots7ctA+Sa5OEXsX2Fp1+3VWGgSu1matzEitm4cPHL2/tJIX4EyY6lsbi0VD9YCiw9Z5zs1LsUQri9/jgVnGPxbLT9L3D9jS1QfNhdVHwRjLC/ZyQ7lInPavlLwpBbhcMvbvHVvWGZMdNEFYTfRLxP7IQJMgOU8nQKRa7PtLpW5RrCV2CMjHEm+TADMaDnEy+1ghOLEHCm6agtKCD58EJzJ9E2bhyCg5fRps46hoPVpyDglxDKpwIPvGTobAgnFG6Dn+biTvDicju2Sm0YjAA6tH2CW65kjzVvr4R8CGPRpRSIqoTAKZa8PVFfE9HUjdIX7AezAnt8YjkgVQY7dRI9zy5zKwPyZGTmPIiO+qbFwPMnS38ybNwOvPMc67VaAjj2nXV/uNJXhwOcuWv5MfW2CEd3bwSOK8AMnEGP3mSZmRUp8FL2sahmoWLYRzqonhdTRasosuvrlLkN+Rn6xQk0wML8Y0knHbu3xIp1eYk5Ph3VCKt8Kb5MBEHhQrz6xu7jXS/IrUBnFME7LylLKRSakFH5E6CQw9HusiV1DR9A1/ahaymQVySSl9PWwiZvLBWvbuiJ8TIdd2LTbguMkqlk2AiZV9JDd31HWBFsrMSMlo8n7exUWI47eBe6lv740XQVeSfUqD522ROpi69awCd3CxxJTSYUUwocReHwramBOkw5GLwBEthExxOf5QVhvEA1L9elrEHT+EbSPoyXlFmaE8yFcyJt6wwJNIMw/m48KSB+gJIOJBngo+t7gNs3rWqSGm9/cVDWKiVJBOCwujTTPyeomrWiAh/07ydpcDI63DedjSSVMRc0T0NES1ItDwwpO0NrUBldtjlPzve0YM6QltfekpRMHgUGGCwoED1xO8Tx1iU5JMSCOQsxHLhdy1mmPqc0X0TOhsfnTm6kP140YDoTioTV3CXT+rJ5R9sFv3gFjHarI6ZhTlLYoEnxt1Q+44KMkTrvDn6O85/Qn/ZmH2YlGLKG2ouvf7Gsk69+SbxV4/RkmzCudPr7Vi+YWVZyLFHUT4cHFWfbXxMf8SktPcRtaA5ls/y4B+uQ0TDzUzi0MtBf5qkrn7w6/+NyQu0CkOb6U31jKVCpyfB+5NzEJxWsDhif9EChTfDUD79FoghGklo5dE2ZV8EdIsS1NOaW+695Rm09vG77TMOIZNwOdpRbMmKU2FHzCdXvx+09JxMmGfbMEARfcRNgzkOe3pu3YwReKb8cD54ny+04Tvqhhw6FF+fm+KodF8o046ID22hc0bNQ5v8TGLl9MCcHrgQK/700vvIeWjovPQl14u0jIEH+CkTHGxFOKgRK3D965CWKaGstEeSrX+OG4DaSuMgyXyzRtCOG4X6D/+9w0PY/xI9qOQkTbr0GHf/3wB9KWicFmOmot4gWxA+MXDWQwg51oCYI9b8Ya9WA5aTS+DzmWKV/hjAxw/6mFveLGIT9DUsJC+MBnfi/MmYcaTe9ZsEhmnDrXGx1xqNs5pKneQKpdcPbBTc1bD3wleYLDtfD2L1lGPgwJLdLsSwaMHBL/d49fbGSZwiJi2FMa9oYbfz5V/nygufrYdVF6S5UdnzyqysdHqIeeuuy0uyf/LZqKSalH9eZdPl9dBEMkh0wJcEKNJhKCPG/NGH2vRQe8zLVzLY+1WNd27Yul0Pt8CPUg8emDBg4tkImSQSGjSJsa32/p5o51nVwaaG/iv9+gr/OtozCZArs5EG7hxq2daHzZ8+nD+asSYJENGp8ZQkk1+vx4w5ISP1t4ZulQCojchBMvPVBVki/EGOvELBSVhlNAAxlHIJK6R1a/sh6m8ypk8dVvg1azkid4VgKoyMl3I6HWTpdaJv/BMvgZran39Rw/StgEJ/jwGC0KykQx23kEzcf3LrpQKdefWAcbTdoUqMqNObFancgL/BvGNC/cTRZUoFjNJQe1PILftp4pK6n5gdqLgLf+YW35+WHA3lvugCTXtHF69dBcnoQffRLR2TlNgucviswQanuJf/yi2n87FdgoLyCaMDeJklq6nMa7fywmEL1o2mrvAK8dQq2YYNBMBg3OkSRpT9Df4SOHvrcUYna2rWU3/kd3Em/zl7SAUSzLXpPMMFKatAnQarlC/7wTiJ2wg61lvwqB/dpuyPuTOQG44a9nqFjoXAY+ICJGVdYJEivVXB9vw30QAPtJGGGoetfwxPzFoe1Js+mqZib/MJow5NnM2PNcS0vpqtn5dHLc1PrXS1AdNSk48sAa57dG70jLB5wRRBzlVS9d335ZWmnns7HX7I6pRYkvbH+pTq/+AvuSl6G1c6lAwdF4bq6kQc2rNO6n3Gm7XhOhpMZx9Ifv2KitDk1aT90nhKqgwRsHY8OeIQKxKVQV1zgaKEyGYeCFKeGgFH0gHx/IdX7MUG3bqEJtx00K938JnRI2C5LXx9wARitG5DKEJwyP1b2G1RDjZEHcWvAmcjP+cZPn0sqwHfScx1VFmWCXcHc2BszOpAO4TteVsPJrQ6FrBC4X6wK0TPA38DplNPAkptqwH9zqebheOl17O7eSHOuGpK0mJbNjYfhFI1Yvj3bt1Bxn9Vo41j7PsbOhp+p2KHzVbp2M1qOoZ7NTxZ/jm+Q8PiqjNVYZd3VC9Ft9xefaw0H92PhzKwZUfOS0GFJ8uG99808QnpgLgY2DhowWDMOYFyRiA86RWHe+wUjyyRIvvURCa+ivMgrmZR3VWYVXuMSkf8HGNsc9xMzjijzwDZOHwrpbjLoOA0MY0b0T+Pvk9EoXhU6m3k5v6Ng9i8ODfR/p08f2+SoSCxTJAApjp7HRI/F2H+aeDFD19kp6QATZ+J7tPow4D4YzKo72gfx3HEDwEAw3hUOHyKS8YkPvsZJSIcPPgfwWGmt6MN4ABn8Wvs67lHTR46GOqMlYCvpE5dkUFOHLpLGqMhSOxY/sgMd+IQLLWAUEWBev38f7fwCO+p0BneLZsB2EGNOf22zVvuZGe3ftxQD+210dotcGXzFtvrA+rV0cNNG7L4yhcXCBs2rnlyKid8O4XDtEkhp/w56HMHsdY4AT5boHzy2Kr77DGbH0h4/vHRsu+tgnjdXiLolS2CRX5A8tPAY9OZku298Jz2i/wodvck0GbHL3zLdbAf+Mz+R0PT7WFzLvJbf0QZlbIfm5j5cf2u9hdTpSnS2AyLzYmrsBxNtbURtWX+KRKE+AF24VfbBbLu43PY+vj2kDpXDAdGzji8s5tTTGBAb05pYrdDgwaBo16crqeEI/AOky2gw3nQ9VK8ZLYyL2WjbEHMBF1sshp9pENhWN9COlTXQ8zs4SEioRuKpS2WEvvVFIn9KSDp+P3n7aNT9CVLQz0EKHMBkMFTMSQOUW36m1QLUya8nK3Uf1QWeIO6fTEKndV9g+/ozIILyGbQjkzqbymAcSVwCUPovMbY+bYqOfZl0d3es4OchPRaT+pPHuEFfUsG321NnSiOlUdWAJgecjXXgJ9RZtHnTkDRq6PBZj/doiBLko754Vd541jRpcEMiDIi6Pbtoz6ov05YCNb8fg0l/t64uwbi4ob46K0bb2PLs+/Zbqt0OJytamtt9DQzUMJ54+5q+O9yQx3XZpU8fxv27R8GAfgpGtC9tCcoNAqaBr0D9qorq6h+kL36PiZphML0h1/4ZEu1/mQz1uDFBTC8J+xpd/YYa9WeSOj9oqMNhCm5bOBTEQAF79/dOyVSEp1SV8ZUj9YApJ2oFJHwXOdAT2VwAAAzSSURBVAV/IuRrHwZIVXBCIB+Dvm2nuxWZD80U7fi0hkJ1dc52EdwrfMAQ0UNCyYdaGRez0baEFOjWaBt1RI7W0vYVn5gCkNPBYHp8CUc254W1p4GnOeyclm2TfMue2Ed1R5+A5PG3YCBfRJmgG+nYDkvANpkfHvoW+t/DM/LD9PmTrb0+24FJTGdm3qA/BInnP9C32DKkuSglwrP7bbaBsHVXvyK9/n+huzyYtIiGE3HY9SRNS4xkLx4k3Ov/YnDZ1lEl0UnG0lt9om8UTu/dXBlsBbN9I9qJAaLReWvgMsd4zrUUCH1b7fYdtHc13n12KGlJmKdgLC1SdfvfT0r+8ME3IQV+4nqSQELd8/XXdHTnDse4CR9bhahn3ri25+akuLVH5BfPHICJ4wtYsGah+sfAmGuzzwiPMT54vgX8ZzDTZtN+jI+audnTgbKrprDAvXT9HmznVkXbkO0pgHbwgYdQ69CGH5Me/g3VPJVckufbFXzLwpH0BzzxDgwVqNbbaFdjAldUTcbqBAhv09U42lTUz0nuEyFPtnvfeZt5W6JHeHuF6xcYNBkHlgJ12oabHOFG+F2wO3Vl6U83dBhAz62eNrw2abVstM3mCoCcNN1pJMy6wtBP7vgMOms7vAAz+tRleGejQY8jv7u6neLoNB8r75f2WQYzlCowkNmgzUvA8bDJRExpKtM+xBDk8sr04PwGhsKdePDk32jJwUW0Gu7Ush2YoR4OPoexdxtAP4D6trlvwzHmbUp9Agxb4VEwPH7VEH6SluNEPVXwR8Zi+zsomsxT0eIPCz1w/YzeTbhClwq203gt/CkY6wGTBlb1cxrbvEs8Ncun+VZBILN5pmPRnlhd8BMHVVSmg8cKC0dpzkRvR6AyyGQEVuFNjRdA1FsdGaqmqoKlwG1baP+aNbjWNhJjO/UtJtO4OBL+5EhO7hupwJnxkaMvkz//SwyMUY4U1EmB8YCB2+Ivv6TSsnGU360rmpmar0ktgMOTo38OdlqbYCibFHg7REJ1sRJ+7Mpm7YFJxHLSjFHwonIRzEPOAzJQjrNbqdTta40w6CPU1/hvESb3e7gWt5JC4a3Y8rbtrZdVD2Lhq1pK5es3kwqCkdNFWIgr8AkTHXikbrlYJZPO4tK5VQZOdo01GCvVGHxv40WSL2nlum1EWOStguE7G2YCu83xZccCWBkijLdaXaGzgu8kbUn9Thrvr0abJzjvO8XX4h7FX3IVjUF7gSsWluTJzWgh3YBtpPJZ06m5QNa/2ZE96xW2AjhxdjmI8CYGIK4h2RGsVenmCDC94qFn0MgbfoBxyBJFcljSF8DV4dCs6qt6z28unPSboAmVd2NS485lOpM6ERbwANMbMPkiGnThJWCAyfuaT7HxQtN+Q8mLqq/skeVtTiJOWfo9YHoOlfhwLREORTU5FDSfBMLfiT+H4wr9RJE5uNf7nxQ4sCfjU143zamo8FH9kK4wLekB01Q8ckWngxkMBki4V9Nx6wMPCQnidzeiT2gp8yEqvDfCkp7Yihm8Dh38Lenat+Rr3EOH6/c4NtQ+99ahuNLZkyIO3HZpEKnCcjVUAsm3025oMH72MEj1PXBYYz/QfVjRdf0gLXskajqWrN6xtw0nDbaSTuBJ1Llvx3Jiu8R2CA4HahtixpOop/8JiMxTXUmBGJ+sAxx5w03U7fShSaVAlv7gnOALylcXOrKvO/uuUgo0LARHPT1zKRC04/vGXbvS2dNnUrAIap8kUqAWyCU91PD4nroDs1ZNGw4znBMsVKAf68EMlXgZp4rOrjqao09uACP5F/p4zh/bvcXDpwaosLATpFAwPV8umHoQ1/v4+htz6mjQzFPdRrQRfRSpp3CglvaFamnjYw2xLGl8Yo9YlUZ2SOBtE9ATVWnyAktc0oRnCattWnwMapqNbiNcJlZeiK0Uu/Zxdl0pFRqQAruPHEnDp96AHGhaghTIhs+GXn9P9ZV9f4sMyUXEeNiCxlX+BJz1F64YIFeFRX7QpZfTgEkVYMLxt5hY+lNS1OpG4+UfXtF/cTwKJ9iv8TNvBXPAjRq+6uOMxOgrHIjR7ygn9CieRkx+Wtq+ZEicJ04a1r4Ye7U7ogBrKds/NEq4UVLVUcWpC3QgAe5fuw6Pnm9pdepqSn96aI0/kgOnn45mJiMCsTLyNLY4m7EVdoFYdP6w0XbjEZwbgOG1DIwbRdQb2i4DhqkneGjU/4ItMQ4z4tuYulXgJcIYBAb4j7g/PA93h6cRGwenFxIZVHql7XMzw2v5Z1/Cy3FCUKCtB45zIoyf8R288focJK2A80JJckLHBjf3dMZ3rzO3nrEcMhCAXz39X6uvLPlP6G/SWMGrJI3f/kscZvyz2y0613ralVdT3/HlzVt0MAowxHp4fbkGesl3Yvie0J/jbi0n6V8AltEbi4ezppgHC6IBfQPjXH0NpMgVYKSf407yBqgg9kGerCMtBE8TWD2MnDw8ntsDjHMw/BGcRVrkRVo870NnFXm5PAo0U6B9T4Gb8cArrrnvUn5oCUS3C1xtN/kGxurV5g2Mwt59wLN0zB/Y1oX1zQGDnkmP+TGC0E/IWY9jCzsdUmBPcNWWWKfxPWqus3PlSioZdRb5AnwPGQ9r4EaKHgq9f0SJj9IA1rGz6r5PwKB+AYew94OJ5TgSuFldIaBvUziAUAIHEAImIvDEorSj6ETc55U4ePDzK364YxzKx6qBd1Z8+dDTdcapK+vfPAbYsUdFh8SuWbnb3ujtWR6i3mOgXKZreeOZMTqQJIwQBAkwva5Dh4JfYcZA+tPDjXPea1j8F1qwIA3p7xgWQwoOUqRLf0gl4xL1imnhiQO0UO0RysN7xIWl7AGJJ70I41zxxx9d0+vLtGB15Mw7agzqftZa0Auv5YmJQDW9nYYw9YeQ8qgLmGcJPntjRPQHlIH46484eKGmHma6Ija90WnikKfoq6/S71sA8cKpS4HMGU1b0Kze/wZ2TCvAvdxBhxS456tVVLdrNyQsbH3D4V1+oT9G06Y53I8lVM9G24bA+8ZZMNqGRMrX48JwloDnMvlA5OOQOvheQo0n/k+++sVXwEg9GJW60+CBzMbMP/xnsjSsaiz5xf6Yn8bSWSIXYgRtL2BG6QWPAmlRoGMxQL7wLulhjG5z2KfVkpaZMV9COGzY8Sl4KXtlNvQ/R/L7r2mZJe3vdQe/Ahw28Ui7aFwBGG0f2bKZDqxbCz4vdaGLOYu/c0b2bzzEVdpOP/gKmIKXaNLvB5OC2YhL2iVrhjlUJOz4aESyZC/Oo4AVBdpgRFpV5yDNn/MCGODX2LdiZYckmOkf3vbY/c03uCGy9bAWzINfPdOA1QECKbKweygN5h0KLpX43ZBM8RJ45Ah2gNs//5Iaaw9/FtHCr6Wo8eSIXjpvK4U1+OMzfgLBDY5WXUr3yajCvvSELE+W5MV5FLCiQMc5BIlh+eEDe7WJt/+39AcvcXyCGCsb92mQ3tAIJrhq9ZExw1bFJWX6Y0d4ha9P3q+F5h94bG+WGSQ4E67bhyupG9a/9Nk9kzN385RZ7ce/FN9eGD7zUVzkhxQu7sIfv3/Ll7Kzg4v5sDmBAVZhQcehlRc8CjikQMdjgOAseqPxvJ5HH1DIwRUhq4aGSezevKm2djhvv7IQYO0fGfx3uECPx6tDYVfbdK2+Vmzbvn5PFrA6MUCsmr+fhkx5k7r1XgOr76tx4vt9bInPwtYYPc48yw05TUY6mio29qBqSJle8CjgkAJpaKYdQvSyeRSwo0D5zGIcKg2ESvBCmLnAH546G1JhkVnM1OmZJxw2UHjo4o8ZqBn0/eChk/E2sbMX446V8j5ObQrERs+pTQWv9e1DAb4H3kUUUJBwE8Q3AZIhtrH6cDCyPvgrhKQN3V7CEDUFRZb4xBEwUHhSEaugV1xEquEDOlK70rEjgvZpsVdrB6NAwujqYNh56JwiFMBD6aNycigHRtNKy4MxfA8wtl7wKFKMzyI4JMCJGILiayXwQajTAdz+2AVv0TvxPi48PR9ooFXwvkx42N0LHgXSoIDHANMglpf1eFEADBEOlehovqRCXcNpFkyjc6JKwvwGg/bUGrS2HsyumhmeG+Xh8WqQV49HAY8CHgU8CngU8CjgUcCjgEcBjwIeBTwKeBTwKOBRwKOARwGPAh4FPAp4FPAo4FHAo4BHAY8CHgU8CngU8CjgUcCjgEcBjwIeBTwKeBTwKOBRwKOARwGPAh4FPAp4FPAo4FHAo4BHAY8CHgU8CngU8CjgUcCjgEcBjwIeBTwKeBTwKOBRwKOARwGPAh4FPAp4FPAo4FHAo4BHAY8CHgU8CngU8CjgUcCjgEcBjwIeBTwKeBTwKOBRwKOARwGPAh4FPAp4FPAocGpR4P8D562jRcudh/kAAAAASUVORK5CYII=
+      mediatype: image/png
+  maturity: stable
+  links:
+    - name: Source Code
+      url: https://github.com/quay/quay-operator
+  maintainers:
+    - email: quay-sig@googlegroups.com
+      name: Project Quay Contributors
+  provider:
+    name: Red Hat
+  selector:
+    matchLabels:
+      alm-owner-quay-operator: quay-operator
+      operated-by: quay-operator
+  version: 3.9.19
+  replaces: quay-operator.v3.9.18 ## Except for ".0", always put the previous z-stream here

--- a/operators/project-quay/3.9.19/manifests/quayregistries.crd.yaml
+++ b/operators/project-quay/3.9.19/manifests/quayregistries.crd.yaml
@@ -1,0 +1,1187 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: quayregistries.quay.redhat.com
+spec:
+  group: quay.redhat.com
+  names:
+    kind: QuayRegistry
+    listKind: QuayRegistryList
+    plural: quayregistries
+    singular: quayregistry
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: QuayRegistry is the Schema for the quayregistries API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: QuayRegistrySpec defines the desired state of QuayRegistry.
+            properties:
+              components:
+                description: Components declare how the Operator should handle backing
+                  Quay services.
+                items:
+                  description: Component describes how the Operator should handle
+                    a backing Quay service.
+                  properties:
+                    kind:
+                      description: Kind is the unique name of this type of component.
+                      type: string
+                    managed:
+                      description: Managed indicates whether or not the Operator is
+                        responsible for the lifecycle of this component. Default is
+                        true.
+                      type: boolean
+                    overrides:
+                      description: Overrides holds information regarding component
+                        specific configurations.
+                      properties:
+                        affinity:
+                          description: Affinity is a group of affinity scheduling
+                            rules.
+                          properties:
+                            nodeAffinity:
+                              description: Describes node affinity scheduling rules
+                                for the pod.
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node matches the corresponding
+                                    matchExpressions; the node(s) with the highest
+                                    sum are the most preferred.
+                                  items:
+                                    description: An empty preferred scheduling term
+                                      matches all objects with implicit weight 0 (i.e.
+                                      it's a no-op). A null preferred scheduling term
+                                      matches no objects (i.e. is also a no-op).
+                                    properties:
+                                      preference:
+                                        description: A node selector term, associated
+                                          with the corresponding weight.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      weight:
+                                        description: Weight associated with matching
+                                          the corresponding nodeSelectorTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to an update), the system may or may
+                                    not try to eventually evict the pod from its node.
+                                  properties:
+                                    nodeSelectorTerms:
+                                      description: Required. A list of node selector
+                                        terms. The terms are ORed.
+                                      items:
+                                        description: A null or empty node selector
+                                          term matches no objects. The requirements
+                                          of them are ANDed. The TopologySelectorTerm
+                                          type implements a subset of the NodeSelectorTerm.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                              type: object
+                            podAffinity:
+                              description: Describes pod affinity scheduling rules
+                                (e.g. co-locate this pod in the same node, zone, etc.
+                                as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which
+                                    matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                              This field is beta-level and is only
+                                              honored when PodAffinityNamespaceSelector
+                                              feature is enabled.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to a pod label update), the system may
+                                    or may not try to eventually evict the pod from
+                                    its node. When there are multiple elements, the
+                                    lists of nodes corresponding to each podAffinityTerm
+                                    are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity)
+                                      with, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is beta-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                            podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling
+                                rules (e.g. avoid putting this pod in the same node,
+                                zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the anti-affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling anti-affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which
+                                    matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                              This field is beta-level and is only
+                                              honored when PodAffinityNamespaceSelector
+                                              feature is enabled.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the anti-affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the anti-affinity requirements specified by this
+                                    field cease to be met at some point during pod
+                                    execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict
+                                    the pod from its node. When there are multiple
+                                    elements, the lists of nodes corresponding to
+                                    each podAffinityTerm are intersected, i.e. all
+                                    terms must be satisfied.
+                                  items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity)
+                                      with, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces. This field is beta-level
+                                          and is only honored when PodAffinityNamespaceSelector
+                                          feature is enabled.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        env:
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        replicas:
+                          format: int32
+                          nullable: true
+                          type: integer
+                        volumeSize:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  required:
+                  - kind
+                  - managed
+                  type: object
+                type: array
+              configBundleSecret:
+                description: ConfigBundleSecret is the name of the Kubernetes `Secret`
+                  in the same namespace which contains the base Quay config and extra
+                  certs.
+                type: string
+            type: object
+          status:
+            description: QuayRegistryStatus defines the observed state of QuayRegistry.
+            properties:
+              conditions:
+                description: Conditions represent the conditions that a QuayRegistry
+                  can have.
+                items:
+                  description: 'Condition is a single condition of a QuayRegistry.
+                    Conditions should follow the "abnormal-true" principle in order
+                    to only bring the attention of users to "broken" states. Example:
+                    a condition of `type: "Ready", status: "True"“ is less useful
+                    and should be omitted whereas `type: "NotReady", status: "True"`
+                    is more useful when trying to monitor when something is wrong.'
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              configEditorCredentialsSecret:
+                description: ConfigEditorCredentialsSecret is the Kubernetes `Secret`
+                  containing the config editor password.
+                type: string
+              configEditorEndpoint:
+                description: ConfigEditorEndpoint is the external access point for
+                  a web-based reconfiguration interface for the Quay registry instance.
+                type: string
+              currentVersion:
+                description: CurrentVersion is the actual version of Quay that is
+                  actively deployed.
+                type: string
+              lastUpdated:
+                description: LastUpdate is the timestamp when the Operator last processed
+                  this instance.
+                type: string
+              registryEndpoint:
+                description: RegistryEndpoint is the external access point for the
+                  Quay registry.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/project-quay/3.9.19/metadata/annotations.yaml
+++ b/operators/project-quay/3.9.19/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable-3.9
+  operators.operatorframework.io.bundle.channels.v1: stable-3.9
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: project-quay


### PR DESCRIPTION
## Summary
- Re-adding Quay operator version 3.9.19 with corrected skipRange configuration
- Relates: #9687

## Test plan
- [ ] Verify skipRange is properly formatted
- [ ] Check operator manifests are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)