### PR TITLE
operator logicmonitor-openshift-operator (0.3.3)

### DIFF
--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-lmcontainer-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-lmcontainer-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+  name: logicmonitor-openshift-operator-lmcontainer-admin-role
+rules:
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers/status
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-lmcontainer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-lmcontainer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+  name: logicmonitor-openshift-operator-lmcontainer-editor-role
+rules:
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers/status
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-lmcontainer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-lmcontainer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+  name: logicmonitor-openshift-operator-lmcontainer-viewer-role
+rules:
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers/status
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-manager-metrics-svc_v1_service.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-manager-metrics-svc_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+    control-plane: controller-manager
+  name: logicmonitor-openshift-operator-manager-metrics-svc
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: logicmonitor-openshift-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator.clusterserviceversion.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/logicmonitor-openshift-operator.clusterserviceversion.yaml
@@ -1,0 +1,789 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "lm-container-rosa",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator"
+            },
+            "name": "lm-container",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "rm-rosa-cluster-operator",
+              "clusterTreeParentID": 493,
+              "collector": {
+                "replicas": 2,
+                "size": "large"
+              },
+              "enabled": true,
+              "jobs": {
+                "eventMode": "logs"
+              },
+              "monitoring": {
+                "disable": [
+                  "resourcequotas",
+                  "limitranges",
+                  "roles",
+                  "rolebindings",
+                  "networkpolicies",
+                  "configmaps",
+                  "clusterrolebindings",
+                  "clusterroles",
+                  "priorityclasses",
+                  "storageclasses",
+                  "endpoints",
+                  "ingresses",
+                  "secrets",
+                  "serviceaccounts",
+                  "poddisruptionbudgets",
+                  "customresourcedefinitions"
+                ]
+              },
+              "monitoringMode": "Advanced"
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "companyDomain": "logicmonitor.com",
+              "userDefinedSecret": "lm-credentials"
+            },
+            "kube-state-metrics": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "lm-monitoring-full",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator",
+              "environment": "production"
+            },
+            "name": "lm-monitoring-full",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "prod-openshift-east",
+              "clusterTreeParentID": 1,
+              "deleteDevices": true,
+              "disableAlerting": false,
+              "enabled": true,
+              "loglevel": "info",
+              "resourceContainerID": 1
+            },
+            "collector": {
+              "escalationChainID": 0,
+              "groupID": 0,
+              "replicas": 2,
+              "size": "medium",
+              "useEA": false
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "companyDomain": "logicmonitor.com",
+              "image": {
+                "pullPolicy": "Always",
+                "registry": ""
+              },
+              "userDefinedSecret": "lm-credentials"
+            },
+            "kube-state-metrics": {
+              "collectors": [
+                "daemonsets",
+                "replicasets",
+                "statefulsets",
+                "persistentvolumes",
+                "persistentvolumeclaims",
+                "endpointslices",
+                "cronjobs",
+                "jobs",
+                "pods",
+                "nodes",
+                "deployments",
+                "services",
+                "poddisruptionbudgets"
+              ],
+              "enabled": true,
+              "replicas": 1,
+              "selfMonitor": {
+                "enabled": true,
+                "telemetryPort": 8081
+              }
+            },
+            "lm-logs": {
+              "enabled": false
+            },
+            "lmotel": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "name": "lm-monitoring-minimal",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "my-cluster"
+            },
+            "global": {
+              "companyDomain": "logicmonitor.com",
+              "userDefinedSecret": "lm-credentials"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "annotations": {
+              "openshift.io/description": "LogicMonitor container monitoring for OpenShift"
+            },
+            "labels": {
+              "app.kubernetes.io/instance": "lm-monitoring-openshift",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator"
+            },
+            "name": "lm-monitoring-openshift",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "openshift-prod",
+              "clusterTreeParentID": 1,
+              "deleteDevices": true,
+              "enabled": true,
+              "loglevel": "info"
+            },
+            "collector": {
+              "replicas": 2,
+              "size": "medium"
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "companyDomain": "logicmonitor.com",
+              "userDefinedSecret": "lm-credentials"
+            },
+            "kube-state-metrics": {
+              "collectors": [
+                "daemonsets",
+                "replicasets",
+                "statefulsets",
+                "persistentvolumes",
+                "persistentvolumeclaims",
+                "endpointslices",
+                "cronjobs",
+                "jobs",
+                "pods",
+                "nodes",
+                "deployments",
+                "services",
+                "poddisruptionbudgets"
+              ],
+              "enabled": true,
+              "replicas": 1
+            },
+            "lm-logs": {
+              "enabled": false
+            },
+            "lmotel": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "lmcontainer-sample",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator"
+            },
+            "name": "lmcontainer-sample",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "",
+              "clusterTreeParentID": 1,
+              "enabled": true
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "accessID": "",
+              "accessKey": "",
+              "account": "",
+              "collectorsetServiceNameSuffix": "lm-container-collectorset-controller",
+              "companyDomain": "logicmonitor.com",
+              "image": {
+                "pullPolicy": "",
+                "registry": ""
+              },
+              "userDefinedSecret": ""
+            },
+            "kube-state-metrics": {
+              "collectors": [
+                "daemonsets",
+                "replicasets",
+                "statefulsets",
+                "persistentvolumes",
+                "persistentvolumeclaims",
+                "endpointslices",
+                "cronjobs",
+                "jobs",
+                "pods",
+                "nodes",
+                "deployments",
+                "services",
+                "poddisruptionbudgets"
+              ],
+              "enabled": true,
+              "replicas": 1,
+              "selfMonitor": {
+                "enabled": true,
+                "telemetryPort": 8081
+              }
+            },
+            "lm-logs": {
+              "enabled": false
+            },
+            "lmotel": {
+              "enabled": false
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring
+    containerImage: ghcr.io/ryanmat/logicmonitor-openshift-operator:0.3.3
+    createdAt: "2026-05-24T00:18:43Z"
+    description: Deploy LogicMonitor container monitoring on OpenShift clusters
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://github.com/ryanmat/logicmonitor-openshift-operator
+    support: LogicMonitor
+  name: logicmonitor-openshift-operator.v0.3.3
+  namespace: placeholder
+spec:
+  replaces: logicmonitor-openshift-operator.v0.3.2
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: LMContainer deploys LogicMonitor container monitoring components including Argus, Collectorset Controller, and Kube State Metrics to monitor Kubernetes resources.
+        displayName: LM Container
+        kind: LMContainer
+        name: lmcontainers.monitoring.logicmonitor.com
+        version: v1alpha1
+  description: |
+    ## LogicMonitor Container Monitoring Operator
+
+    **Note**: This is a community-maintained operator. For official LogicMonitor
+    support, please contact LogicMonitor directly. Issues and contributions are
+    welcome on [GitHub](https://github.com/ryanmat/logicmonitor-openshift-operator).
+
+    The LogicMonitor Operator provides a native OpenShift experience for deploying
+    and managing LogicMonitor's container monitoring solution.
+
+    ### Features
+
+    - **Automatic Discovery**: Automatically discovers and monitors pods, nodes,
+      services, deployments, and other Kubernetes resources
+    - **Pre-configured Alerting**: Ships with pre-configured alert thresholds
+      based on best practices
+    - **Long-term Data Retention**: 2-year data retention for capacity planning
+      and trend analysis
+    - **Unified Monitoring**: Integrates with existing LogicMonitor infrastructure
+      monitoring for end-to-end visibility
+
+    ### Components Deployed
+
+    - **Argus**: Kubernetes resource discovery and monitoring agent
+    - **Collectorset Controller**: Manages LogicMonitor collector pod lifecycle
+    - **Kube State Metrics**: Exports Kubernetes object metrics
+
+    ### Prerequisites
+
+    - LogicMonitor account with Container Monitoring license
+    - API credentials with appropriate permissions
+    - OpenShift 4.12 or later
+
+    ### Getting Started
+
+    1. Create a Secret with your LogicMonitor credentials:
+       ```
+       oc create secret generic lm-credentials \
+         --namespace logicmonitor \
+         --from-literal=account=YOUR_ACCOUNT \
+         --from-literal=accessID=YOUR_ACCESS_ID \
+         --from-literal=accessKey=YOUR_ACCESS_KEY
+       ```
+
+    2. Create an LMContainer resource:
+       ```yaml
+       apiVersion: monitoring.logicmonitor.com/v1alpha1
+       kind: LMContainer
+       metadata:
+         name: lm-monitoring
+         namespace: logicmonitor
+       spec:
+         global:
+           userDefinedSecret: "lm-credentials"
+           companyDomain: "logicmonitor.com"
+         argus:
+           clusterName: "my-openshift-cluster"
+       ```
+
+    ### Documentation
+
+    For detailed documentation, visit:
+    https://www.logicmonitor.com/support/lm-container
+  displayName: LogicMonitor Container Monitoring
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAALT0lEQVR42u2de1iUVR7Hz+V9YYbhWsolLyh5zXXXNSRztTQNE8i8hNcg00VEk8xAVkNdSUJU8MaamYqiayiYmikhWE+KT3lrzWjVrU3RR93wsoHiwMx7ztk/jh7fx6XEeYeXGZr3L57hed7h/czvfH+X8z0DlLyjgOv65Qu5ELgAuQC5ALkAuQC5ALkAOcafiyDGyAWofjQIQUoZIbRnjw4eRncXoHuXJGFKGaWse7d22zbPPnxgqZeXEQAAIWz0t3ZwNBgjSpmikE4dW82fM/6lyN7u7vJtcx0hVKfPxpHRMMY4iLjXXnh3wQRfHxMAgBAKAdQhdhwXEEKQgwAAjBvVf1p8VFho5ztooN4i7ViA+PMrCgEADHjm97NmRg8a0IOj4fmLMaa3/DkOGoQgIVRRSN8+3d5KHBE1JEzEkZao4fFIKXNiQBgjQigh7BE/r6mTI2e9GW00uvFH0oJGQHfiCOJJihDq62OKHtFvdvLoNq1a8MDRqDWShBWFEMJ69ugQGOC3r/gYL6Ocpg5CCEoSJoQyxqKH9z18IGv18mltWrXgr2ihgzGCECoK8W/pkzY35lDJkv79ugMAMMbOEUEIQQghIZRS8mLEU0lvjOzTuysAQFEIxkgjGlEZzJs9LiEussWj3gCAm7fMzrHEVKLA2gUHvJU4YsqfI0T+liSsHToAIGJwr+QZI/v26QYAMJstBoOsBbqkZ7vARSGkfdDE2OenTo7y8jRSyjQuKDX0gf17zEke/Uzf34l4lCSksaSU9FlTjAFFISYPw8zE4TNeH+bt5aFSYqgFutWqEMI6dWyVmjJ2bPSzPKMzxrTEo36AEIII3Sn8XhkzIHnGy090basu/LSgAQBYrUqLR70z35k4amQ/g8FNFY/Q0QtFUZ5RSkJ7dkybG/P8c3+0CxpKGWX02vVqAMD40QNSU8Z0ePwxu8SjfoC43AAAunZpk5Q4cuyoZ2VZ0t5J8QwlSdjkYZgYG/7q+IG9nuxkl/SnHyAxnXg8JGhO8ujo4f2MRjfthZ9AI0n4+NffL1lWmLcuyd1dVhSCELKX3DQuIHUNkjRj5Kw3X/bz9RRotNDhd5AkfL7ip/Ql2zZtKWWMrfj5ln9LX14TOnqzqp5OjBrRb3rC0N5hXewS+QKu2WzZuKUkY+n2K/+5AQDwNBkwRghBHZp7SWPhB+GdRrl3WJfZSaMiBvcSSqwl8illEAKMkcWibP7wQNbKnd//cAkAIMuSohBCdRon2g5IDG4YA316d52eMHTkS3+CEGov/BhjlN65w+5Pvpq3cPM/T19Qq5vOIyHJ5umEohAfb9P8OeOmJwwVOqol0QolxhieOXsxLWNrwc6yuxN7ypewbpNWGwEJufH28oifFBE/aUhwW3/xmWMMtSepq9eqMrMLVq/da7Uq/O14xdBUl/Sw0gAAGPbi02mpMV27tOGvIARtRqNOUlXVNetyi1es3s2VmMdpkw/zpIeKnaef6pqaMpbPiXkNwl+3WYm5YNXVWT/I/TR75UcXL11TDRibns5DAMIYW63KkPDQQQN61NVZZVnSkqRUSgy/PHI6PnHV6TMXudw4DhpbltitW7U8hdscOGolPlV+Lj0zf+eeL3nzzYUfONgl2eAdoLaWIUJuLl+5kb3qo/c+2GuxKHyg44BodB2YiSb+2vXqFX/bvWbd3p+raoTc6L7Z5UiA1Ls3e/YdmZK4qvJq1QPlRtQ7rKnhSY0dOBxN6ecns1bsKP38pEDzK2sKwntNlm17NU4DCGN08tSPaRlb9+w7om4XHijkAIAWj3rX3K41my3NMIL4EyoKScv4cMnyQi5AYtfhgdProEC/HVtTQ9oHWixK3LQVn5acEBM40GwseBBCRaHrNxUTQmVZ4tunDciSiDGWEBcZ2rOjj7cpMMAvbW6MLEuUUv27sEbfWYUQ+Pl5QggJaeiHz8Pk5WF9eZHNGAtpHyhLuAllCDW2SNebhiQJ84FRvXEhyxJfkhDC2lorA6z510H1Rgql5Jd+y9cjpczdXYYAgt+ODRghKMvS3L+M3b19Xt66pLatW/JKWr3btfuTr3gBiRD84d+X6yzWphIgvSOIJ6PEqVHzZo/jr7i7y6NjMhBCADAAABfjle/tDg72fymy96nyc7FxWXz82lQyJOnpXOBt6pRJEbyGRghGhIcGt/WvuFDJC0JO4dLl62NiF7ULDrh85Tpv1pqtSP9/fYQQ9PLywBjJMoYQGgxuT4d14Qn+voH3+YqfLBZFn60LxxJpsX3Gfz5/ofK+nosxRgjjRWO9sYMRaoYRxIc+VispKj7GGzSM0anyc0ePn623yOalUL0HEm7V1Oq26HSNID5IWpiZ37lT6y6d29TVWVNSc/lokRDWcIdw+MCeJpOBi3czA8QghBUXK58Jn/VY0CPV1bdv1dSKXdmGOIS7PRG8cF4sdwg3Tw1ijPFpxuUrNx44zRBoCGH+LX3iJ0VMTxjq5+vJb9KcRVqMxH6Fzt3DT8xodIt7bUjSGyOCAh+xi0PYOXzSv5K81b602HED5ySPfjwkqLF9QE5zVoOvKUpJxw6tlmXGDR70pF3cEM3hrAZPUoSwdsEBM6cPHz9mgLeXh3ZfmijQnf6shqKQAH/fmdNHTJoQ7uNt4s+mcUEpCpVlydNkcFZAYhTraTJMnRw1JS5SnNXQsj0p7mA0uv147krR/uOiCnMaQKopNRvYv0dOdgI3q9rFlyZW5cbNJclvr/+5qqYhE3FHAaT2xv+he0hiwtDY8QNV3nhNvjThMc4vPLg8Z9eJf3yvce9Iaiol7typ9czXh8eMe06WJcYYY8BObghQXHoiM7vw0OFysdHkHCItlDgwwG9afNSMacMMhnsOYZsLY7Ub4rMvvklfnH+wrPw+163jn9VAAFAuDRNiBmW+M5E7hLXLjaIQ7kurqq5ZlFWwdPmO+1y3jn9WA4kWPCy087sLXn22b3e7FH7CKGI2W3Le//j99UUVFyrtcgZTJ0BcVmrNdYTQsNDOKTOjI1/oxWFpjBpKGaVUkjBjbNuOQxlLtwkbLG9rnaCS5qJgNLqFtA/6a+orMWOfE62pRiXmd0YIF+wsW7Zq57ET/7rPBuvorYY4O2g2W3I371+/ZkZwG3/+YBp9aTxJ8QMJi7IK1m8qFkrcqNv2UmP4gEo/P5mSuuG70xWvxYRrb6buHkiAly5f37ilZNmqXVXVNfZV4sYFJCIfAHCwrDx9cf5nX3wDAGjZwkchxIjdbN6WEDbY2lrL2g1FmdkF3Hylp0NYsotFSpLwmbMXU+bm7is+JhKtohCb535qG2ze1gOLsgr4WQ39bbAS0Gw7rLxalff30mU5OyuvVvEOq94NiYdFgzH8+uQPGUu379rzZcPNVw4BSH1iZe2GovTF+XzAfDfybR8Y88IPY1hxsTJ9cf7GzaX8jexSE+sBiP+h7u4yAKBwV9nqtXt5y6M98kX6u3a9elHW9ty8kuqbtx3hQMLDAXJzkzFGhw6XL3h36xdl39ol8tVpbsnywpw1e0Q8NtCX5hCAuKacv/DT/IVblufsum2u0x754tQcrwyWLCvk6c9B0DwcIB4jm7aUqltzu1QGR4+fTV+8jac/pz+rIZKURrnhlUH5d+ffXpBXtP84d33wr2wBwJmd9pQyoMExKCoDRSHzF27JWbPntrlOnf4A+M2f1QAA5OaVrFrz8bffnXc0uWkaQOph6CdFRzOzC746esYp0OgBiHcbGMO9nx5774O9xaUn7DgMdXpAEEJfH9ON/96cPX/jhk377T4M1efCyL1TY6DhVaXBIE+Izz5YVs79CJQyRz4aVv+z6PBvIxzk/DJwWI+i89JxfSO5C5ALkAuQC5ALkAtQc77+B8QD3+WWj4ALAAAAAElFTkSuQmCC
+      mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - logicmonitor-scc
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+            - apiGroups:
+                - monitoring.logicmonitor.com
+              resources:
+                - lmcontainers
+                - lmcontainers/status
+                - lmcontainers/finalizers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - logicmonitor.com
+              resources:
+                - collectorsets
+                - collectorsets/status
+                - collectorsets/finalizers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - pods/log
+                - services
+                - services/finalizers
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+                - nodes
+                - nodes/metrics
+                - nodes/proxy
+                - nodes/stats
+                - componentstatuses
+                - containers
+                - limitranges
+                - persistentvolumes
+                - replicationcontrollers
+                - resourcequotas
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - deployments/scale
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - cronjobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+                - escalate
+                - bind
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+                - ingressclasses
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+                - use
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+                - podmonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - discovery.k8s.io
+              resources:
+                - endpointslices
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+                - volumeattachments
+              verbs:
+                - list
+                - get
+                - watch
+                - update
+            - apiGroups:
+                - scheduling.k8s.io
+              resources:
+                - priorityclasses
+              verbs:
+                - list
+                - get
+                - watch
+                - update
+            - apiGroups:
+                - cert-manager.io
+              resources:
+                - certificates
+              verbs:
+                - list
+                - get
+            - apiGroups:
+                - extensions
+              resources:
+                - daemonsets
+                - deployments
+                - replicasets
+                - statefulsets
+              verbs:
+                - list
+                - get
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - certificates.k8s.io
+              resources:
+                - certificatesigningrequests
+              verbs:
+                - list
+                - watch
+            - nonResourceURLs:
+                - /
+                - /healthz
+                - /healthz/*
+                - /metrics
+                - /proxy
+              verbs:
+                - get
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: logicmonitor-openshift-operator-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: logicmonitor-openshift-operator
+            control-plane: controller-manager
+          name: logicmonitor-openshift-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: logicmonitor-openshift-operator
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app.kubernetes.io/name: logicmonitor-openshift-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-require-rbac
+                      - --metrics-secure
+                      - --metrics-bind-address=:8443
+                      - --leader-elect
+                      - --leader-election-id=logicmonitor-openshift-operator
+                      - --health-probe-bind-address=:8081
+                    image: ghcr.io/ryanmat/logicmonitor-openshift-operator:0.3.3
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 10m
+                        memory: 128Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: logicmonitor-openshift-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: logicmonitor-openshift-operator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - monitoring
+    - observability
+    - kubernetes
+    - openshift
+    - logicmonitor
+    - metrics
+    - apm
+  links:
+    - name: Documentation
+      url: https://www.logicmonitor.com/support/lm-container
+    - name: LogicMonitor
+      url: https://www.logicmonitor.com
+  maintainers:
+    - email: support@logicmonitor.com
+      name: LogicMonitor
+  maturity: alpha
+  minKubeVersion: 1.23.0
+  provider:
+    name: LogicMonitor
+    url: https://www.logicmonitor.com
+  version: 0.3.3

--- a/operators/logicmonitor-openshift-operator/0.3.3/manifests/monitoring.logicmonitor.com_lmcontainers.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/manifests/monitoring.logicmonitor.com_lmcontainers.yaml
@@ -1,0 +1,302 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: logicmonitor-operator
+    app.kubernetes.io/part-of: logicmonitor-operator
+  name: lmcontainers.monitoring.logicmonitor.com
+spec:
+  group: monitoring.logicmonitor.com
+  names:
+    kind: LMContainer
+    listKind: LMContainerList
+    plural: lmcontainers
+    shortNames:
+    - lmc
+    singular: lmcontainer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: LogicMonitor cluster name
+      jsonPath: .spec.argus.clusterName
+      name: Cluster
+      type: string
+    - description: Deployment phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Number of collectors
+      jsonPath: .status.collectorCount
+      name: Collectors
+      type: integer
+    - description: Argus ready status
+      jsonPath: .status.argusReady
+      name: Argus
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LMContainer deploys LogicMonitor container monitoring to a Kubernetes
+          cluster.
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of LMContainer deployment.
+            properties:
+              argus:
+                description: Argus configuration for Kubernetes resource discovery.
+                properties:
+                  clusterName:
+                    description: |
+                      Unique name for this cluster in LogicMonitor.
+                      Appears as "Kubernetes Cluster: <clusterName>" in the portal.
+                      WARNING: Do not change after initial deployment.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                    type: string
+                  clusterTreeParentID:
+                    default: 1
+                    description: |
+                      Parent resource group ID in LogicMonitor where the cluster tree is created.
+                      The resource group must exist before deployment.
+                    minimum: 1
+                    type: integer
+                  enabled:
+                    default: true
+                    description: Enable Argus deployment.
+                    type: boolean
+                  resourceContainerID:
+                    description: Resource container group ID in LogicMonitor.
+                    minimum: 1
+                    type: integer
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              collector:
+                description: Collector configuration.
+                properties:
+                  escalationChainID:
+                    description: Alert escalation chain ID for collector alerts.
+                    minimum: 0
+                    type: integer
+                  groupID:
+                    description: Collector group ID in LogicMonitor. Auto-created
+                      if not specified.
+                    minimum: 0
+                    type: integer
+                  replicas:
+                    default: 1
+                    description: Number of collector pod replicas.
+                    maximum: 10
+                    minimum: 1
+                    type: integer
+                  size:
+                    default: small
+                    description: Collector size determining resource allocation.
+                    enum:
+                    - nano
+                    - small
+                    - medium
+                    - large
+                    type: string
+                  useEA:
+                    default: false
+                    description: Use Early Access collector version.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              collectorset-controller:
+                description: Collectorset Controller configuration for collector pod
+                  management.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable Collectorset Controller deployment.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              global:
+                description: Global configuration shared across all components.
+                properties:
+                  accessID:
+                    description: |
+                      LogicMonitor API access ID. Generate from Settings > Users and Roles > API Tokens.
+                      Ignored if userDefinedSecret is set.
+                    type: string
+                  accessKey:
+                    description: |
+                      LogicMonitor API access key.
+                      Ignored if userDefinedSecret is set.
+                    type: string
+                  account:
+                    description: |
+                      LogicMonitor account name. This is the subdomain from your portal URL.
+                      Example: If your URL is "acme.logicmonitor.com", use "acme".
+                      Ignored if userDefinedSecret is set.
+                    maxLength: 64
+                    minLength: 1
+                    pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                    type: string
+                  companyDomain:
+                    description: |
+                      LogicMonitor domain. Leave empty for standard logicmonitor.com.
+                      Use "lmgov.us" for government cloud.
+                    enum:
+                    - ""
+                    - logicmonitor.com
+                    - lmgov.us
+                    type: string
+                  image:
+                    description: Global image configuration overrides.
+                    properties:
+                      pullPolicy:
+                        description: Override image pull policy for all components.
+                        enum:
+                        - ""
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      registry:
+                        description: Override image registry for all components.
+                        type: string
+                    type: object
+                  userDefinedSecret:
+                    description: |
+                      Name of a Secret containing LogicMonitor credentials.
+                      The Secret must contain keys: accessID, accessKey, account.
+                      When set, inline credential fields are ignored.
+                    type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              kube-state-metrics:
+                description: Kube State Metrics configuration.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable Kube State Metrics deployment.
+                    type: boolean
+                  replicas:
+                    default: 1
+                    description: Number of KSM pod replicas.
+                    maximum: 5
+                    minimum: 1
+                    type: integer
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              lm-logs:
+                description: LM Logs configuration for log forwarding.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enable LM Logs deployment.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              lmotel:
+                description: LMOTEL configuration for OpenTelemetry integration.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enable LMOTEL deployment.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of LMContainer.
+            properties:
+              argusReady:
+                description: Whether Argus is ready and registered with LogicMonitor.
+                type: boolean
+              collectorCount:
+                description: Number of running collector pods.
+                minimum: 0
+                type: integer
+              collectorsetControllerReady:
+                description: Whether Collectorset Controller is ready.
+                type: boolean
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the LMContainer state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message for the condition.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              helmReleaseName:
+                description: Name of the managed Helm release.
+                type: string
+              helmReleaseStatus:
+                description: Status of the Helm release.
+                type: string
+              lastReconcileTime:
+                description: Last successful reconciliation time.
+                format: date-time
+                type: string
+              message:
+                description: Human-readable status message.
+                type: string
+              observedGeneration:
+                description: Last observed generation of the LMContainer resource.
+                format: int64
+                type: integer
+              phase:
+                description: Current phase of the LMContainer deployment.
+                enum:
+                - Pending
+                - Installing
+                - Running
+                - Failed
+                - Updating
+                - Deleting
+                type: string
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/logicmonitor-openshift-operator/0.3.3/metadata/annotations.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: logicmonitor-openshift-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # OpenShift version compatibility.
+  com.redhat.openshift.versions: "v4.12"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/logicmonitor-openshift-operator/0.3.3/tests/scorecard/config.yaml
+++ b/operators/logicmonitor-openshift-operator/0.3.3/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Thanks submitting your Operator. Please check below list before you create your Pull Request.

### New Submissions

* [ ] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-via-pr.md)?
* [ ] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [ ] Have you tested your Operator with all Custom Resource Definitions?
* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
* [ ] Have you considered whether you want to use [semantic versioning order](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md#semver-mode)?
* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?
* [ ] Is operator [icon](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#operator-icon) set?

### Updates to existing Operators

* [x] Did you create a \`ci.yaml\` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [x] Is your new CSV pointing to the previous version with the \`replaces\` property if you chose \`replaces-mode\` via the \`updateGraph\` property in \`ci.yaml\`?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the \`package.yaml\` or \`annotations.yaml\` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Modify any files outside the above-mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

---

## Release Notes

This release vendors upstream lm-container Helm chart v13.1.0 in place of v13.0.0.

### Subchart versions inherited from upstream v13.1.0

| Subchart | Before | After |
|---|---|---|
| argus | 15.0.1 (app v18.0.0) | 15.1.0 (app v18.1.0) |
| collectorset-controller | 12.2.0 (app v13.4.0) | 12.3.0 (app v13.5.0) |
| lm-logs | 1.0.1 | 1.1.0 |
| kube-state-metrics | 7.1.0 | 7.2.2 |
| lmutil | 0.1.10 | 0.1.11 |
| lmotel | 1.9.0 (unchanged) | 1.9.0 |

### Removed workaround templates

- \`charts/argus/templates/post-install.yaml\`
- \`charts/collectorset-controller/templates/post-install.yaml\`

These no longer exist upstream. Upstream replaced the imperative kubectl patches with declarative \`secretKeyRef\` env injection in deployment templates plus correct \`replicas\` defaults.

### Replaces chain

\`replaces: logicmonitor-openshift-operator.v0.3.2\`

### Tested

- \`operator-sdk bundle validate ./bundle --select-optional name=community\` passes
- \`helm lint helm-charts/lm-container/\` passes
- RBAC audit confirms operator ClusterRole is a strict superset of all child ClusterRoles in argus 15.1.0 + CSC 12.3.0 + KSM 7.2.2