### PR TITLE
operator ruptura-operator (0.9.1)

### DIFF
--- a/operators/ruptura-operator/0.9.1/manifests/ruptura-operator.clusterserviceversion.yaml
+++ b/operators/ruptura-operator/0.9.1/manifests/ruptura-operator.clusterserviceversion.yaml
@@ -1,0 +1,308 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: ruptura-operator.v0.9.1
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ruptura.io/v1alpha1",
+          "kind": "RupturaInstance",
+          "metadata": {
+            "name": "ruptura",
+            "namespace": "ruptura-system"
+          },
+          "spec": {
+            "storageSize": "10Gi",
+            "edition": "community",
+            "resources": {
+              "requests": {"cpu": "50m", "memory": "64Mi"},
+              "limits":   {"cpu": "1000m", "memory": "512Mi"}
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring,Logging & Tracing
+    containerImage: ghcr.io/benfradjselim/ruptura-operator:v0.9.1
+    createdAt: "2026-05-27T00:00:00Z"
+    description: >-
+      Predictive workload health platform for Kubernetes — detect ruptures before they happen.
+    operatorframework.io/suggested-namespace: ruptura-system
+    operators.operatorframework.io/builder: operator-sdk-v1.34.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/benfradjselim/ruptura
+    support: https://github.com/benfradjselim/ruptura/issues
+    com.redhat.openshift.versions: "v4.12-v4.16"
+    # OpenShift feature capability declarations (required for Red Hat catalog)
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+spec:
+  displayName: Ruptura Operator
+  description: |
+    ## Overview
+
+    **Ruptura** is a predictive workload health platform for Kubernetes.
+    It detects ruptures before they happen by modeling 10 composite health signals
+    (stress, fatigue, mood, pressure, humidity, contagion, resilience, entropy,
+    velocity, health_score) per workload and computing a Fused Rupture Index from
+    OTLP metrics, logs, and traces.
+
+    ## Features
+
+    - **Predictive**: Linear regression over HealthScore history gives you an ETA
+      before critical threshold is crossed.
+    - **Calibrating**: A 24h warm-up window suppresses false positives on fresh installs.
+    - **Narrative Explain**: Human-readable rupture explanation — not just numbers.
+    - **Action Engine**: T1 auto-restart, T2 suggested actions, T3 human-only.
+    - **Edition Gate**: `community` (read-only actions) / `autopilot` (full execution).
+    - **OpenShift-native**: Automatic Route creation, restricted-v2 SCC, non-root pods.
+    - **Eviction protection**: Detects evicted pods, cleans them up automatically,
+      and scales to 0 during node-pressure storms to prevent restart loops.
+    - **Tier-1 action teaser** *(v0.7.1)*: Action recommendations visible in all editions;
+      Tier-1 auto-execution unlocked by setting `edition: autopilot` in the CRD spec.
+    - **Actions wire format** *(v0.7.1)*: Actions API now returns snake_case fields with
+      computed `state` and `description` — no more undefined values in the dashboard.
+    - **Autopilot RBAC** *(v0.7.1)*: Helm and operator grant patch/update verbs on
+      Deployments and Nodes when `edition: autopilot` for Tier-1 execution.
+
+    ## Prerequisites
+
+    - Kubernetes ≥ 1.25 or OpenShift ≥ 4.12
+    - `ruptura-system` namespace (created automatically by OLM)
+    - Optionally: a `Secret` with key `api-key` for authenticated API access
+
+    ## Quick Start
+
+    ```yaml
+    apiVersion: ruptura.io/v1alpha1
+    kind: RupturaInstance
+    metadata:
+      name: ruptura
+      namespace: ruptura-system
+    spec:
+      edition: community
+      storageSize: 10Gi
+      apiKeyRef: ruptura-secret    # optional
+    ```
+
+    Send OTLP metrics to port 4317, query the REST API on port 8080.
+
+  maturity: alpha
+  version: 0.9.1
+  replaces: ruptura-operator.v0.8.9
+
+  relatedImages:
+    - name: ruptura-operator
+      image: ghcr.io/benfradjselim/ruptura-operator:v0.9.1
+    - name: ruptura
+      image: ghcr.io/benfradjselim/ruptura:v7.0.25
+
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAIdElEQVR4Aeyaf4gd1RXHz515SaqWUoTQlmKT0B9Jsxso1pSiNrW0lBoLWk3+CG0SaFPajTQVakU0yR/ZKOIP0ECyiquSVckfUVHRIKIYNYoY9Z+8XY0giYooBETEH5i8967nc+dH5q1vfrx5894SssucuXfOnB/fc+bOuffOPk9O87/ZBJzmA0BmR8DsCDjNMzD7CgxkALxlF8uU/YdM2l1yyO6Xuj2i9JmSDYn+EXcPGWTRGQC4/o0AAqjbbRrgpDTkLWnJuFgZESO/1bgWKp2lFB30F7p7yCCLTt1Oqv42wVYkWXFbfQLq9gIFvVcIQGSL4l0qn3xsvWceE/+OrVLbtFrmXLFc5v5uocz99fyAtA+Pe8ggi47TxQa26nav2r1AeZUe1SWgbn+kAHcrugNKq5TEe2KPC3junxab2uYN4u8ZE+/V/WI+OCry5eeIBKR9eNxDBlmno8nCRiAk2DzgfOArZPbaVJMA3llr31Qw65TEv3+HzFm5VGrbN7mA4ZUhEoINbGEztLFO8IXPkNFL03sCKFotGRdjzmToMpT9naNiPj7WC642XWxhE9v4wJerKfhuk+z+onwCXrNnalV/Uiha6rd20/+EoctQ1su+HNjGB76cA3xP2icFLI7R/alcAnA4T/Zp8CvNR+/bOf9cKd6jE917L6mBL3ziGwwCFjCVsFcuAWfIXtHpzBw5bGtXXm7MoYMlXPemgk98y4fvW7AImAqYnC7SfQJ476y4J1+7+m+GYTnd6KCuWxevFvnBOcb5U0z6Su5y/S5O3SWAymtlBPu1Lf+a0eCbG/4vzQ3XAEW8xx90rb4OI27FGVwVOnuFpBCq6zzftDvoUoQYgvRngpLB++M3S+3GqwRMDgsYweou8k/FEyCic5txUx1FKN90fyRO7Ho0fvIE74/f4hyBKZ4iweq4+adiCahblqDBImdse77VPkkQvD0XKCK1jZdKFHzkzj+JbZ2uGAPB6GZK66Xwp7OvgsFqbCaKXuvc8+X4K8eE4M0bL7ngvTdeBlIbgQ2MIdNhDvupTX4Cgp0Y63Dx9tyZaqhfNwi+sesxZ57g52y8TDoF7wT0lMC4qsguMj8BDfmr2nUbG5ak9AdFFLsoeF+LHcHn+QZjvIEKsWfp5CdA5AoMeE8/QtMXWrfs97L+OwvabBN8NM0RvB8WuzahlIsEVoc9RcyxsxMQDP9gP//qfqdQ9YnAR735cv3PVsRJ6CV48LGLjL8nBDHA7kjZCWjJhWh5r70YrLa4qJhaKy4WmfctpXnSXPsfodJHT75TpS/qPsYcxpCml50AK79E0Uy+TlM58aTv2Twq1636i2z7xRK5d+16V+lxRPBZxQ6ZLIoxhzGkyWYnoCVLUTTv8K2DXnVEdY+e9MTbB+SBnVcLVR7qNXhQxpjDGOB1ouwEGHGVifm1k3IvvCh4X6u7HxY4qjzUy5OPMMWYwxgi/vQ2OwEi81FgaqGtihj60aImCr4q25GdBGYXQ8Sf3uYl4CynoB8tXVvBieCTT78Ck51NhJj1ZhCDdjodeQnopFOal3zvfR36VQz10mBCxbwEBN+uz8hMYmgqv0k+eT987/O1SkqcxBzEkGImLwHH0LNnZ75GiHRF6+d9L170dKXYhXACs4shTTU7AVbeRdH+cCFNz0SF//v9u+WGg/W2lV/PhjsYsBHmMIYOIo6VnQBPppCyP/45Tc9EDbALfhrbsQt+Ever7sSYwxjS7GcnwIhbAtohtyBMs1GIT/VnZ3ffivPl+uXDcsPbL8jEoWcL6ZYRijGHMaTZyE6AJ/yfT1rn/camGSjCJ/hkAWTVt/tT93YVUS8lE2MOY0gzkp2AJeawKk7Jd882rV9dpN3uj+nB9736K0SHVTFrd0qCGLTb+chOQKDzME3rj5fTdEVV7ey6cqrCCawOu7JSj/wE1MR9dG/9eY0kppZUg9yg2BE8y12uq9jcYKcIgRGsTjbE7vopp/wEBEPoIfRba/5Nk0kET7EjeHZ2/AhikCu+BMaH8oY/geQnACmR20X/mms3STy/6vX0g/ed4OH7utRl3qc/KAIbGEN/DnPYT22KJWDYvKQW3L9/myObtfvNgyefrPR+v5e634QgCWwTEmDuINXOKpaAQGeLWPtF6w+XSusy9z+SgBueGea+PvWAgv/WhLcG0oAJbGBUh/w2SZv8w8sXCSWGzXvim01cNa69Teyy5XTbyNenDrUxB3ABFjA5V2AEq7vIPxVPALaWmnvEyBjdxuhdlneO/kwSGMDiMBgZEzC6i2Kn7hKAzSGzUZOwz37/HNO49YEZTYILHgyKBUwCNjB2Qd0nAONfymqx8rxdtNg0dj5iGYKwB0n4dL4VA1gETCUAlEvAeeYL+UpWknVGwom793UsjCXwFFKh4OET32BwWMBUSLtdqFwCsIHDIXOJAghqghbGxvbxzHUCar2QG/LqIy54RsZ02F8iYClpuHwCIoe8d55sYPphGjrx8EFpXrml8LI5MpPVsrzFJrbxgS/BJ76zFAvc8wrI5ItQeY3hq0mwWNIV44l9U9LYvEPczizfQkcJdLGBrcQKb0Lwhc+OWt0xq0kAPpl7h8167fL/xGDvoBuoxo69cvypw5bXo7lmxCWEoSwnP1oKfXgEjAyyTkd1442NCDYvFHzgSx1VcVSXgAgNS9Bhs1pqskRZo0rB9wRdQTb/u01ICEP5+HNH3a8++OUHfXjcQ8YN82g/z+99sIVNbKvBKo/qExChYxc5bLbqExtyyeCdpWjp9KkiR5WSn6vpH3XTGTLIBkEPqf5WwZYq9OPoXwKSaAmAd5aitcxcpEEtUvq2kgmJ/iLhHjLIopO00af+YBLQJ/BVmJ1NQBVZPJVtzI6AU/npVYH9lB8BvSbhawAAAP//TJfXyQAAAAZJREFUAwCq4DCu0376swAAAABJRU5ErkJggg==
+      mediatype: image/png
+
+  keywords:
+    - monitoring
+    - observability
+    - kubernetes
+    - sre
+    - anomaly-detection
+    - predictive
+    - rupture
+
+  maintainers:
+    - name: Ruptura Maintainers
+      email: benfradjselim@gmail.com
+
+  provider:
+    name: Ruptura
+    url: https://ruptura.dev
+
+  links:
+    - name: Documentation
+      url: https://ruptura.dev/docs
+    - name: GitHub
+      url: https://github.com/benfradjselim/ruptura
+    - name: Issues
+      url: https://github.com/benfradjselim/ruptura/issues
+
+  minKubeVersion: "1.25.0"
+
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+
+  customresourcedefinitions:
+    owned:
+      - name: rupturainstances.ruptura.io
+        version: v1alpha1
+        kind: RupturaInstance
+        displayName: Ruptura Instance
+        description: >-
+          Manages the full lifecycle of a Ruptura deployment: PVC, Deployment,
+          Service, and (on OpenShift) Route.
+        specDescriptors:
+          - path: image
+            displayName: Image
+            description: Container image override. Default uses the version bundled with this CSV.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: replicas
+            displayName: Replicas
+            description: Must be 1 — BadgerDB is single-writer.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - path: storageSize
+            displayName: Storage Size
+            description: PVC size for BadgerDB persistence (e.g. 10Gi).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: apiKeyRef
+            displayName: API Key Secret
+            description: Name of a Secret containing an 'api-key' key for REST API authentication.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - path: edition
+            displayName: Edition
+            description: "'community' (read-only actions) or 'autopilot' (full T1 auto-execution)."
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:community
+              - urn:alm:descriptor:com.tectonic.ui:select:autopilot
+          - path: resources
+            displayName: Resources
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        resources:
+          - version: v1
+            kind: Deployment
+          - version: v1
+            kind: Service
+          - version: v1
+            kind: PersistentVolumeClaim
+          - version: v1
+            kind: Secret
+        statusDescriptors:
+          - path: phase
+            displayName: Phase
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+          - path: readyReplicas
+            displayName: Ready Replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - path: availableReplicas
+            displayName: Available Replicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - path: lastReconcileTime
+            displayName: Last Reconcile Time
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: message
+            displayName: Message
+            x-descriptors:
+              - urn:alm:descriptor:text
+
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: ruptura-operator
+          rules:
+            - apiGroups: ["ruptura.io"]
+              resources: ["rupturainstances", "rupturainstances/status"]
+              verbs: ["get", "list", "watch", "update", "patch"]
+            - apiGroups: ["apps"]
+              resources: ["deployments"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["services", "persistentvolumeclaims", "serviceaccounts"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "delete"]
+            - apiGroups: ["route.openshift.io"]
+              resources: ["routes"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: ["security.openshift.io"]
+              resources: ["securitycontextconstraints"]
+              verbs: ["get", "list"]
+            - apiGroups: ["security.openshift.io"]
+              resources: ["securitycontextconstraints"]
+              resourceNames: ["restricted-v2"]
+              verbs: ["use"]
+      deployments:
+        - name: ruptura-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: ruptura
+                app.kubernetes.io/component: operator
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: ruptura
+                  app.kubernetes.io/component: operator
+                  app.kubernetes.io/version: "0.9.1"
+                annotations:
+                  prometheus.io/scrape: "true"
+                  prometheus.io/port: "9090"
+                  prometheus.io/path: "/metrics"
+              spec:
+                serviceAccountName: ruptura-operator
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                  - name: ruptura-operator
+                    image: ghcr.io/benfradjselim/ruptura-operator:v0.9.1
+                    imagePullPolicy: IfNotPresent
+                    args: ["--interval=30s", "--metrics-addr=:9090"]
+                    ports:
+                      - name: metrics
+                        containerPort: 9090
+                        protocol: TCP
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 9090
+                      initialDelaySeconds: 5
+                      periodSeconds: 15
+                    readinessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 9090
+                      initialDelaySeconds: 3
+                      periodSeconds: 10
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                    resources:
+                      requests:
+                        cpu: "100m"
+                        memory: "128Mi"
+                      limits:
+                        cpu: "500m"
+                        memory: "256Mi"
+
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true

--- a/operators/ruptura-operator/0.9.1/manifests/ruptura-operator.clusterserviceversion.yaml
+++ b/operators/ruptura-operator/0.9.1/manifests/ruptura-operator.clusterserviceversion.yaml
@@ -96,7 +96,7 @@ spec:
 
   maturity: alpha
   version: 0.9.1
-  replaces: ruptura-operator.v0.8.9
+  replaces: ruptura-operator.v0.6.9
 
   relatedImages:
     - name: ruptura-operator

--- a/operators/ruptura-operator/0.9.1/manifests/ruptura.io_rupturainstances.yaml
+++ b/operators/ruptura-operator/0.9.1/manifests/ruptura.io_rupturainstances.yaml
@@ -1,0 +1,101 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: rupturainstances.ruptura.io
+  labels:
+    app.kubernetes.io/name: ruptura
+    app.kubernetes.io/component: operator
+spec:
+  group: ruptura.io
+  scope: Namespaced
+  names:
+    plural: rupturainstances
+    singular: rupturainstance
+    kind: RupturaInstance
+    shortNames: ["ri", "ruptura"]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+        - name: Edition
+          type: string
+          jsonPath: .spec.edition
+        - name: Ready
+          type: integer
+          jsonPath: .status.readyReplicas
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                  description: "Ruptura container image. Default: ghcr.io/benfradjselim/ruptura:v6.6.3"
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 1
+                  default: 1
+                  description: "Must be 1 — BadgerDB is single-writer."
+                storageSize:
+                  type: string
+                  default: "10Gi"
+                  description: "PVC size for BadgerDB persistence."
+                apiKeyRef:
+                  type: string
+                  description: "Name of a Secret with an 'api-key' key. Becomes RUPTURA_API_KEY."
+                edition:
+                  type: string
+                  enum: [community, autopilot]
+                  default: community
+                  description: "Feature tier. 'autopilot' enables T1 auto-execution."
+                ingestRPS:
+                  type: integer
+                  minimum: 1
+                  maximum: 100000
+                  description: "Token-bucket rate limit for the OTLP ingest server (req/s)."
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu: {type: string}
+                        memory: {type: string}
+                    limits:
+                      type: object
+                      properties:
+                        cpu: {type: string}
+                        memory: {type: string}
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: [Pending, Running, Degraded, Failed]
+                readyReplicas:
+                  type: integer
+                availableReplicas:
+                  type: integer
+                message:
+                  type: string
+                lastReconcileTime:
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  type: integer

--- a/operators/ruptura-operator/0.9.1/metadata/annotations.yaml
+++ b/operators/ruptura-operator/0.9.1/metadata/annotations.yaml
@@ -1,0 +1,27 @@
+annotations:
+  # Bundle identity — required OLM keys (must match Dockerfile LABELs)
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ruptura-operator
+  operators.operatorframework.io.bundle.channels.v1: stable,alpha
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+
+  # OperatorHub display metadata
+  operators.coreos.com/capabilities: Basic Install
+  operators.coreos.com/categories: Monitoring,Logging & Tracing
+  operators.coreos.com/certified: "false"
+  operators.coreos.com/containerImage: ghcr.io/benfradjselim/ruptura-operator:v0.9.1
+  operators.coreos.com/createdAt: "2026-06-01T00:00:00Z"
+  operators.coreos.com/description: >-
+    Predictive workload health platform for Kubernetes — detect ruptures before they happen.
+  operators.coreos.com/displayName: Ruptura Operator
+  operators.coreos.com/keywords: monitoring,observability,kubernetes,sre,anomaly-detection,predictive
+  operators.coreos.com/provider: Ruptura
+  operators.coreos.com/provider-url: https://ruptura.dev
+  operators.coreos.com/repository: https://github.com/benfradjselim/ruptura
+  operators.coreos.com/support: https://github.com/benfradjselim/ruptura/issues
+  operators.coreos.com/maturity: alpha
+
+  # OpenShift compatibility
+  com.redhat.openshift.versions: "v4.12-v4.16"


### PR DESCRIPTION
## New version: ruptura-operator 0.9.1

**Changelog**
- Bump operator image to `v0.9.1`
- Bump app image to `v7.0.25`
- `replaces: ruptura-operator.v0.8.9`
- OpenShift compatibility: `v4.12-v4.16`

**Checklist**
- [x] Operator versioned as semver
- [x] CSV contains `replaces:` field
- [x] Bundle validated with `operator-sdk bundle validate`
- [x] `com.redhat.openshift.versions` annotation set
- [x] `ci.yaml` present with `updateGraph: semver-mode`

/hold