### PR TITLE
operator apicurio-registry-3 (3.2.5) - fix channel annotations

### DIFF
--- a/operators/apicurio-registry-3/3.2.5/bundle.Dockerfile
+++ b/operators/apicurio-registry-3/3.2.5/bundle.Dockerfile
@@ -6,8 +6,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=apicurio-registry-3
-LABEL operators.operatorframework.io.bundle.channels.v1=3.2.x
-LABEL operators.operatorframework.io.bundle.channel.default.v1=3.2.x
+LABEL operators.operatorframework.io.bundle.channels.v1=3.x,3.2.x
+LABEL operators.operatorframework.io.bundle.channel.default.v1=3.x
 
 COPY target/bundle/apicurio-registry-3/3.2.5/manifests /manifests/
 COPY target/bundle/apicurio-registry-3/3.2.5/metadata /metadata/

--- a/operators/apicurio-registry-3/3.2.5/metadata/annotations.yaml
+++ b/operators/apicurio-registry-3/3.2.5/metadata/annotations.yaml
@@ -1,7 +1,7 @@
 annotations:
   com.redhat.openshift.versions: v4.12
-  operators.operatorframework.io.bundle.channel.default.v1: 3.2.x
-  operators.operatorframework.io.bundle.channels.v1: 3.2.x
+  operators.operatorframework.io.bundle.channel.default.v1: 3.x
+  operators.operatorframework.io.bundle.channels.v1: 3.x,3.2.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
## Summary

The 3.2.5 bundle was accidentally published with only the `3.2.x` channel (`channels.v1: 3.2.x`), removing it from the rolling `3.x` channel. This broke the `3.x` upgrade chain:

- `3.2.4` (in `3.x`) → `3.2.5` (only in `3.2.x`) → `3.3.0` (in `3.x,3.3.x`)

This causes a **dangling bundle** error for `3.2.4` in the `3.x` channel, blocking the [3.3.0 submission (PR #9961)](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/9961).

## Changes

- Add `3.x` back to `channels.v1` → `3.x,3.2.x` (in both `annotations.yaml` and `bundle.Dockerfile`)
- Restore `channel.default.v1` to `3.x` (new installations should default to the rolling channel)

This restores the `3.x` upgrade path (`3.2.4 → 3.2.5 → 3.3.0`) while keeping `3.2.5` in the new `3.2.x` channel for users who want to pin to a specific minor version stream.

## Why this modifies an existing bundle

We understand that existing bundles are normally immutable. This is a metadata-only fix (channel annotations) — no manifests, CSVs, or CRDs are changed. The bundle image content is identical. Without this fix, the `3.x` channel is broken and the 3.3.0 release cannot be published.

**We kindly request maintainers to apply the appropriate override labels to allow this modification.**

## References

- Blocked PR: #9961
- Multi-channel OLM design: https://github.com/Apicurio/apicurio-registry/issues/7742
- Precedent: OpenShift GitOps uses the same multi-channel pattern (`latest,gitops-1.16`)