### PR TITLE
Catalog update [openshift-integration-operator] [v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.19/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.19/openshift-integration-operator/catalog.yaml
@@ -5,6 +5,10 @@ schema: olm.package
 ---
 entries:
 - name: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.4.1
+  replaces: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.6.6
+  replaces: openshift-integration-operator.v0.4.1
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -22,6 +26,164 @@ properties:
   value:
     packageName: openshift-integration-operator
     version: 0.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+name: openshift-integration-operator.v0.4.1
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.1
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
+name: openshift-integration-operator.v0.6.6
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.6.6
 - type: olm.csv.metadata
   value:
     annotations:
@@ -82,9 +244,9 @@ properties:
         ]
       capabilities: Basic Install
       categories: Integration & Delivery
-      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
       createdAt: "2026-06-08T18:00:00Z"
-      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually, deploy with GitOps, observe in real time. Apache Camel + SonataFlow with Kaoto designer, GitOps, MCP/AI, and OpenTelemetry observability
       operatorframework.io/suggested-namespace: openshift-integration
       operators.operatorframework.io/builder: operator-sdk-v1.40.0
       operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
@@ -100,49 +262,6 @@ properties:
         kind: IntegrationFlow
         name: integrationflows.platform.io
         version: v1alpha1
-    description: |
-      ## OpenShift Integration Operator
-
-      Real-Time Integration & Orchestration Platform for OpenShift that brings
-      **Apache Camel** and **SonataFlow** workflows together with a visual
-      **Kaoto** designer, **GitOps** deployment (Tekton + ArgoCD), **MCP/AI**
-      integration, and **OpenTelemetry** observability.
-
-      ### Features
-
-      * **Single CRD** — `IntegrationFlow` manages the full lifecycle of
-        integration workflows across engines and deployment modes
-      * **Five integration types** — Camel Route, Kamelet, Pipe, Test,
-        and SonataFlow
-      * **Ephemeral Quick Try** — deploy flows instantly without Git using
-        domain-specific worker images with configurable TTL
-      * **GitOps pipeline** — automated scaffolding, Tekton builds, and
-        ArgoCD multi-cluster deployment
-      * **Visual design** — embedded Kaoto designer for drag-and-drop
-        flow creation
-      * **OpenShift Console plugin** — integrated dashboard for flow
-        management, live logs, and telemetry
-      * **MCP Bridge** — AI tool discovery and invocation for integration
-        flows
-      * **Resilience** — declarative retry policies and circuit breaker
-        configuration
-      * **Observability** — OpenTelemetry tracing/metrics and
-        PrometheusRule auto-generation
-
-      ### Prerequisites
-
-      * OpenShift 4.19+
-      * Red Hat OpenShift Pipelines (Tekton)
-      * Red Hat OpenShift GitOps (ArgoCD)
-      * Camel K Operator (optional, for Kamelet/Pipe types)
-      * OpenShift Serverless Logic (optional, for SonataFlow types)
-
-      ### Getting Started
-
-      1. Install the operator from OperatorHub
-      2. Create an IntegrationFlow CR with your Camel or SonataFlow design
-      3. The operator scaffolds, builds, and deploys your integration automatically
-      4. Monitor via the OpenShift Console plugin or `oc get integrationflows`
     displayName: OpenShift Integration Operator
     installModes:
     - supported: true
@@ -171,8 +290,6 @@ properties:
       url: https://maximilianopizarro.github.io/openshift-integration-operator/
     - name: Source Code
       url: https://github.com/maximilianoPizarro/openshift-integration-operator
-    - name: Helm Chart
-      url: https://maximilianopizarro.github.io/openshift-integration-operator/
     maintainers:
     - email: maximiliano.pizarro.5@gmail.com
       name: Maximiliano Pizarro
@@ -182,10 +299,14 @@ properties:
       name: maximilianoPizarro
       url: https://github.com/maximilianoPizarro
 relatedImages:
-- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.20/openshift-integration-operator/catalog.yaml
@@ -5,6 +5,10 @@ schema: olm.package
 ---
 entries:
 - name: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.4.1
+  replaces: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.6.6
+  replaces: openshift-integration-operator.v0.4.1
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -22,6 +26,164 @@ properties:
   value:
     packageName: openshift-integration-operator
     version: 0.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+name: openshift-integration-operator.v0.4.1
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.1
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
+name: openshift-integration-operator.v0.6.6
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.6.6
 - type: olm.csv.metadata
   value:
     annotations:
@@ -82,9 +244,9 @@ properties:
         ]
       capabilities: Basic Install
       categories: Integration & Delivery
-      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
       createdAt: "2026-06-08T18:00:00Z"
-      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually, deploy with GitOps, observe in real time. Apache Camel + SonataFlow with Kaoto designer, GitOps, MCP/AI, and OpenTelemetry observability
       operatorframework.io/suggested-namespace: openshift-integration
       operators.operatorframework.io/builder: operator-sdk-v1.40.0
       operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
@@ -100,49 +262,6 @@ properties:
         kind: IntegrationFlow
         name: integrationflows.platform.io
         version: v1alpha1
-    description: |
-      ## OpenShift Integration Operator
-
-      Real-Time Integration & Orchestration Platform for OpenShift that brings
-      **Apache Camel** and **SonataFlow** workflows together with a visual
-      **Kaoto** designer, **GitOps** deployment (Tekton + ArgoCD), **MCP/AI**
-      integration, and **OpenTelemetry** observability.
-
-      ### Features
-
-      * **Single CRD** — `IntegrationFlow` manages the full lifecycle of
-        integration workflows across engines and deployment modes
-      * **Five integration types** — Camel Route, Kamelet, Pipe, Test,
-        and SonataFlow
-      * **Ephemeral Quick Try** — deploy flows instantly without Git using
-        domain-specific worker images with configurable TTL
-      * **GitOps pipeline** — automated scaffolding, Tekton builds, and
-        ArgoCD multi-cluster deployment
-      * **Visual design** — embedded Kaoto designer for drag-and-drop
-        flow creation
-      * **OpenShift Console plugin** — integrated dashboard for flow
-        management, live logs, and telemetry
-      * **MCP Bridge** — AI tool discovery and invocation for integration
-        flows
-      * **Resilience** — declarative retry policies and circuit breaker
-        configuration
-      * **Observability** — OpenTelemetry tracing/metrics and
-        PrometheusRule auto-generation
-
-      ### Prerequisites
-
-      * OpenShift 4.19+
-      * Red Hat OpenShift Pipelines (Tekton)
-      * Red Hat OpenShift GitOps (ArgoCD)
-      * Camel K Operator (optional, for Kamelet/Pipe types)
-      * OpenShift Serverless Logic (optional, for SonataFlow types)
-
-      ### Getting Started
-
-      1. Install the operator from OperatorHub
-      2. Create an IntegrationFlow CR with your Camel or SonataFlow design
-      3. The operator scaffolds, builds, and deploys your integration automatically
-      4. Monitor via the OpenShift Console plugin or `oc get integrationflows`
     displayName: OpenShift Integration Operator
     installModes:
     - supported: true
@@ -171,8 +290,6 @@ properties:
       url: https://maximilianopizarro.github.io/openshift-integration-operator/
     - name: Source Code
       url: https://github.com/maximilianoPizarro/openshift-integration-operator
-    - name: Helm Chart
-      url: https://maximilianopizarro.github.io/openshift-integration-operator/
     maintainers:
     - email: maximiliano.pizarro.5@gmail.com
       name: Maximiliano Pizarro
@@ -182,10 +299,14 @@ properties:
       name: maximilianoPizarro
       url: https://github.com/maximilianoPizarro
 relatedImages:
-- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.21/openshift-integration-operator/catalog.yaml
@@ -5,6 +5,10 @@ schema: olm.package
 ---
 entries:
 - name: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.4.1
+  replaces: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.6.6
+  replaces: openshift-integration-operator.v0.4.1
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -22,6 +26,164 @@ properties:
   value:
     packageName: openshift-integration-operator
     version: 0.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+name: openshift-integration-operator.v0.4.1
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.1
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
+name: openshift-integration-operator.v0.6.6
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.6.6
 - type: olm.csv.metadata
   value:
     annotations:
@@ -82,9 +244,9 @@ properties:
         ]
       capabilities: Basic Install
       categories: Integration & Delivery
-      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
       createdAt: "2026-06-08T18:00:00Z"
-      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually, deploy with GitOps, observe in real time. Apache Camel + SonataFlow with Kaoto designer, GitOps, MCP/AI, and OpenTelemetry observability
       operatorframework.io/suggested-namespace: openshift-integration
       operators.operatorframework.io/builder: operator-sdk-v1.40.0
       operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
@@ -100,49 +262,6 @@ properties:
         kind: IntegrationFlow
         name: integrationflows.platform.io
         version: v1alpha1
-    description: |
-      ## OpenShift Integration Operator
-
-      Real-Time Integration & Orchestration Platform for OpenShift that brings
-      **Apache Camel** and **SonataFlow** workflows together with a visual
-      **Kaoto** designer, **GitOps** deployment (Tekton + ArgoCD), **MCP/AI**
-      integration, and **OpenTelemetry** observability.
-
-      ### Features
-
-      * **Single CRD** — `IntegrationFlow` manages the full lifecycle of
-        integration workflows across engines and deployment modes
-      * **Five integration types** — Camel Route, Kamelet, Pipe, Test,
-        and SonataFlow
-      * **Ephemeral Quick Try** — deploy flows instantly without Git using
-        domain-specific worker images with configurable TTL
-      * **GitOps pipeline** — automated scaffolding, Tekton builds, and
-        ArgoCD multi-cluster deployment
-      * **Visual design** — embedded Kaoto designer for drag-and-drop
-        flow creation
-      * **OpenShift Console plugin** — integrated dashboard for flow
-        management, live logs, and telemetry
-      * **MCP Bridge** — AI tool discovery and invocation for integration
-        flows
-      * **Resilience** — declarative retry policies and circuit breaker
-        configuration
-      * **Observability** — OpenTelemetry tracing/metrics and
-        PrometheusRule auto-generation
-
-      ### Prerequisites
-
-      * OpenShift 4.19+
-      * Red Hat OpenShift Pipelines (Tekton)
-      * Red Hat OpenShift GitOps (ArgoCD)
-      * Camel K Operator (optional, for Kamelet/Pipe types)
-      * OpenShift Serverless Logic (optional, for SonataFlow types)
-
-      ### Getting Started
-
-      1. Install the operator from OperatorHub
-      2. Create an IntegrationFlow CR with your Camel or SonataFlow design
-      3. The operator scaffolds, builds, and deploys your integration automatically
-      4. Monitor via the OpenShift Console plugin or `oc get integrationflows`
     displayName: OpenShift Integration Operator
     installModes:
     - supported: true
@@ -171,8 +290,6 @@ properties:
       url: https://maximilianopizarro.github.io/openshift-integration-operator/
     - name: Source Code
       url: https://github.com/maximilianoPizarro/openshift-integration-operator
-    - name: Helm Chart
-      url: https://maximilianopizarro.github.io/openshift-integration-operator/
     maintainers:
     - email: maximiliano.pizarro.5@gmail.com
       name: Maximiliano Pizarro
@@ -182,10 +299,14 @@ properties:
       name: maximilianoPizarro
       url: https://github.com/maximilianoPizarro
 relatedImages:
-- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.22/openshift-integration-operator/catalog.yaml
@@ -5,6 +5,10 @@ schema: olm.package
 ---
 entries:
 - name: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.4.1
+  replaces: openshift-integration-operator.v0.4.0
+- name: openshift-integration-operator.v0.6.6
+  replaces: openshift-integration-operator.v0.4.1
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -22,6 +26,164 @@ properties:
   value:
     packageName: openshift-integration-operator
     version: 0.4.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+name: openshift-integration-operator.v0.4.1
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.4.1
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          }
+        ]
+      capabilities: Basic Install
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+      createdAt: "2026-06-08T18:00:00Z"
+      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.1
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.1
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
+name: openshift-integration-operator.v0.6.6
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.6.6
 - type: olm.csv.metadata
   value:
     annotations:
@@ -82,9 +244,9 @@ properties:
         ]
       capabilities: Basic Install
       categories: Integration & Delivery
-      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
       createdAt: "2026-06-08T18:00:00Z"
-      description: Real-Time Integration & Orchestration Platform for OpenShift — Apache Camel + SonataFlow with visual Kaoto designer, GitOps, MCP/AI integration, and OpenTelemetry observability
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually, deploy with GitOps, observe in real time. Apache Camel + SonataFlow with Kaoto designer, GitOps, MCP/AI, and OpenTelemetry observability
       operatorframework.io/suggested-namespace: openshift-integration
       operators.operatorframework.io/builder: operator-sdk-v1.40.0
       operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
@@ -100,49 +262,6 @@ properties:
         kind: IntegrationFlow
         name: integrationflows.platform.io
         version: v1alpha1
-    description: |
-      ## OpenShift Integration Operator
-
-      Real-Time Integration & Orchestration Platform for OpenShift that brings
-      **Apache Camel** and **SonataFlow** workflows together with a visual
-      **Kaoto** designer, **GitOps** deployment (Tekton + ArgoCD), **MCP/AI**
-      integration, and **OpenTelemetry** observability.
-
-      ### Features
-
-      * **Single CRD** — `IntegrationFlow` manages the full lifecycle of
-        integration workflows across engines and deployment modes
-      * **Five integration types** — Camel Route, Kamelet, Pipe, Test,
-        and SonataFlow
-      * **Ephemeral Quick Try** — deploy flows instantly without Git using
-        domain-specific worker images with configurable TTL
-      * **GitOps pipeline** — automated scaffolding, Tekton builds, and
-        ArgoCD multi-cluster deployment
-      * **Visual design** — embedded Kaoto designer for drag-and-drop
-        flow creation
-      * **OpenShift Console plugin** — integrated dashboard for flow
-        management, live logs, and telemetry
-      * **MCP Bridge** — AI tool discovery and invocation for integration
-        flows
-      * **Resilience** — declarative retry policies and circuit breaker
-        configuration
-      * **Observability** — OpenTelemetry tracing/metrics and
-        PrometheusRule auto-generation
-
-      ### Prerequisites
-
-      * OpenShift 4.19+
-      * Red Hat OpenShift Pipelines (Tekton)
-      * Red Hat OpenShift GitOps (ArgoCD)
-      * Camel K Operator (optional, for Kamelet/Pipe types)
-      * OpenShift Serverless Logic (optional, for SonataFlow types)
-
-      ### Getting Started
-
-      1. Install the operator from OperatorHub
-      2. Create an IntegrationFlow CR with your Camel or SonataFlow design
-      3. The operator scaffolds, builds, and deploys your integration automatically
-      4. Monitor via the OpenShift Console plugin or `oc get integrationflows`
     displayName: OpenShift Integration Operator
     installModes:
     - supported: true
@@ -171,8 +290,6 @@ properties:
       url: https://maximilianopizarro.github.io/openshift-integration-operator/
     - name: Source Code
       url: https://github.com/maximilianoPizarro/openshift-integration-operator
-    - name: Helm Chart
-      url: https://maximilianopizarro.github.io/openshift-integration-operator/
     maintainers:
     - email: maximiliano.pizarro.5@gmail.com
       name: Maximiliano Pizarro
@@ -182,10 +299,14 @@ properties:
       name: maximilianoPizarro
       url: https://github.com/maximilianoPizarro
 relatedImages:
-- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.4.0
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.6.6
   name: ""
-- image: quay.io/maximilianopizarro/integration-console-plugin:v0.4.0
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
   name: ""
 schema: olm.bundle


### PR DESCRIPTION
## Summary

Update FBC (File-Based Catalog) entries for `openshift-integration-operator` adding all released versions to the catalog upgrade graph.

**Upgrade path:** `0.4.0` → `0.4.1` → `0.6.6`

**Catalogs updated:** v4.19, v4.20, v4.21, v4.22

## Context

The bundle images for versions 0.4.0, 0.4.1, and 0.6.6 were released via previous PRs:
- PR #9962 — released bundle 0.4.0
- PR #10062 — released bundle 0.4.1
- PR #10107 — released bundle 0.6.6

All three PRs were merged successfully, but the operator-release-pipeline only published the bundle images without adding them to the FBC catalog. As the pipeline message stated:

> "Operator bundle using FBC mode has been released. To add bundle to FBC templates, follow this guide to create a new PR with catalog changes."

This PR completes the publication by updating `catalog.yaml` with all three bundle entries in the `alpha` channel using `replaces` to define the upgrade graph.

## Bundle Images

- `quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.0`
- `quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.4.1`
- `quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.6.6`


Made with [Cursor](https://cursor.com)