### PR TITLE
Catalog update [openshift-integration-operator] [v4.19,v4.20,v4.21,v4.22]

### DIFF
--- a/catalogs/v4.19/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.19/openshift-integration-operator/catalog.yaml
@@ -9,6 +9,8 @@ entries:
   replaces: openshift-integration-operator.v0.4.0
 - name: openshift-integration-operator.v0.6.6
   replaces: openshift-integration-operator.v0.4.1
+- name: openshift-integration-operator.v0.7.0
+  replaces: openshift-integration-operator.v0.6.6
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -308,5 +310,159 @@ relatedImages:
 - image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
   name: ""
 - image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+name: openshift-integration-operator.v0.7.0
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-ephemeral"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "deploymentMode": "EPHEMERAL",
+              "kaotoDesign": "- route:\n    id: quick-try\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 10000\n      steps:\n        - log:\n            message: \"Ephemeral quick-try flow\"\n",
+              "ephemeral": {
+                "ttlSeconds": 3600
+              }
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-sonataflow"
+            },
+            "spec": {
+              "engine": "SONATAFLOW",
+              "integrationType": "SONATAFLOW",
+              "gitRepository": "https://gitea.example.com/user1/sample-sonataflow.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "id: greeting\nversion: '1.0'\nspecVersion: '0.8'\nname: Greeting Workflow\nstart: GreetPerson\nstates:\n  - name: GreetPerson\n    type: operation\n    actions:\n      - name: greetAction\n        functionRef:\n          refName: greetFunction\n          arguments:\n            name: .name\n    end: true\nfunctions:\n  - name: greetFunction\n    operation: sysout\n    type: custom\n"
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+      createdAt: "2026-06-15T18:00:00Z"
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually with Kaoto, deploy with GitOps (Tekton + ArgoCD), observe in real time with OpenTelemetry. Open-source Kubernetes-native alternative to n8n for integration workflows.
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+      console.openshift.io/plugins: '["integration-console-plugin"]'
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - integration
+    - camel
+    - apache-camel
+    - sonataflow
+    - kaoto
+    - workflow
+    - gitops
+    - openshift
+    - tekton
+    - argocd
+    - mcp
+    - opentelemetry
+    links:
+    - name: Documentation
+      url: https://maximilianopizarro.github.io/openshift-integration-operator/
+    - name: Source Code
+      url: https://github.com/maximilianoPizarro/openshift-integration-operator
+    maintainers:
+    - email: maximiliano.pizarro.5@gmail.com
+      name: Maximiliano Pizarro
+    maturity: alpha
+    minKubeVersion: 1.32.0
+    nativeAPIs:
+    - group: apps
+      kind: Deployment
+      version: v1
+    - group: ""
+      kind: Service
+      version: v1
+    - group: route.openshift.io
+      kind: Route
+      version: v1
+    - group: console.openshift.io
+      kind: ConsolePlugin
+      version: v1
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.7.0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.20/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.20/openshift-integration-operator/catalog.yaml
@@ -9,6 +9,8 @@ entries:
   replaces: openshift-integration-operator.v0.4.0
 - name: openshift-integration-operator.v0.6.6
   replaces: openshift-integration-operator.v0.4.1
+- name: openshift-integration-operator.v0.7.0
+  replaces: openshift-integration-operator.v0.6.6
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -308,5 +310,159 @@ relatedImages:
 - image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
   name: ""
 - image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+name: openshift-integration-operator.v0.7.0
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-ephemeral"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "deploymentMode": "EPHEMERAL",
+              "kaotoDesign": "- route:\n    id: quick-try\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 10000\n      steps:\n        - log:\n            message: \"Ephemeral quick-try flow\"\n",
+              "ephemeral": {
+                "ttlSeconds": 3600
+              }
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-sonataflow"
+            },
+            "spec": {
+              "engine": "SONATAFLOW",
+              "integrationType": "SONATAFLOW",
+              "gitRepository": "https://gitea.example.com/user1/sample-sonataflow.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "id: greeting\nversion: '1.0'\nspecVersion: '0.8'\nname: Greeting Workflow\nstart: GreetPerson\nstates:\n  - name: GreetPerson\n    type: operation\n    actions:\n      - name: greetAction\n        functionRef:\n          refName: greetFunction\n          arguments:\n            name: .name\n    end: true\nfunctions:\n  - name: greetFunction\n    operation: sysout\n    type: custom\n"
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+      createdAt: "2026-06-15T18:00:00Z"
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually with Kaoto, deploy with GitOps (Tekton + ArgoCD), observe in real time with OpenTelemetry. Open-source Kubernetes-native alternative to n8n for integration workflows.
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+      console.openshift.io/plugins: '["integration-console-plugin"]'
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - integration
+    - camel
+    - apache-camel
+    - sonataflow
+    - kaoto
+    - workflow
+    - gitops
+    - openshift
+    - tekton
+    - argocd
+    - mcp
+    - opentelemetry
+    links:
+    - name: Documentation
+      url: https://maximilianopizarro.github.io/openshift-integration-operator/
+    - name: Source Code
+      url: https://github.com/maximilianoPizarro/openshift-integration-operator
+    maintainers:
+    - email: maximiliano.pizarro.5@gmail.com
+      name: Maximiliano Pizarro
+    maturity: alpha
+    minKubeVersion: 1.32.0
+    nativeAPIs:
+    - group: apps
+      kind: Deployment
+      version: v1
+    - group: ""
+      kind: Service
+      version: v1
+    - group: route.openshift.io
+      kind: Route
+      version: v1
+    - group: console.openshift.io
+      kind: ConsolePlugin
+      version: v1
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.7.0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.21/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.21/openshift-integration-operator/catalog.yaml
@@ -9,6 +9,8 @@ entries:
   replaces: openshift-integration-operator.v0.4.0
 - name: openshift-integration-operator.v0.6.6
   replaces: openshift-integration-operator.v0.4.1
+- name: openshift-integration-operator.v0.7.0
+  replaces: openshift-integration-operator.v0.6.6
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -308,5 +310,159 @@ relatedImages:
 - image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
   name: ""
 - image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+name: openshift-integration-operator.v0.7.0
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-ephemeral"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "deploymentMode": "EPHEMERAL",
+              "kaotoDesign": "- route:\n    id: quick-try\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 10000\n      steps:\n        - log:\n            message: \"Ephemeral quick-try flow\"\n",
+              "ephemeral": {
+                "ttlSeconds": 3600
+              }
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-sonataflow"
+            },
+            "spec": {
+              "engine": "SONATAFLOW",
+              "integrationType": "SONATAFLOW",
+              "gitRepository": "https://gitea.example.com/user1/sample-sonataflow.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "id: greeting\nversion: '1.0'\nspecVersion: '0.8'\nname: Greeting Workflow\nstart: GreetPerson\nstates:\n  - name: GreetPerson\n    type: operation\n    actions:\n      - name: greetAction\n        functionRef:\n          refName: greetFunction\n          arguments:\n            name: .name\n    end: true\nfunctions:\n  - name: greetFunction\n    operation: sysout\n    type: custom\n"
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+      createdAt: "2026-06-15T18:00:00Z"
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually with Kaoto, deploy with GitOps (Tekton + ArgoCD), observe in real time with OpenTelemetry. Open-source Kubernetes-native alternative to n8n for integration workflows.
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+      console.openshift.io/plugins: '["integration-console-plugin"]'
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - integration
+    - camel
+    - apache-camel
+    - sonataflow
+    - kaoto
+    - workflow
+    - gitops
+    - openshift
+    - tekton
+    - argocd
+    - mcp
+    - opentelemetry
+    links:
+    - name: Documentation
+      url: https://maximilianopizarro.github.io/openshift-integration-operator/
+    - name: Source Code
+      url: https://github.com/maximilianoPizarro/openshift-integration-operator
+    maintainers:
+    - email: maximiliano.pizarro.5@gmail.com
+      name: Maximiliano Pizarro
+    maturity: alpha
+    minKubeVersion: 1.32.0
+    nativeAPIs:
+    - group: apps
+      kind: Deployment
+      version: v1
+    - group: ""
+      kind: Service
+      version: v1
+    - group: route.openshift.io
+      kind: Route
+      version: v1
+    - group: console.openshift.io
+      kind: ConsolePlugin
+      version: v1
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.7.0
   name: ""
 schema: olm.bundle

--- a/catalogs/v4.22/openshift-integration-operator/catalog.yaml
+++ b/catalogs/v4.22/openshift-integration-operator/catalog.yaml
@@ -9,6 +9,8 @@ entries:
   replaces: openshift-integration-operator.v0.4.0
 - name: openshift-integration-operator.v0.6.6
   replaces: openshift-integration-operator.v0.4.1
+- name: openshift-integration-operator.v0.7.0
+  replaces: openshift-integration-operator.v0.6.6
 name: alpha
 package: openshift-integration-operator
 schema: olm.channel
@@ -308,5 +310,159 @@ relatedImages:
 - image: quay.io/maximilianopizarro/camel-worker-core:v0.6.6
   name: ""
 - image: quay.io/maximilianopizarro/camel-worker-full:v0.6.6
+  name: ""
+schema: olm.bundle
+---
+image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+name: openshift-integration-operator.v0.7.0
+package: openshift-integration-operator
+properties:
+- type: olm.gvk
+  value:
+    group: platform.io
+    kind: IntegrationFlow
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: openshift-integration-operator
+    version: 0.7.0
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-camel-route"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "gitRepository": "https://gitea.example.com/user1/sample-camel-worker.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "- route:\n    id: sample-route\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 5000\n      steps:\n        - log:\n            message: \"Hello from IntegrationFlow\"\n"
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-ephemeral"
+            },
+            "spec": {
+              "engine": "CAMEL",
+              "integrationType": "CAMEL_ROUTE",
+              "deploymentMode": "EPHEMERAL",
+              "kaotoDesign": "- route:\n    id: quick-try\n    from:\n      uri: \"timer:tick\"\n      parameters:\n        period: 10000\n      steps:\n        - log:\n            message: \"Ephemeral quick-try flow\"\n",
+              "ephemeral": {
+                "ttlSeconds": 3600
+              }
+            }
+          },
+          {
+            "apiVersion": "platform.io/v1alpha1",
+            "kind": "IntegrationFlow",
+            "metadata": {
+              "name": "sample-sonataflow"
+            },
+            "spec": {
+              "engine": "SONATAFLOW",
+              "integrationType": "SONATAFLOW",
+              "gitRepository": "https://gitea.example.com/user1/sample-sonataflow.git",
+              "branch": "main",
+              "targeting": {
+                "strategy": "explicit",
+                "clusters": ["local"]
+              },
+              "kaotoDesign": "id: greeting\nversion: '1.0'\nspecVersion: '0.8'\nname: Greeting Workflow\nstart: GreetPerson\nstates:\n  - name: GreetPerson\n    type: operation\n    actions:\n      - name: greetAction\n        functionRef:\n          refName: greetFunction\n          arguments:\n            name: .name\n    end: true\nfunctions:\n  - name: greetFunction\n    operation: sysout\n    type: custom\n"
+            }
+          }
+        ]
+      capabilities: Full Lifecycle
+      categories: Integration & Delivery
+      containerImage: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+      createdAt: "2026-06-15T18:00:00Z"
+      description: The missing lifecycle layer for Apache Camel on OpenShift — design visually with Kaoto, deploy with GitOps (Tekton + ArgoCD), observe in real time with OpenTelemetry. Open-source Kubernetes-native alternative to n8n for integration workflows.
+      operatorframework.io/suggested-namespace: openshift-integration
+      operators.operatorframework.io/builder: operator-sdk-v1.40.0
+      operators.operatorframework.io/project_layout: quarkus.javaoperatorsdk.io/v1-alpha
+      repository: https://github.com/maximilianoPizarro/openshift-integration-operator
+      support: Community
+      console.openshift.io/plugins: '["integration-console-plugin"]'
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: IntegrationFlow defines an integration workflow using Apache Camel
+          or SonataFlow engine with visual Kaoto design, GitOps deployment via Tekton
+          and ArgoCD, ephemeral Quick Try mode, and OpenTelemetry observability.
+        displayName: Integration Flow
+        kind: IntegrationFlow
+        name: integrationflows.platform.io
+        version: v1alpha1
+    displayName: OpenShift Integration Operator
+    installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - integration
+    - camel
+    - apache-camel
+    - sonataflow
+    - kaoto
+    - workflow
+    - gitops
+    - openshift
+    - tekton
+    - argocd
+    - mcp
+    - opentelemetry
+    links:
+    - name: Documentation
+      url: https://maximilianopizarro.github.io/openshift-integration-operator/
+    - name: Source Code
+      url: https://github.com/maximilianoPizarro/openshift-integration-operator
+    maintainers:
+    - email: maximiliano.pizarro.5@gmail.com
+      name: Maximiliano Pizarro
+    maturity: alpha
+    minKubeVersion: 1.32.0
+    nativeAPIs:
+    - group: apps
+      kind: Deployment
+      version: v1
+    - group: ""
+      kind: Service
+      version: v1
+    - group: route.openshift.io
+      kind: Route
+      version: v1
+    - group: console.openshift.io
+      kind: ConsolePlugin
+      version: v1
+    provider:
+      name: maximilianoPizarro
+      url: https://github.com/maximilianoPizarro
+relatedImages:
+- image: quay.io/community-operator-pipeline-prod/openshift-integration-operator:0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/openshift-integration-operator:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/integration-console-plugin:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-core:v0.7.0
+  name: ""
+- image: quay.io/maximilianopizarro/camel-worker-full:v0.7.0
   name: ""
 schema: olm.bundle


### PR DESCRIPTION
## Summary

Add openshift-integration-operator v0.7.0 to FBC catalogs (v4.19-v4.22).

This is the FBC catalog follow-up after the bundle PR #10033 was merged.

### Changes
- Added `openshift-integration-operator.v0.7.0` entry to the alpha channel with `replaces: v0.6.6`
- New olm.bundle entry with enhanced metadata:
  - Full Lifecycle capabilities
  - nativeAPIs (Deployments, Services, Routes, ConsolePlugins)
  - console.openshift.io/plugins annotation
  - Expanded description
  - Links and keywords
  - Updated container images (v0.7.0)

Made with [Cursor](https://cursor.com)