### PR TITLE
openshift-integration-operator (0.7.0): add release-config.yaml for FBC autorelease

### DIFF
--- a/operators/openshift-integration-operator/0.7.0/release-config.yaml
+++ b/operators/openshift-integration-operator/0.7.0/release-config.yaml
@@ -1,0 +1,5 @@
+---
+catalog_templates:
+  - template_name: semver.yaml
+    channels:
+      - Candidate


### PR DESCRIPTION
## Summary

- Add `release-config.yaml` to the v0.7.0 bundle directory to enable FBC autorelease

## Motivation

This configures the operator-pipelines FBC autorelease feature so that future bundle merges will automatically generate catalog PRs. This is the bundle-side counterpart to the catalog configuration in PR #10056.

## Test plan

- [ ] CI pipeline passes (bundle validation)
- [ ] Verify pipeline recognizes release-config.yaml for future autorelease


Made with [Cursor](https://cursor.com)