### PR TITLE
operator kubernaut-operator (1.5.2)

### DIFF
--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubernaut-operator
+    control-plane: controller-manager
+  name: kubernaut-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: kubernaut-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-kubernaut-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-kubernaut-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubernaut-operator
+  name: kubernaut-operator-kubernaut-admin-role
+rules:
+- apiGroups:
+  - kubernaut.ai
+  resources:
+  - kubernauts
+  verbs:
+  - '*'
+- apiGroups:
+  - kubernaut.ai
+  resources:
+  - kubernauts/status
+  verbs:
+  - get

--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-kubernaut-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-kubernaut-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubernaut-operator
+  name: kubernaut-operator-kubernaut-editor-role
+rules:
+- apiGroups:
+  - kubernaut.ai
+  resources:
+  - kubernauts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubernaut.ai
+  resources:
+  - kubernauts/status
+  verbs:
+  - get

--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-kubernaut-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-kubernaut-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kubernaut-operator
+  name: kubernaut-operator-kubernaut-viewer-role
+rules:
+- apiGroups:
+  - kubernaut.ai
+  resources:
+  - kubernauts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubernaut.ai
+  resources:
+  - kubernauts/status
+  verbs:
+  - get

--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubernaut-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator.clusterserviceversion.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut-operator.clusterserviceversion.yaml
@@ -1,0 +1,536 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: "[\n  {\n    \"apiVersion\": \"kubernaut.ai/v1alpha1\",\n    \"kind\": \"Kubernaut\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\"\
+      ,\n        \"app.kubernetes.io/name\": \"kubernaut-operator\"\n      },\n      \"name\": \"kubernaut\",\n      \"namespace\": \"kubernaut-system\"\n    },\n    \"spec\": {\n      \"aiAnalysis\": {\n\
+      \        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"policy\": {\n          \"configMapName\": \"aianalysis-policies\"\n        }\n      },\n      \"ansible\": {\n       \
+      \ \"enabled\": false\n      },\n      \"apiFrontend\": {\n        \"auth\": {\n          \"allowInsecureIssuers\": true,\n          \"audience\": \"https://keycloak-keycloak.apps.dev.redhat-internal.com/realms/kagenti\"\
+      ,\n          \"issuerURL\": \"https://keycloak-keycloak.apps.dev.redhat-internal.com/realms/kagenti\",\n          \"jwksURL\": \"http://keycloak-service.keycloak:8080/realms/kagenti/protocol/openid-connect/certs\"\
+      \n        },\n        \"enabled\": true,\n        \"logging\": {\n          \"level\": \"debug\"\n        },\n        \"rateLimit\": {\n          \"ipRequestsPerSec\": 50,\n          \"maxConcurrentSessions\"\
+      : 100,\n          \"toolCallsPerMinute\": 60,\n          \"userRequestsPerSec\": 20\n        },\n        \"rbac\": {\n          \"roleBindings\": [\n            {\n              \"groups\": [\n  \
+      \              \"platform-engineering\"\n              ],\n              \"role\": \"sre\"\n            },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n \
+      \             ],\n              \"role\": \"ai-orchestrator\"\n            },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n              ],\n            \
+      \  \"role\": \"cicd\"\n            },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n              ],\n              \"role\": \"observability\"\n         \
+      \   },\n            {\n              \"groups\": [\n                \"platform-engineering\"\n              ],\n              \"role\": \"l3-audit\"\n            },\n            {\n              \"\
+      groups\": [\n                \"platform-engineering\"\n              ],\n              \"role\": \"remediation-approver\"\n            }\n          ],\n          \"sarCacheTTL\": \"30s\"\n       \
+      \ },\n        \"route\": {\n          \"enabled\": false\n        },\n        \"shutdown\": {\n          \"drainSeconds\": 15\n        },\n        \"spire\": {\n          \"className\": \"zero-trust-workload-identity-manager-spire\"\
+      ,\n          \"enabled\": true\n        }\n      },\n      \"authWebhook\": {\n        \"logging\": {\n          \"level\": \"info\"\n        }\n      },\n      \"console\": {\n        \"auth\": {\n\
+      \          \"secretName\": \"kubernaut-console-oidc\"\n        },\n        \"enabled\": true,\n        \"route\": {\n          \"enabled\": true\n        }\n      },\n      \"dataStorage\": {\n  \
+      \      \"endpointPropagationDelay\": \"10s\",\n        \"logging\": {\n          \"level\": \"info\"\n        }\n      },\n      \"effectivenessMonitor\": {\n        \"assessment\": {\n          \"\
+      stabilizationWindow\": \"30s\",\n          \"validityWindow\": \"300s\"\n        },\n        \"logging\": {\n          \"level\": \"info\"\n        }\n      },\n      \"gateway\": {\n        \"config\"\
+      : {\n          \"cors\": {\n            \"allowCredentials\": false,\n            \"maxAge\": 300\n          },\n          \"deduplicationCooldown\": \"5m\",\n          \"k8sRequestTimeout\": \"15s\"\
+      \n        },\n        \"enabled\": false,\n        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"route\": {\n          \"enabled\": false\n        }\n      },\n      \"image\"\
+      : {\n        \"pullPolicy\": \"IfNotPresent\"\n      },\n      \"kubernautAgent\": {\n        \"alignmentCheck\": {\n          \"enabled\": false,\n          \"maxStepTokens\": 500,\n          \"\
+      timeout\": \"10s\"\n        },\n        \"audit\": {\n          \"enabled\": true\n        },\n        \"interactive\": {\n          \"enabled\": true,\n          \"inactivityTimeout\": \"10m\",\n\
+      \          \"maxConcurrentSessions\": 10,\n          \"rateLimitPerUser\": 10,\n          \"sessionTTL\": \"30m\"\n        },\n        \"llm\": {\n          \"credentialsSecretName\": \"llm-credentials\"\
+      ,\n          \"maxRetries\": 3,\n          \"model\": \"claude-sonnet-4-6\",\n          \"phaseModels\": {\n            \"workflow_discovery\": {\n              \"model\": \"claude-haiku-4-5\"\n \
+      \           }\n          },\n          \"provider\": \"vertex_ai\",\n          \"timeoutSeconds\": 120,\n          \"vertexLocation\": \"global\",\n          \"vertexProject\": \"itpc-gcp-eco-eng-claude\"\
+      \n        },\n        \"logging\": {\n          \"level\": \"debug\"\n        },\n        \"maxTurns\": 40,\n        \"safety\": {\n          \"anomaly\": {\n            \"maxRepeatedFailures\": 3,\n\
+      \            \"maxToolCallsPerTool\": 10,\n            \"maxTotalToolCalls\": 40\n          },\n          \"sanitization\": {\n            \"credentialScrubEnabled\": true,\n            \"injectionPatternsEnabled\"\
+      : true\n          }\n        },\n        \"serverRateLimit\": {\n          \"burst\": 100,\n          \"requestsPerSecond\": 50\n        },\n        \"session\": {\n          \"ttl\": \"30m\"\n  \
+      \      },\n        \"shutdown\": {\n          \"drainSeconds\": 15\n        },\n        \"summarizer\": {\n          \"maxToolOutputSize\": 100000,\n          \"threshold\": 8000\n        }\n    \
+      \  },\n      \"monitoring\": {\n        \"enabled\": true\n      },\n      \"networkPolicies\": {\n        \"enabled\": false\n      },\n      \"notification\": {\n        \"logging\": {\n       \
+      \   \"level\": \"info\"\n        },\n        \"slack\": {\n          \"channel\": \"#kubernaut-alerts\",\n          \"secretName\": \"slack-webhook\"\n        }\n      },\n      \"postgresql\": {\n\
+      \        \"host\": \"postgresql.kubernaut-system.svc.cluster.local\",\n        \"port\": 5432,\n        \"secretName\": \"postgresql-secret\",\n        \"sslMode\": \"require\"\n      },\n      \"\
+      remediationOrchestrator\": {\n        \"asyncPropagation\": {\n          \"gitOpsSyncDelay\": \"10s\",\n          \"operatorReconcileDelay\": \"1m\",\n          \"proactiveAlertDelay\": \"5m\"\n \
+      \       },\n        \"dryRun\": false,\n        \"dryRunHoldPeriod\": \"1h\",\n        \"effectivenessAssessment\": {\n          \"stabilizationWindow\": \"2m20s\"\n        },\n        \"logging\"\
+      : {\n          \"level\": \"info\"\n        },\n        \"notifications\": {\n          \"notifySelfResolved\": false\n        },\n        \"retention\": {\n          \"period\": \"24h\"\n       \
+      \ },\n        \"routing\": {\n          \"consecutiveFailureCooldown\": \"1h\",\n          \"consecutiveFailureThreshold\": 3,\n          \"exponentialBackoffBase\": \"1m\",\n          \"exponentialBackoffMax\"\
+      : \"10m\",\n          \"exponentialBackoffMaxExponent\": 4,\n          \"ineffectiveChainThreshold\": 3,\n          \"ineffectiveTimeWindow\": \"4h\",\n          \"noActionRequiredDelayHours\": 24,\n\
+      \          \"recentlyRemediatedCooldown\": \"5m\",\n          \"recurrenceCountThreshold\": 5,\n          \"scopeBackoffBase\": \"5s\",\n          \"scopeBackoffMax\": \"5m\"\n        },\n       \
+      \ \"timeouts\": {\n          \"analyzing\": \"10m\",\n          \"awaitingApproval\": \"15m\",\n          \"executing\": \"30m\",\n          \"global\": \"1h\",\n          \"processing\": \"5m\",\n\
+      \          \"verifying\": \"30m\"\n        }\n      },\n      \"signalProcessing\": {\n        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"policy\": {\n          \"configMapName\"\
+      : \"signalprocessing-policy\"\n        }\n      },\n      \"valkey\": {\n        \"host\": \"valkey.kubernaut-system.svc.cluster.local\",\n        \"port\": 6379,\n        \"secretName\": \"valkey-secret\"\
+      \n      },\n      \"workflowExecution\": {\n        \"cooldownPeriod\": \"1m\",\n        \"logging\": {\n          \"level\": \"info\"\n        },\n        \"workflowNamespace\": \"kubernaut-workflows\"\
+      \n      }\n    }\n  }\n]"
+    capabilities: Full Lifecycle
+    categories: AI/Machine Learning,Monitoring
+    com.redhat.openshift.versions: v4.18
+    containerImage: quay.io/kubernaut-ai/kubernaut-operator@sha256:6e3f88fd84b2dbc14d7e8e9cf2ab7bbe20286f94268255c0094bd41356e20ce9
+    createdAt: '2026-06-21T14:24:35Z'
+    description: "Automated Kubernetes remediation powered by AI \u2014 detects issues, analyzes root causes, and executes verified fixes."
+    documentation: https://jordigilh.github.io/kubernaut-docs/latest/
+    features.operators.openshift.io/cnf: 'false'
+    features.operators.openshift.io/cni: 'false'
+    features.operators.openshift.io/csi: 'false'
+    features.operators.openshift.io/disconnected: 'true'
+    features.operators.openshift.io/fips-compliant: 'false'
+    features.operators.openshift.io/proxy-aware: 'false'
+    features.operators.openshift.io/tls-profiles: 'true'
+    features.operators.openshift.io/token-auth-aws: 'false'
+    features.operators.openshift.io/token-auth-azure: 'false'
+    features.operators.openshift.io/token-auth-gcp: 'false'
+    operatorframework.io/suggested-namespace: kubernaut-operator-system
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/jordigilh/kubernaut-operator
+    support: jgil@redhat.com
+  name: kubernaut-operator.v1.5.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: 'Kubernaut is the Schema for the kubernauts API.
+
+        It declares a single Kubernaut deployment within the namespace it is created in.'
+      displayName: Kubernaut
+      kind: Kubernaut
+      name: kubernauts.kubernaut.ai
+      version: v1alpha1
+  description: "## Kubernaut Operator for OpenShift\n\nThe Kubernaut Operator deploys and manages the **Kubernaut AIOps Remediation Platform**\non OpenShift Container Platform (OCP) 4.18+.\n\nKubernaut\
+    \ automatically detects Kubernetes issues via AlertManager signals, performs\nAI-powered root cause analysis, selects and executes remediation workflows, and\nverifies effectiveness \u2014 all with\
+    \ policy-governed approval gates.\n\n### Features\n\n- **Single CR deployment**: one `Kubernaut` custom resource deploys all 10 services\n- **BYO infrastructure**: bring your own PostgreSQL and Valkey/Redis\n\
+    - **OCP-native**: auto-wires Prometheus, AlertManager, service-ca TLS, and Routes\n- **Policy-governed**: Rego policies control signal classification and AI analysis approval\n- **LLM-powered analysis**:\
+    \ integrates with OpenAI, Anthropic, and other LLM providers\n- **Full lifecycle management**: automated DB migrations, OCP service-CA TLS integration, RBAC provisioning\n- **Ansible integration**:\
+    \ optional AWX/AAP for Ansible-based remediation workflows\n\n### Prerequisites\n\n- OpenShift Container Platform 4.18+ (Kubernetes 1.31+)\n- PostgreSQL database with credentials in a Secret\n- Valkey/Redis\
+    \ with credentials in a Secret\n- LLM API credentials (e.g., OpenAI API key) in a Secret\n- Rego policy ConfigMaps for AI analysis and signal processing\n\n### Getting Started\n\n1. Create the required\
+    \ BYO secrets (PostgreSQL, Valkey, LLM credentials)\n2. Create Rego policy ConfigMaps\n3. Apply a `Kubernaut` CR \u2014 see the sample in the operator bundle\n"
+  displayName: Kubernaut Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deXxU5b0/8M9zzqyZmeyELIAQVmWRJAgXEQ2KQmtFq1Lcai/Y6q2IuPZq61VRr1t/WkHAqqW86lJ/bl3EahVFREEhhLAvBghLyED2TDL7nPPcP2IwO+dM5szMyXzf/9gZzvKgfT7znGc7ACGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQvSLxboAkTZ+/Pi0pKQkmyzLpliXhfQfgiAEPB6Pe9euXQ2xLksk6S4AzjvvvGzO+RQAoznnowCMATACgB2ALaaFI4nCDaAFwEEA+xlj3wHYL4ri5s2bN5+KbdHUifsAmDZtmsPr9V4qCMLFnPMZAM6JdZkI6cUezvkXANb5/f61e/bsaYl1gXoTrwEgFBUVnc8Y+znn/Aa0/roTojc+AGs4568nJyd/vH79+lCsC9RZXAVAUVFRCmPsDs757QBylZ7HOSDLgCxzcA5wzjUsJUlUjDEIAgNjgCAATF3tqeKcr2CMrSgtLW3SqIiqxUUAFBQUDBBF8S7O+UIAKb0dK0kcfj9HMMgRCnFIUut3hESbKDKIImAwMBiNDCYTg8FwxirVxDlfzhh7obS0tDYa5exNTAOgqKjICGAxgEfQQzOfcyAQ4PB6ZQQCMiQpqkUkRBVRBMxmARYLg8kk9NZKaAawBMCy0tLSYNQK2EnMAqCgoOBCQRBWABjX3Z+HQhwejwyvV4YsR7lwhESAKDJYLAKSknptGezinC/ctm3bV9EsW5uoB0BxcbGlubn5DwBu6+7+gYCMlhYOv59qPek/zGYGh0OE0dhtleMAXnI4HPeuX7/eF81yRTUAJk+ePEqSpHcAnNv5z4JBDpdLQiBAz/Ok/zKZGJKTewyCMkmS5m3fvr08WuWJWgAUFhbOY4y9CsDR/nvOgeZmGR6PBOq8J4mAMSApSYDdLkIQuvyxizF2y9atW9+LRlnEaNykqKjoHsbYKwDM7b/3+znq6yVq7pOEEwy2dmwbjULn/gEzgGtzc3ObnE7nZq3LoXUAsEmTJj0K4Em0a21wDrjdMpqa6FefJC7OAa9XBuetIwftMACzc3Nz051O5ydalkHLAGBFRUUvA7in/ZeS1Pqr7/XSrz4hQGtrwO/nsFi6DBtOycnJyXY6nf/S6t6aBUBhYeEzjLE7238XCrVW/lCIfvYJaU+WAZ9PhtksQBB+SAHG2KS8vDxjVVXVOi3uq0kATJo06Q4A/9v+u0CAo74+RGP6hPSAc8Dn4zCbGUSxQ1Ngel5enquqqurbSN8z4gFQWFg4D8AqtHvmDwZbKz897xPSu15C4NKcnJzdTqdzXyTvF9FhwMLCwhGMsVIAyW3fSRJQWxukX35CVBAEICPD0HmEoIUxNmnr1q0HInafSF2ouLjYwhh7Dx0qP0ddHTX7CVFLloGGBqlz3bFzzv86YsQIcw+nqRaxAPh+em+HGX4NDRKt1CMkTKEQR0NDl0fnwtTU1OcidY+IPAIUFRVdAGBD++u5XBLcbvrpJ6Sv7HYRDkeH32ouCMKMkpKSL/t67T63AL5f0vtHtKv8fj+nyk9IhLS0dJkty2RZXlZcXGzo67X7HACMsbsBjG37LMtAY2Pc7XxEiK41NcmdHwUmuFyuO/p63T49AhQUFAwQBOEw2m3mQU1/QrRhs4lITu7wm+0SRTF/y5YtdeFes08tAEEQ7ka7yh8Mtm7iQQiJPI+nyyzaZFmWF/XlmmG3AIqKilIAHEW7Pfzq6kK0np8QDZnNDOnpHR79GwwGw9DNmze7wrle2C0AxtgdaFf5g0FOlZ8Qjfn9HIFAh1Z2WigUuj3c64UVAHPnzhW/37r7tOZm2q2TkGhwu7v80N4xd+7csKb1hxUAhw4dmol2+/aHQq3LGQkh2vP5ZASDHepbXkVFxcXhXCusAGCM3dz+M3X8ERJdnffT4JzfFM51VAfA2LFj7QCu/OHGrauXCCHR4/PxzvMCrvm+bqqiOgCsVusstHsLbyDAab4/IVEmSV063W1Wq/UStdcJ5xFgRvsPtLUXIbHh83V5DFDdD6A6ADrfpNOQBCEkSroZdp/R3XG9URUARUVFOQDGtH1uezknIST6uql/46ZMmTJQzTVUBQBjbDLazR6kiT+ExFbnVYLBYHCymvNVBQDnfEz7z53GIgkhURbqtPCWMTZKzflqWwCjO96cAoCQWOqmDo7u7rieqAoAWZY7XJye/wmJrW4CYEx3x/VEbQtgWNv/5hw0/k9IjElSlwlB+WrOVzsMeHr1nyxT5SckHnSqiyk9HdcdxQHw/Woj6w83VXMbQohWOrUAbFBRrxUfePjwYTsi/CIRQkjfdQoANm3aNFsPh3ahOABCoVCHhQb0mi9C4kPnutjS0pLc/ZFdKW8qCEKHfYgoAAiJD53rYue62puIvRmIEKI/FACEJDAKAEISGAUAIQmMAoCQBEYBQEgCowAgJIFRABCSwCgACElgFACEJDAKAEISGAUAIQmMAoCQBEYBQEgCowAgJIFRABCSwCgACElgFACEJDAKAEISGAUAIQmMAoCQBEYBQEgCowAgJIFRABCSwCgACElgFACEJDAKAEISGAUAIQmMAoCQBEYBQEgCowAgJIFRABCSwCgACElghlgXQM/MZhNMJhMcDhuMRiMkSQLnHF6vD36/H263N9ZF7BfsXIKZcyRxGQLnEAAEGYOLifAzBj+j37FwUQCcgclkwvDhZ2HUqHyMGpWP7OwsDBw4AAMHZsJmS+r13EAggPr6JtTW1uHUqVpUVBzDkSOVOHLkGI4erYQkyVH6W8Q3ERz5IT+GBf0YEfIhP+RHjhTAACmETDkIE+e9nt8siDglGOEUjThhMGGf0Yr9RivKDRYEGIvS30KfKAA6EQQBY8aMwOTJBZg8eSLGjx8DURTDupbJZEJ29gBkZw/AuHEd/8zj8WLPngPYtWs/duzYi+3b9yAYDEbgbxD/TJyjKOBGUcCNiQE3xgc8sPHww9AhS3DIEkaEfID/h++DjGG7MQnfmB3YZLFjrzEJFLkdKY7HgoKCswRBONL22e/nqK8PaVKoWBg2bDBmz56BWbOKkZWVGfX7ezxelJTswKZNJfjqq81obHRFvQxaSpNDuNjnwnRfM873NyOpDxU+XCdFI9ZY07AmKQ2HDeao318r6ekGmM0/VGVZloeWlZUdVXJuQgeAIAiYNu083HTT1Rg//uxYF+c0SZLwzTel+Pe/1+Prr7cgEAjEukhhMXMZM3wuXOFtxDR/MwxnaMpH0zaTDX+2D8CXlmTET6nC05cASMhHAMYYLrvsItx881wMGzY41sXpQhRFXHDBZFxwwWQ0N7fggw8+xfvv/wsnT9bEumiK5EkBXO+uwzWeejhkKdbF6VZhwI3CejcOGix4xZGFj62pug+CcCRcC2D06OG4555b4+oXXwlJkrFhw7d44433sW9feayL063xAQ8WtNTgYp8Los6q0zaTDU+m5GK/0RrroqhGjwAKmEwmLFz4n7jmmh9DEPQ9bLRxYwlWrXoL+/cfjHVRAADjgh4sbD6F6b7mWBelTyQwvGnLwAvJOboaPaBHgDPIzx+CJUvuw/DhQ2NdlIiYNu08nH/+JHz55bdYsWI1Tpw4GZNyDA4FcL+rChf7+keHpQiOm921mBJowf1pZ/WrjsKe6PunUIFZs4qxatXz/abyt2GMobh4Kt58czl+9asbYbFE7/+sVi7jzuaT+GfNgX5T+dsbHfThnZpyzPY2xroomuvXAXDjjVfj4YfvhtlsinVRNGMymTB//jz89a8rMWVKgeb3m+5vxprqA7i1ufqME3T0zMJlPNtwDD9vqY11UTTVLx8BGGO4884FmDfvyohdMxSScPRoJcrLK1BRcQw1NbU4ebIGTU0uBAJBtLR4IMsyHA4bGGNIS0tFWloKMjLSMGhQDoYNG4KhQwcjJycrYmVqLzt7AJ5//lH885+fYPny1fB4IjsN2c4l/KbJias99RG9bmeVogkVRjMOGSw4KppQKxpRJxjQIBrAAbiYCAGAg0swcRmpsoRcKYCBUhAjgj6MCfowNOSHIQKdkAKA/3ZVIUsO4rnknD5fLx71ywC49dYbI1L5q6tr8eWX32LLljKUle1WVKmam1sAoMfn8rS0FIwbNwbjx4/B5MkFGDlyGFiEOpwYY7jqqtmYMqUQjz76HHbt2heR6xYF3Hi64RhypMjOVOQA9hmt+MZsx3aTDTtMSagXlP1fshE/zM4sha3Dn9m4jMn+Fkz1N2Omz4WsPpZ7fksNfEzACsfAPl0nHvW7UYC5c3+Cu+++NezzQyEJX3yxEWvWrMW2bbsgy9rOWMvKysT550/CzJnTMXHi2IiNUEiShOXLV+Pttz/o03V+3lKLe13OiPyiAoAMYIvZjn9bU/Gl2YEa0RiR6/ZEBMdkvxvXeOpxqbepT8OTT6Tk4f/bMiJYusigYcDvTZ8+BU899WBYlUiSJHzwwad444334XRWa1C6M8vKysSsWcW48spZyM2NzK/NZ599haefXq76kSCJy3i8sRKzItQRdlw04V1bBj60pqJa40rfk8FSAPOba3C1pz6sQJMBLEwfhq8sjsgXrg8oANBaef7ylxeQkpKs+tytW3fgD394BRUVxzUomXqCIOCCCyZj3rw5KCgYd+YTzuDAgUO4777HUFfXoOj4TCmIl+qP4Oxg3/sRtpjteMOWifWW5LhZiDMy6MODripM9reoPrdBMODqASM1b7mokfABIAgCli59DEVFE1SdFwgE8NJLr+Gdd9aAx2mP9vjxZ+Pmm6/FtGnn9ek6Tmc17rnnURw9WtnrcfkhP/5YV4FcqW/rD8pMNrzoGIgtZnufrqMVBuBaTz0eaKqCWeXCpBKTDb/MzIekvPpoqi8BoHida05OTipj7K62z5IEeL3xkenXXXclrrpqtqpzqqtrsWjRQ9iwYbNGpYqM6uparF27AWVluzF69HCkp6eGdR2Hw4ZLL52OsrLdqKmp6/aYiQEPVtUdRqYcfrDvN1pxf9oQLE/OxglDfA+/7jVa8ZXFgWJ/s6rlyHlSEM2CATtMve8HES1WqwCD4YcA4Jy/cPLkySYl5+p+HkB6eioWLLhe1TkVFcdx662/QXl5hUalirxt23Zh/vy78fzzr5weaVArJSUZS5c+hrPPHtnlzyYEPPhjXQWSw1y80ySIeDwlD/MGjEBJnP7qd2ef0YobM0fgkMGi6rxfN59CRh+CMl7oPgD+679uhs2mfAHHiRNOLFr0O1RX62+CRygk4b33PsT119+ODRu+DesaNlsSli17vEMInBP04o/1FbDz8Cr/VxYHrhowCm/bMuKmWayGUzTiPzPzcUTF1F+HLOEOV2ymYEeSrgNg+PCh+PGPL1Z8fF1dAxYvfhj19fqe4llf34gHHngSTzyxNKx9B222JLzwwhIMHz4Uo4M+rKo7HNYvf4sg4rdpg/Hr9GFx1SkWjgbBgF9nDEOdwnkIAHC1p6F1FyId03UA3HDDVYqH/GRZxpIlz6Oq6pTGpYqejz76HPPn34VDh46oPtfhsGPpbxfipcZjYa3ZP2ww44bMEfjAmqb63Hh1XDThvrQhilsxIjh+ofOpwroNgIyMNFx66YWKj3/99fewdesODUsUG5WVTtx662/w6adfqjvR7cbg++5BVlD9L9gaaxp+NmBkv1wtV2K2Y7V9gOLjL/c26LovQLcBcO21l8NgUNZcq6yswp///LbGJYodr9eHJUuex+rVCv+OsoykxYsh7tmj6j4cwErHQDyYNhi+frwV90rHQBwXlY1gmDjHde7uR1X0QJf/FRljmD17huLjly37c7/fcZdzjldffRNPPLEUktR7k9708sswfPaZquuHwPBY6iCs7Ifz4TsLMIbnUpQv/vmpp16HXZ+tdBkA55wzCgMHKmum7d37Hb7+eovGJYofH330OR555DmEQt2HgFhaCvNzz6m6Zogx3J8+BO8mpUeiiLrwmSUFuxVuD5YtBTE26NG4RNrQZQBccskFio99661/aFiS+LRu3ddYsuS5Li8eYY2NsC5aBBZS/swaAsNvUodgrSUl0sWMe6+p6AuY5VU07ybu6DIALrzwPxQd17qc9xuNSxOfPv/8azz55LIOU5zNy5ZBqKpSfA0O4KG0wfjUmniVHwA+taYoHt7U685IuguArKxMxSvlvvhiY49N4UTw8cfrsGrVW60fZBnGv/1N1fkvOrLxoTW8qcf9QQgMnyhs+ZwV8vdpCnWs6C4Axo4drfjYdes2aVgSfVi9+m18/PE6sPp6sEblE6D+npSGVxza7F6kJ5+paP0UBNwalkQbuguA8ePHKDqusdGF3bv3a1ya+Mc5xzPPrET5iVOAwp2H9plteDxlkMYl04dtJhtcgrI1c+cG9NcRqLsA6G4hS3f27DkQt0t8oy0QCOC3/7sMwXHjz3islJSEe1MG62pffC3JAHYYla36G0cBoL1Bg5SNz9Kvf0eVlU6sHjC491YAY1g1YQqOxfky3mjbbrKd+SAAQ/q4h0Is6CoAzGaT4vXwBw4c0rg0+rNs/3F8fuFMoLv1E4KAzy+ciWXH9DurTSt7Fc4HyJSCutsqXVe7AmdnZyneQbc/LfqJpMXlp3DFpGLcJviQ7WwdEjyZk4uXZQvWlNO/s+4o3dhEAJArBVQtK441nQWAsokZnHPdvEk3FtZU1mINAOD7/ROPtQAIb5ORRFAlGsGhbP88vQWArh4B7HZlz2INDU0IBPT3PEbik48JaFC4T4BN423kI01XAaD0/Xcej/56Y0l88yhc/ZikcoPRWNNVAFityjpj/H769SeR5VUYAFYKAO0obQH4fH6NS0ISjU/hzlMUAIQQ3dBVAHi9yravUtpSIEQpi8LOPaWPCvFCV6X1+ZQFgNlMM9lIZClt2lMAaEjps31SUny8sYX0H0p795WOFsQLXZW2pUXZcsu0tBSYTNQKIJFh4TLSFK71b1G4cjBe6CoAlM7uY4wpnjWYiK4YlIkPh9ix1ejCVqMLHw6x44pBmbEuVtzKkwKKN/2s0tkLUnQ1FfjkyWpwzhWtB8jLy8axYyeiUCp9WTpyIC756nOgXafW0KNH8JQgYOb0S7CY1gN0kRdSNq9EBuBUuJ14vNBVC8DvDyh+rdeoUfkal0Z/7hwzGJds+KxD5T9NlnHJhs9w55CM6Bcszo0NKnv9Wq1o1N0+CroKAAA4flzZppbjxinbOShRDBqUg/k1x4Helqtyjlt2bsYQhb94iULpTj/HdPbrD+gwAPbtK1d03LhxoxW/N7C/M5lMeOqhxTDu3nXGY0WPB883HdfdunatiOA4V+Ge/7tN+ht90l0N2b37gKLjUlKSFe8f2J8xxvDAA3dgRG5W77/+7Yzxu/FoU6Vu33YTSYUBj+KXp26nANCemq2+iovP17Ak+rBgwXWYPbsYPD0dPFX5Ft9zPA24rZk6BGeqeOGH0q3D4onuAqCmpg4nTpxUdOzFF0+DwaCvcdlI+vGPL8GCBde1fhAEBK++WtX5C5tPYY63QYOS6YOBc8zyKQuAowYzahXuGRBPdBcAABS/7WfAgIyEbQVcdtlFePDBRR2GTP133gk5N1fxNRiAxxoqMdur/H0C/clsXxMyJWUvlf3MkqxxabShywBYt26j4mOvu+4qDUsSn2bOnI7/+Z+7IYod//Py1FR4ly8HV/hadQAwgOPphuO4TKfvvuuLm1uUbyu3VqdvUNJlAOzbV654VuA554zERRcpe5dgf/CTn8zEww/f06Xyt5EKC+G/7z5V1zSA4/cNx/Azd+LsGHyZtwnnKBz/PyGasEfhzsHxRpcBwDnHxx+vU3z8HXcs6PdrAxhjuO22m/Db3955xn6PwG23IXjppaquL4Lj4aYTWNh8qt+PDpi5jHtdTsXH/zMpDXodNNVlAADA3/72EYJBZc9neXnZuOWW6zUuUewkJVmxZMl9+MUvfqbsBMbgXboU0rhxqu/16+ZTeLrhmO52vlFjUfMp5Cl8yUeAMbxt0+/sSd0GQF1dAz799EvFx994408xeXKBhiWKjcGDc/Hyy89i5szp6k5MSsLx3z+HapNF9T0v9zbinZpyDA8p259BT6b5m1U9+39gTUOdDnv/2+g2AADgrbf+AUlS9kskCAIeeeQe5OUpe7WYHsyZcxlWr/4Dhg8/S/W5LlczFj+5HLelDFH88sv2hoX8eLPmEH7qqVd9brw6K+THUw3HFVcKCQyv2fW96lTXAXD48DGsWfOp4uPT0lLwwgtLkJGRpmGptJeRkYZnnvkdHnjgDiQlqe98amlx4557HsWhQ0dRbrTglox8NIURAnYu4fHGSvyxrgJZCofL4lW6HMLK+iNIV7juHwDetaXjsI5eAtIdXQcAALz66ptwu5W/ByAvLxsvvviELvcLMBhEzJs3B2+9tRLTp08J6xotLW4sXvww9u79YU3FPqMVt6UPC3sziwv8zfhHzXe4wV0Hgw67wwZJAbxWewhnhZTvJu0SRKxwDNSwVNGh+wBoaGjCn/70lqpzhg4djFde+b3iV43Hg8mTC7B69QtYvPiXit+Q1Fljowt33fVwtwuqdpuS8Kv0YWgMMwSSZQm/bTqBd2rKMcWvn9eMjQt48EbNQQxVUfkBYKVjoOK3BcUzxf+1c3JyUhljd7V9liTA642PnuB9+8oxYcLZyM3NVnxOUpIVl18+E4IgYMeOveBxuvpt/Piz8dBDi7FgwXWK34zcnaqqU1i06CEcPHikx2OqRSPWWlIx3d+MVIULYDrLkEO40tuAqf4WVIkmxS/WjDYG4OfuWvy+8RgcKkc0Ssx2PJmSCx4nA6JWqwCD4YeycM5fOHnypKKZW4r/BgUFBWcJgnCk7bPfz1Ffr/x5SWuZmel47bVlSE1VPyVz+/Y9eP75V3DwYIUGJVNPFAVMnz4Fc+degYIC9UN1ne3bV477739c8WYqmXIIK+sqFE+E6U2JyYY37Zn4wpIMKU4qzNlBLx5sqkJhQNkek+3VCQZcM2AkauNo66/0dAPM5h/+3cqyPLSsrOyoknP7TQAAwNSpk/Dssw/1OAuuN5Ik46OPPsfrr7+Pykplm45EWnb2AMyaVYw5c2YhJycrItf85JP1ePbZlYrfqdAmictY0liJH0VoHcAJ0YT3bOn40JoGZ4wqz1khP37ZUo05nkaIYfRVSGC4PWMoNpodGpQufBQA7fz0pz/C/ff/OuzzJUnG+vWb8OGHa7F16w7Fw4zhys4egKlTJ+HSSy/EhAlnR2wTk1AohKVLV+H99//Vp+vc5K7FfS4nDBF6RJIBlJps+Niaiq8syZqHgQiO8/0tuNpTj0u8TX3q9FqSOgjvJqVHrGyRQgHQyS23XB+RmX91dQ3YsOFbbN5chtLSHXC7+94kzshIw4QJZ2PChLMxadLEsMbwz+TEiZN45JH/h717v4vI9SYGPHi64RgGKZwdp8Z3Rgu+NTtQZkpCmckWkSW1dlnCfwRacL6/BRd7m5CpYmivJyscA/FSnPb6UwB04/bbf4GbbromYteTJBnHj59AeXkFDh8+iurqWpw8WQOXqxk+n/90E9tqtYAxhvT0VGRkpCEzMx25udkYNmwwhg4djKws7bbf5pzj73//GCtX/gUeT9/Dqj0bl3FvkxNzPXWaPsmfFI04bLDgkMGMSoMJ1aIRtYIBdYIRnP3w4o0kLsPCZaTKEnKkALJDQYwM+TAm6MWQUCCsJn5PVtkH4A/J8TuBjAKgB/PmzcGiRQsSYm/AqqpTeOaZFSgp2a7pfc73N+PRxhPI1aA1EG9kAM+k5OJNW3y/M6EvAaD/gcxevP32B6ipqcfvfncnrFb1c971wO8P4I033scbb7wPv1/7SrnJ7MCcrFG4paUGt7RU99vNQz1MwO/SBmOtJSXWRdFUv/9pXLfua8yffzfKy+NjiC9SOOf44ouNuOGG27Fq1VtRqfxtfEzACsdAzMkajbWWFB3O/evdHqMVcweM7PeVH+jnjwDtGY1G3H77zbj22ivCGiaMF5xzbNxYgj/96a/47rvDsS4OAOCcoBcLm0/hIp8r1kXpkxAY3rBnYqkjG0EdveCD+gBUGD58KO699zZMnDg21kVRJRSS8NVX3+LNN//WYR5/PBkX8OCWlhpc7HNFtBMuGraY7XgqJRflBv09KlIAqMQYw4wZ0zB//s8wfPjQWBenV01NLnzwwVq8//6/UF1dG+viKJIjBXG9uxbXeOqREuaU4mjZb7TiZUeWrpv7FABhYoxh6tQi3HTTNXHVIgiFQti0aSv+/e8vsHHjVsU7H8UbE+e4yOfCFd4GTPc3wxhHHYYlJhv+7MjC12aHztoqXdEoQJg459i0aSs2bdqKIUPy8KMfzcCsWTNislTY7fZg8+Zt2LSpFF9/vQUuV3PUyxBpAcaw1pqCtdYUpMoSZviacKG/GVN9LbDz6LcMTogmrElKwxprKo7qfB1/pCR0C6A7giBg1Kh8nHfeuZgypRDjx4+B0Rj56aputwc7d+7D7t37sX37HuzatQ+hUHw3lyPFwDkKAm5MCrhxbsCDiUEP7Bo8KgQYQ5nJhk1mB74x27HPaNX9r3136BFAQwaDAcOHn4WRI4dh5Mh85OVlY+DATGRlZcLhsPd6rtfrQ21tPerqGnDyZA2OHDmGY8dO4PDhY6isdELu7jXdCUhA60KdESEfhoX8yA/6kCsFkSGHMFAKwnKG5bouQcQp0Ygq0YTjogkHjBbsN1pRbrAgpKPe/HDRI4CGQqEQDhw4hAMHDnX5M5PJBLPZhKQka4etuF2uFkiSFPHpuP2VDKDCYEZFD83yJC7DwDlS2j02hMDgZgJ8TEAgASq5VigA+iAQCCAQCKC5WT874OiRhwkAA1zK968hCul3RgwhpM8oAAhJYBQAhCQwCgBCEhgFACEJjAKAkARGAUBIAqMAICSBUQAQksAoAAhJYBQAhCQwClIyUVMAAAbUSURBVABCEhgFACEJjAKAkARGAUBIAqMAICSBUQAQksAoAAhJYBQAhCQwCgBCEhgFACEJjAKAkARGAUBIAqMAICSBUQAQksAoAAhJYBQAhCQwCgBCEhgFACEJjAKAkARGAUBIAqMAICSBUQAQksAUB4Asy6H2nxmLfGEIIep1roud62pvFAeAwWBo6e2mhJDY6FwX7Xa7S+m5igMgPz+/BQBXXCpCSFR0CgC+ceNGt9JzFQfAu+++KwHwnj6Reg8IiQuC0CEB3ABkxeeqvFdTDzclhMRIpxZAUw+HdUttABxuf1NRpBAgJJZEsWMAMMYOqTlfVQBwzg90vjkhJHYMhk4dAJ3q6JmoCgBBEDpcvPPNCSHR1U0d1C4AAOxv/8FopAAgJJY610FNWwCBQOBbtBsKNJkoAAiJJZOpQxXmRqOxRM35qgJg586d1QD2tX02GBj1AxASI6LYpf7t2rx58yk111A9ms85X9f+s9lMEwIIiQWzuUsL/Au11win9na4icVCjwGExILF0rH6MsbW9XBoj1QHQCgU+gTA6XUBJpNA8wEIiTJB6NIH5/Z6vdoHwM6dO90A/tn2mbGuSUQI0ZbVKnSeAfjenj17Wno4vEfh1tzXOhaGWgCERJPV2rHqyrL8ejjXCSsA8vPzPwdQ1fbZaGTddUgQQjRgsQidx/8ry8rKVHcAAmEGwLvvvisxxla2/87hoPFAQqLBZutSbZdDxQrA9sJ+eOecLwfQ2PbZaGQ0MYgQjZnNXepZvcViWdnT8WcSdgCUlpY2cc5XtP8uJUWknYII0QhjQHJyx5Y253zZxo0bm8O9Zp+67xljLwA4fXODgSEpiUYECNFCUpLQefFPk9lsfrEv1+zTg7vT6fTk5uYGAFzW9p3RKMDrlcFp8zBCIkYUGdLSDJ1b2P+9ZcuW9X25bp9/rh0Ox1IAu05fUABSUw19vSwhpJ1uHq+35+fnr+jhcMUi8sReVFR0AYAN7a/ncklwu8PqmCSEtGO3C51H2bgsy9PKysq+6eu1IzJ253Q6j+Xl5Q0AMLntO7NZgN/PIVMGEBI2k4khJaVL0//Fbdu2vRqJ60esx85ut98HoKz9d+npBlouTEiYDAaG1FSx855/W5uamn4TqXtELADWr1/v45z/DMDplxIIApCRYaDFQoSoJAhAWprYue40MsbmHTx40B+x+0TqQgCwbdu2g4yxW9BuVlJr76VI24gTopAgMKSnGzoP+ckA5peUlBzu4bSwRLyBXlVVtTc3N7cWwOWnbyK2rhXw+Wh4kJDetFZ+sbv9Nu8uLS39S6Tvp8kTutPpLMnNzTUDmH76RiKDxdLaMUghQEhXBkOPlf+x0tLSp7W4p2ZddE6nc11eXl4OgKK27wSBwWoVEAxySJJWdyZEf0ym1kflbrb5XllaWhqxTr/ONO2jr6qq+ldeXh4AFLd9x1jbZgYMgQA1BQix2QSkpRm66yd7prS09F5o+FJezQfpqqqq1ufm5jYAmIXvJwox1pp4JhOjRwKSsFp7+g3dLe+VOeeLtm3b9pTWZYjKKL3T6dycl5e3B8BsAOa271sXD7UWIRSiFCCJgbG2X/1un/ebANywbdu2sHb4UV2WaNykTWFh4QjG2NsACjv/WSjE4XLJ8Ptp6iDpv8xmhuTkbp/1wRjbyhibF+mhvt5EdZ6e0+mst9lsfzGbzamMsfPQLoDaOggtFgGyTC0C0r9YLAJSUkTY7d3OieEAXmxqarp+9+7dtdEsV8xm50yaNGna9xuKnNvdnweDHF6vDK9XpvUERJcEobXD22rtsodfe9sFQVhYUlKyKZplaxPT6XnFxcUGl8t1B2NsCYDk7o7hHPD7Zfj9HIEAp5YBiWsGQ2vntsUiwGRive2Q1QTgEYfDsWL9+vWh6JWwo7iYnzt16tT0QCCwGMAiAGm9HStJQCAgIxhsfUwIhWSaU0BiQhQBg0GAKLaNaglKFr81MMaWGY3GZd988019FIrZq7gIgDZTpkxJDoVCCwEsBJCn9DzOW5cdc47v/0mtBBJ5jDEIQmsvfus/VVWfSgDLLRbLyr7s4RdpcRUA7QhFRUXnM8Z+zjm/HoAj1gUiJAxeAB9yzl9PTk7+OJZN/Z7EawCcNnbsWLvFYpkJYAaASwCcAx2UmyQkDmA3gHWMsXWBQODz71+lF7d0V5GmTJkyMBgMTgYwhjE2CsBoACMA2EEtBRIdzQBaGGPlnPMDAL7jnO8PhUJbdu7cWR3rwqmhuwA4k4kTJ6aazWa7LMumWJeF9B+CIAT8fn/L9u3bG898NCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQkg0/B+lKe/aV+sxYAAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - agent.kagenti.dev
+          resources:
+          - agentruntimes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - namespaces
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ''
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - kubernaut.ai
+          resources:
+          - kubernauts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kubernaut.ai
+          resources:
+          - kubernauts/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kubernaut.ai
+          resources:
+          - kubernauts/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagerconfigs
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - bind
+          - create
+          - delete
+          - escalate
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - spire.spiffe.io
+          resources:
+          - clusterspiffeids
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kubernaut-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: kubernaut-operator
+          control-plane: controller-manager
+        name: kubernaut-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: kubernaut-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: kubernaut-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                env:
+                - name: RELATED_IMAGE_GATEWAY
+                  value: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
+                - name: RELATED_IMAGE_DATA_STORAGE
+                  value: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
+                - name: RELATED_IMAGE_AIANALYSIS
+                  value: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
+                - name: RELATED_IMAGE_SIGNALPROCESSING
+                  value: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
+                - name: RELATED_IMAGE_REMEDIATIONORCHESTRATOR
+                  value: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
+                - name: RELATED_IMAGE_WORKFLOWEXECUTION
+                  value: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
+                - name: RELATED_IMAGE_EFFECTIVENESSMONITOR
+                  value: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
+                - name: RELATED_IMAGE_NOTIFICATION
+                  value: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
+                - name: RELATED_IMAGE_KUBERNAUT_AGENT
+                  value: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
+                - name: RELATED_IMAGE_AUTHWEBHOOK
+                  value: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
+                - name: RELATED_IMAGE_API_FRONTEND
+                  value: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
+                - name: RELATED_IMAGE_DB_MIGRATE
+                  value: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
+                - name: RELATED_IMAGE_CONSOLE
+                  value: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+                - name: RELATED_IMAGE_OAUTH2_PROXY
+                  value: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+                - name: RELATED_IMAGE_INIT_POSTGRES
+                  value: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
+                - name: RELATED_IMAGE_INIT_UBI_MINIMAL
+                  value: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
+                image: quay.io/kubernaut-ai/kubernaut-operator@sha256:6e3f88fd84b2dbc14d7e8e9cf2ab7bbe20286f94268255c0094bd41356e20ce9
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: kubernaut-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ''
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: kubernaut-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - kubernaut
+  - remediation
+  - ai
+  - openshift
+  - kubernetes
+  - alertmanager
+  - sre
+  - aiops
+  links:
+  - name: Documentation
+    url: https://jordigilh.github.io/kubernaut-docs/latest/
+  - name: Kubernaut
+    url: https://github.com/jordigilh/kubernaut
+  - name: Kubernaut Operator
+    url: https://github.com/jordigilh/kubernaut-operator
+  maintainers:
+  - email: jgil@redhat.com
+    name: Jordi Gil
+  maturity: alpha
+  minKubeVersion: 1.31.0
+  provider:
+    name: Kubernaut AI
+    url: https://github.com/jordigilh/kubernaut
+  relatedImages:
+  - image: quay.io/kubernaut-ai/gateway@sha256:8ef1d69db4508bfa0ab86e7f22100952ddae85c6e22d81293580d9defaf94004
+    name: gateway
+  - image: quay.io/kubernaut-ai/datastorage@sha256:f10d8c98017c7df35133dc98f0e26e36054ec4584ac5c230b0252d3a5c9a0b44
+    name: data-storage
+  - image: quay.io/kubernaut-ai/aianalysis@sha256:b31b8aaba5f4f3d5df1639213bca23c63438e257704ee0ac6d5f1d9ec82314b0
+    name: aianalysis
+  - image: quay.io/kubernaut-ai/signalprocessing@sha256:de7393f8d0cbd07fadacf13ae0b9504cec321c09e1614c6839ccf1c65ec4d86e
+    name: signalprocessing
+  - image: quay.io/kubernaut-ai/remediationorchestrator@sha256:54778cdfd8e3a7fcef4cd871479c6101e566be0aa8fd0d5e37ed1a0c685eecb8
+    name: remediationorchestrator
+  - image: quay.io/kubernaut-ai/workflowexecution@sha256:47369cf7ab80bf398edca84ff4097028988303cfcc94a8a760cd4235faa7f008
+    name: workflowexecution
+  - image: quay.io/kubernaut-ai/effectivenessmonitor@sha256:96aa70fcbd7d752632f18cd7ee57c009c99ab5667d7f070fbf33fd4e163e9752
+    name: effectivenessmonitor
+  - image: quay.io/kubernaut-ai/notification@sha256:e1c4a270651fe05ca4c2d8e9588ebfb723584d5d0e80620af0cf7cf27ad643dd
+    name: notification
+  - image: quay.io/kubernaut-ai/kubernautagent@sha256:e4bf7bfbe1a3351266b9045ae19b4b012e12fd5a52b9f6559824918215dac184
+    name: kubernaut-agent
+  - image: quay.io/kubernaut-ai/authwebhook@sha256:67b4093ca3d686077dd7816de88ce97ce729a32513e8e9fbe93433dae1434688
+    name: authwebhook
+  - image: quay.io/kubernaut-ai/apifrontend@sha256:54b57237ddbaa9d39cd6d7abf4fdabbc55406f1ef824fc020154ec5d20789946
+    name: api-frontend
+  - image: quay.io/kubernaut-ai/db-migrate@sha256:d94cdefac33c895524743697575425d3a458a97dc9c544deaa72b852b61637b3
+    name: db-migrate
+  - image: quay.io/kubernaut-ai/kubernaut-console@sha256:01300d335dece46e8dab7a5722e6c52a85a564886f2934dcf4719d3fc363317c
+    name: console
+  - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+    name: oauth2-proxy
+  - image: registry.redhat.io/rhel10/postgresql-16@sha256:877ac0f8207ada1559ef73b70e92616255b95d3b6ef6a1af314c0f67edfde96e
+    name: init-postgres
+  - image: registry.access.redhat.com/ubi10/ubi-minimal@sha256:7dc60d7777e010c50f5e041ff069112b379c3d5eef2823d20871c67cf663f10c
+    name: init-ubi-minimal
+  version: 1.5.2
+  webhookdefinitions:
+  - type: ValidatingAdmissionWebhook
+    admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: kubernaut-operator-controller-manager
+    failurePolicy: Fail
+    generateName: validate.kubernaut.ai
+    rules:
+    - apiGroups:
+      - kubernaut.ai
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      resources:
+      - kubernauts
+    sideEffects: None
+    targetPort: 9443
+    webhookPath: /validate-kubernaut-singleton

--- a/operators/kubernaut-operator/1.5.2/manifests/kubernaut.ai_kubernauts.yaml
+++ b/operators/kubernaut-operator/1.5.2/manifests/kubernaut.ai_kubernauts.yaml
@@ -1,0 +1,2290 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: kubernauts.kubernaut.ai
+spec:
+  group: kubernaut.ai
+  names:
+    kind: Kubernaut
+    listKind: KubernautList
+    plural: kubernauts
+    singular: kubernaut
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Kubernaut is the Schema for the kubernauts API.
+          It declares a single Kubernaut deployment within the namespace it is created in.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KubernautSpec defines the desired state of a Kubernaut deployment on OCP.
+              The operator deploys all Kubernaut services into the CR's namespace and
+              auto-derives OCP platform configuration (monitoring, service-ca, Routes).
+            properties:
+              aiAnalysis:
+                description: AIAnalysis controller configuration.
+                properties:
+                  confidenceThreshold:
+                    description: |-
+                      Optional confidence threshold override for the Rego policy.
+                      Expressed as a decimal string, e.g. "0.85".
+                    type: string
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  policy:
+                    description: |-
+                      Policy ConfigMap reference. Required.
+                      The ConfigMap must contain key "approval.rego".
+                    properties:
+                      configMapName:
+                        description: Name of the ConfigMap.
+                        type: string
+                    required:
+                    - configMapName
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                required:
+                - policy
+                type: object
+              ansible:
+                description: Optional AWX/AAP integration for Ansible-based remediation
+                  workflows.
+                properties:
+                  apiURL:
+                    description: AWX/AAP API URL. Required when Enabled is true.
+                    type: string
+                  caCertSecretRef:
+                    description: |-
+                      CACertSecretRef references a Secret containing the PEM-encoded CA
+                      certificate for the AAP/AWX API endpoint. Use this when the AAP uses
+                      a self-signed certificate or a private CA. If omitted, the system
+                      trust store is used.
+                    properties:
+                      key:
+                        default: ca.crt
+                        description: Key within the Secret containing the CA PEM.
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  enabled:
+                    default: false
+                    description: Whether AWX/AAP integration is enabled.
+                    type: boolean
+                  organizationID:
+                    default: 1
+                    description: AWX organization ID.
+                    minimum: 1
+                    type: integer
+                  tokenSecretRef:
+                    description: Reference to the Secret containing the AWX API token.
+                    properties:
+                      key:
+                        default: token
+                        description: 'Key within the Secret. Default: "token".'
+                        type: string
+                      name:
+                        description: Name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+                x-kubernetes-validations:
+                - message: ansible.apiURL is required when ansible.enabled is true
+                  rule: '!self.enabled || has(self.apiURL)'
+              apiFrontend:
+                description: APIFrontend configures the API Frontend (MCP/A2A gateway)
+                  service.
+                properties:
+                  agentCardURL:
+                    description: |-
+                      Display name for the A2A agent card (/.well-known/agent-card.json).
+                      External URL for the A2A agent card discovery endpoint.
+                      When empty, auto-derived from the in-cluster service FQDN.
+                      Must be a valid HTTPS URL when set.
+                    pattern: ^$|^https?://
+                    type: string
+                  auth:
+                    description: OIDC authentication configuration.
+                    properties:
+                      allowInsecureIssuers:
+                        description: |-
+                          Allow HTTP (non-TLS) JWKS URLs. Must remain false in production
+                          (FedRAMP SC-8: transmission confidentiality). Intended for dev/test only.
+                        type: boolean
+                      audience:
+                        default: kubernaut-apifrontend
+                        description: 'Expected JWT audience claim (FedRAMP SC-23:
+                          session authenticity).'
+                        type: string
+                      issuerURL:
+                        description: |-
+                          OIDC issuer URL (e.g. "https://login.kubernaut.ai/realms/kubernaut").
+                          Used for single-provider auth or kagenti auto-detection fallback.
+                          When jwtProviders is non-empty, multi-provider config takes precedence.
+                        type: string
+                      jwksURL:
+                        description: |-
+                          Explicit JWKS endpoint URL for token signature verification
+                          (FedRAMP IA-5: authenticator management). When empty, derived from
+                          issuerURL + "/protocol/openid-connect/certs".
+                        type: string
+                      jwtProviders:
+                        description: |-
+                          Multi-provider JWT configuration (FedRAMP IA-2: multi-source auth).
+                          When non-empty, the AF validates tokens against all configured
+                          providers concurrently. Takes precedence over the single-provider
+                          issuerURL/audience/jwksURL fields above.
+                        items:
+                          description: |-
+                            JWTProviderSpec configures a single OIDC JWT provider for multi-issuer
+                            authentication. Shared by KA interactive and API Frontend auth.
+                          properties:
+                            audiences:
+                              description: Expected audience claim values for session
+                                authenticity (FedRAMP SC-23).
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            claimMappings:
+                              description: Claim mappings for username and group extraction
+                                (FedRAMP AC-6).
+                              properties:
+                                groups:
+                                  description: JWT claim name for group membership
+                                    extraction.
+                                  type: string
+                                username:
+                                  description: JWT claim name for username extraction.
+                                  type: string
+                              type: object
+                            issuerURL:
+                              description: OIDC issuer URL for token validation.
+                              minLength: 1
+                              type: string
+                            jwksURL:
+                              description: |-
+                                JWKS endpoint URL for token signature verification. When empty,
+                                derived from IssuerURL. Must use HTTPS unless the parent's
+                                allowInsecureJWKS/allowInsecureIssuers flag is true.
+                              maxLength: 2048
+                              type: string
+                            name:
+                              description: Human-readable name for this provider (e.g.
+                                "rhbk", "spire").
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                          required:
+                          - audiences
+                          - issuerURL
+                          - name
+                          type: object
+                        maxItems: 8
+                        type: array
+                      oidcCaFile:
+                        description: |-
+                          Path to CA bundle for OIDC/JWKS TLS trust (FedRAMP IA-5). When set,
+                          AF uses this CA to verify the OIDC provider's certificate chain.
+                        type: string
+                      tokenReviewAudience:
+                        description: |-
+                          TokenReview audience for Kubernetes ServiceAccount token validation.
+                          When set, the API Frontend passes this audience to the TokenReview API
+                          so only tokens issued for this specific audience are accepted
+                          (FedRAMP IA-5: authenticator management).
+                        type: string
+                    type: object
+                  enabled:
+                    default: true
+                    description: |-
+                      Whether the API Frontend component is deployed. Defaults to true.
+                      Set to false to skip all AF resources (Deployment, Service, RBAC, etc.).
+                    type: boolean
+                  healthPort:
+                    description: |-
+                      Override for the AF health probe port. Defaults to 8081 (or 8082 when
+                      kagenti sidecar port shifting is active). Use when cluster policies
+                      restrict port ranges.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1024
+                    type: integer
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  metricsPort:
+                    description: |-
+                      Override for the AF metrics port. Defaults to 9090 (or 9092 when
+                      kagenti sidecar port shifting is active). Use when cluster policies
+                      restrict port ranges.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1024
+                    type: integer
+                  rateLimit:
+                    description: Request rate limiting configuration.
+                    properties:
+                      ipRequestsPerSec:
+                        default: 50
+                        description: Per-IP requests per second.
+                        type: integer
+                      maxConcurrentSessions:
+                        default: 100
+                        description: Maximum concurrent MCP/A2A sessions.
+                        type: integer
+                      toolCallsPerMinute:
+                        default: 60
+                        description: Tool calls per minute per user.
+                        type: integer
+                      userRequestsPerSec:
+                        default: 20
+                        description: Per-user requests per second.
+                        type: integer
+                    type: object
+                  rbac:
+                    description: |-
+                      SAR-based RBAC configuration for tool authorization.
+                      When set, the operator provisions persona-based tool ClusterRoles
+                      and group-to-role ClusterRoleBindings instead of file-based RBAC.
+                    properties:
+                      roleBindings:
+                        description: RoleBindings maps persona-based tool roles to
+                          OIDC groups.
+                        items:
+                          description: |-
+                            ToolRoleBinding binds a tool role to one or more OIDC groups.
+                            Exactly one of Role or ClusterRoleName must be set.
+                          properties:
+                            clusterRoleName:
+                              description: |-
+                                ClusterRoleName references a user-managed ClusterRole for custom tool authorization.
+                                The operator creates only the ClusterRoleBinding; the ClusterRole itself must be
+                                pre-created by the user with rules granting verb "use" on resource "tools" in
+                                apiGroup "kubernaut.ai".
+                                Mutually exclusive with Role.
+                              type: string
+                            groups:
+                              description: Groups are the OIDC group names to bind
+                                to this role.
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            role:
+                              description: |-
+                                Role is a built-in persona name. Must be one of: sre, ai-orchestrator, cicd,
+                                observability, l3-audit, remediation-approver.
+                                Mutually exclusive with ClusterRoleName.
+                              enum:
+                              - sre
+                              - ai-orchestrator
+                              - cicd
+                              - observability
+                              - l3-audit
+                              - remediation-approver
+                              type: string
+                          required:
+                          - groups
+                          type: object
+                        type: array
+                      sarCacheTTL:
+                        default: 30s
+                        description: |-
+                          SARCacheTTL is the cache duration for SubjectAccessReview results.
+                          Must be a valid Go duration string (e.g. "30s", "2m").
+                        type: string
+                    type: object
+                  rbacRolesConfigMapRef:
+                    description: |-
+                      Reference to a pre-existing ConfigMap containing RBAC role-to-tool
+                      mappings (key: "rbac_roles.yaml"). When empty, the operator generates
+                      a default RBAC roles ConfigMap.
+                      Deprecated: replaced by RBAC field with SAR-based tool authorization.
+                    properties:
+                      configMapName:
+                        description: Name of the ConfigMap.
+                        type: string
+                    required:
+                    - configMapName
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  route:
+                    description: |-
+                      Route configuration for OCP external access (FedRAMP SC-8).
+                      Disabled by default; set route.enabled=true to expose AF via an
+                      OpenShift Route with reencrypt TLS termination.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Whether to create an OCP Route for the API Frontend.
+                        type: boolean
+                      hostname:
+                        description: Hostname override. When empty, the OCP router
+                          auto-generates a hostname.
+                        type: string
+                    type: object
+                  shutdown:
+                    description: Graceful shutdown configuration.
+                    properties:
+                      drainSeconds:
+                        default: 15
+                        description: Seconds to wait for in-flight requests to drain
+                          during shutdown.
+                        maximum: 300
+                        minimum: 0
+                        type: integer
+                    type: object
+                  spire:
+                    description: |-
+                      SPIRE mTLS identity configuration for kagenti agent card discovery
+                      (FedRAMP SC-8, IA-5). When enabled, a ClusterSPIFFEID is created and
+                      a SPIRE-aware mTLS sidecar is injected into the AF deployment so the
+                      kagenti-operator can perform verified fetch with identity binding.
+                    properties:
+                      className:
+                        description: |-
+                          SPIRE class name for the ClusterSPIFFEID (e.g. "zero-trust-workload-identity-manager-spire").
+                          When empty, the className field is omitted from the ClusterSPIFFEID spec.
+                        type: string
+                      enabled:
+                        default: true
+                        description: Whether SPIRE mTLS sidecar injection is enabled.
+                        type: boolean
+                      trustDomain:
+                        description: |-
+                          TrustDomain overrides the SPIFFE ID trust domain. When empty (default),
+                          the operator uses SPIRE's {{ .TrustDomain }} template variable, which
+                          resolves to the cluster's configured trust domain at SVID registration
+                          time. Set this only if you need a fixed trust domain that differs from
+                          the SPIRE server's.
+                        type: string
+                    type: object
+                type: object
+              authWebhook:
+                description: AuthWebhook admission controller settings.
+                properties:
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              console:
+                description: Console configures the standalone web console (A2A chat
+                  UI).
+                properties:
+                  auth:
+                    description: OIDC authentication configuration for the console
+                      oauth2-proxy.
+                    properties:
+                      secretName:
+                        description: |-
+                          Name of the pre-existing Secret containing OIDC credentials.
+                          Required keys: client-id, client-secret, cookie-secret.
+                        minLength: 1
+                        type: string
+                    type: object
+                  enabled:
+                    default: false
+                    description: Whether the Console component is deployed. Defaults
+                      to false (opt-in).
+                    type: boolean
+                  resources:
+                    description: Resource requirements for the console container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  route:
+                    description: OCP Route configuration for external access.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Whether to create an OCP Route. Defaults to true
+                          on OpenShift.
+                        type: boolean
+                      host:
+                        description: Explicit hostname. Empty = auto-derived from
+                          namespace.
+                        type: string
+                    type: object
+                type: object
+              dataStorage:
+                description: DataStorage service settings.
+                properties:
+                  endpointPropagationDelay:
+                    default: 10s
+                    description: |-
+                      EndpointPropagationDelay is the delay before newly created endpoints
+                      are considered ready. Prevents traffic routing to pods that haven't
+                      finished warming up. Must be a valid Go duration string.
+                    type: string
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  retention:
+                    description: Retention configures periodic purge of expired audit
+                      events (FedRAMP AU-11).
+                    properties:
+                      batchSize:
+                        default: 1000
+                        description: Maximum number of rows deleted per batch.
+                        minimum: 1
+                        type: integer
+                      defaultDays:
+                        default: 2555
+                        description: |-
+                          Number of days to retain audit events before purge.
+                          Clamped to a maximum of 2555 (≈7 years per ADR-034 / SOC 2 / ISO 27001).
+                        maximum: 2555
+                        minimum: 1
+                        type: integer
+                      enabled:
+                        description: |-
+                          Whether the retention purge worker is active.
+                          Defaults to false (safe default — no data is deleted without opt-in).
+                        type: boolean
+                      interval:
+                        default: 24h
+                        description: How often the purge worker runs. Must be a valid
+                          Go duration string.
+                        type: string
+                    type: object
+                  signingCert:
+                    description: |-
+                      SigningCert configures the audit export signing certificate (FedRAMP AU-9).
+                      When set, the named Secret is mounted into the DS pod at /etc/certs.
+                    properties:
+                      mountPath:
+                        default: /etc/certs
+                        description: Mount path inside the container. Defaults to
+                          /etc/certs.
+                        type: string
+                      secretName:
+                        description: Name of the Kubernetes Secret containing the
+                          signing cert (tls.crt, tls.key).
+                        type: string
+                    required:
+                    - secretName
+                    type: object
+                type: object
+              effectivenessMonitor:
+                description: EffectivenessMonitor controller configuration.
+                properties:
+                  assessment:
+                    description: Assessment windows for remediation effectiveness
+                      evaluation.
+                    properties:
+                      stabilizationWindow:
+                        default: 30s
+                        type: string
+                      validityWindow:
+                        default: 300s
+                        type: string
+                    type: object
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              gateway:
+                description: Gateway service settings.
+                properties:
+                  config:
+                    description: Gateway server and middleware configuration.
+                    properties:
+                      cors:
+                        description: |-
+                          CORS configuration. Gateway is an M2M webhook API, not a browser
+                          target, so the defaults block all cross-origin requests.
+                        properties:
+                          allowCredentials:
+                            default: false
+                            description: Whether cross-origin requests may include
+                              credentials.
+                            type: boolean
+                          allowedMethods:
+                            description: |-
+                              HTTP methods allowed for cross-origin requests.
+                              Default: ["GET","POST","PUT","PATCH","DELETE","OPTIONS"].
+                            items:
+                              type: string
+                            type: array
+                          allowedOrigins:
+                            description: |-
+                              Allowed origins for CORS requests.
+                              Default: ["https://no-browser-clients.invalid"] (blocks all browser clients).
+                            items:
+                              type: string
+                            type: array
+                          maxAge:
+                            default: 300
+                            description: Preflight cache duration in seconds.
+                            type: integer
+                        type: object
+                      deduplicationCooldown:
+                        default: 5m
+                        description: Deduplication cooldown period for alert processing.
+                        type: string
+                      k8sRequestTimeout:
+                        default: 15s
+                        description: 'Timeout for outbound K8s API requests. Default:
+                          "15s".'
+                        type: string
+                      trustedProxyCIDRs:
+                        description: |-
+                          Trusted proxy CIDRs for X-Forwarded-For / RealIP extraction.
+                          Empty = fail-closed (proxy headers never trusted).
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  enabled:
+                    default: true
+                    description: |-
+                      Whether the Gateway component is deployed. Defaults to true.
+                      Set to false to skip all Gateway resources (Deployment, Service, RBAC, etc.).
+                    type: boolean
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  route:
+                    description: Route configuration for OCP external access.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Whether to create an OCP Route for the Gateway.
+                        type: boolean
+                      hostname:
+                        description: Hostname override. When empty, the OCP router
+                          auto-generates a hostname.
+                        type: string
+                    type: object
+                type: object
+              image:
+                description: Image pull policy, pull secrets, and optional per-component
+                  overrides.
+                properties:
+                  overrides:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Per-component image overrides. Keys are component names
+                      (e.g. "gateway", "datastorage", "kubernautagent"), values are full
+                      image references (e.g. "myregistry.example.com/gateway:v1.4.0").
+                      When set, overrides the RELATED_IMAGE env var for that component.
+                    type: object
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: Pull policy for all containers.
+                    type: string
+                  pullSecrets:
+                    description: Pull secrets for private registries.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+              kubernautAgent:
+                description: Kubernaut Agent (KA) -- LLM-powered investigation and
+                  analysis service.
+                properties:
+                  additionalClusterRoleBindings:
+                    description: |-
+                      AdditionalClusterRoleBindings is an optional list of pre-existing
+                      ClusterRole names to bind to the Kubernaut Agent ServiceAccount.
+                    items:
+                      type: string
+                    maxItems: 64
+                    type: array
+                    x-kubernetes-list-type: set
+                  alignmentCheck:
+                    description: Alignment check (shadow agent) configuration.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Whether alignment check is enabled.
+                        type: boolean
+                      llm:
+                        description: Optional dedicated LLM for alignment checks.
+                        properties:
+                          apiKey:
+                            type: string
+                          endpoint:
+                            type: string
+                          model:
+                            type: string
+                          provider:
+                            type: string
+                        type: object
+                      maxStepTokens:
+                        default: 500
+                        description: Maximum tokens per alignment step.
+                        type: integer
+                      timeout:
+                        default: 10s
+                        description: Timeout for alignment check requests.
+                        type: string
+                    type: object
+                  audit:
+                    description: Audit logging configuration.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Whether audit logging is enabled.
+                        type: boolean
+                    type: object
+                  interactive:
+                    description: Interactive mode JWT identity delegation configuration.
+                    properties:
+                      allowInsecureJWKS:
+                        description: |-
+                          AllowInsecureJWKS permits HTTP (non-TLS) JWKS URLs for dev/test.
+                          Production deployments MUST leave this false.
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Whether MCP interactive mode endpoint and Lease-based session
+                          management are enabled. When true, KA exposes a Streamable HTTP
+                          MCP endpoint at POST /api/v1/mcp.
+                        type: boolean
+                      inactivityTimeout:
+                        description: |-
+                          Session timeout after last operator activity.
+                          Must be a valid Go duration string (e.g. "10m").
+                        type: string
+                      jwtProviders:
+                        description: JWT providers for OIDC-based identity delegation.
+                        items:
+                          description: |-
+                            JWTProviderSpec configures a single OIDC JWT provider for multi-issuer
+                            authentication. Shared by KA interactive and API Frontend auth.
+                          properties:
+                            audiences:
+                              description: Expected audience claim values for session
+                                authenticity (FedRAMP SC-23).
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                            claimMappings:
+                              description: Claim mappings for username and group extraction
+                                (FedRAMP AC-6).
+                              properties:
+                                groups:
+                                  description: JWT claim name for group membership
+                                    extraction.
+                                  type: string
+                                username:
+                                  description: JWT claim name for username extraction.
+                                  type: string
+                              type: object
+                            issuerURL:
+                              description: OIDC issuer URL for token validation.
+                              minLength: 1
+                              type: string
+                            jwksURL:
+                              description: |-
+                                JWKS endpoint URL for token signature verification. When empty,
+                                derived from IssuerURL. Must use HTTPS unless the parent's
+                                allowInsecureJWKS/allowInsecureIssuers flag is true.
+                              maxLength: 2048
+                              type: string
+                            name:
+                              description: Human-readable name for this provider (e.g.
+                                "rhbk", "spire").
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                          required:
+                          - audiences
+                          - issuerURL
+                          - name
+                          type: object
+                        maxItems: 8
+                        type: array
+                      maxConcurrentSessions:
+                        description: Maximum concurrent interactive sessions per agent
+                          replica.
+                        minimum: 1
+                        type: integer
+                      rateLimitPerUser:
+                        description: Maximum MCP requests per second per authenticated
+                          user.
+                        minimum: 1
+                        type: integer
+                      sessionTTL:
+                        description: |-
+                          Maximum duration for an interactive session before auto-release.
+                          Must be a valid Go duration string (e.g. "30m").
+                        type: string
+                    type: object
+                  llm:
+                    description: LLM provider and credentials configuration.
+                    properties:
+                      azureApiVersion:
+                        description: Azure OpenAI API version.
+                        type: string
+                      bedrockRegion:
+                        description: AWS Bedrock region.
+                        type: string
+                      credentialsSecretName:
+                        description: Name of the Secret containing LLM API credentials.
+                        minLength: 1
+                        type: string
+                      endpoint:
+                        description: LLM API endpoint override. When empty, uses the
+                          provider default.
+                        type: string
+                      maxRetries:
+                        default: 3
+                        description: Maximum number of retries for LLM API calls.
+                        type: integer
+                      model:
+                        description: LLM model name (e.g. "gpt-4o", "gemini-2.5-pro").
+                        minLength: 1
+                        type: string
+                      oauth2:
+                        description: OAuth2 configuration for LLM authentication.
+                        properties:
+                          credentialsSecretRef:
+                            description: |-
+                              Name of the Secret containing OAuth2 client credentials
+                              (keys: "client-id", "client-secret").
+                            type: string
+                          enabled:
+                            default: false
+                            description: Whether OAuth2 authentication is enabled.
+                            type: boolean
+                          scopes:
+                            description: OAuth2 scopes.
+                            items:
+                              type: string
+                            type: array
+                          tokenURL:
+                            description: Token endpoint URL.
+                            type: string
+                        type: object
+                      phaseModels:
+                        additionalProperties:
+                          description: |-
+                            LLMPhaseOverrideSpec allows a specific agent phase to use a different LLM.
+                            All fields are optional; non-zero fields override the corresponding base values.
+                          properties:
+                            apiKey:
+                              type: string
+                            endpoint:
+                              type: string
+                            model:
+                              type: string
+                            provider:
+                              type: string
+                          type: object
+                        description: |-
+                          Per-phase LLM model overrides. Keys are agent phase names
+                          (rca, workflow_discovery, validation). Each override can specify
+                          a different model (and optionally provider/endpoint) for that phase,
+                          allowing faster/cheaper models for structured tasks like workflow discovery.
+                          When absent, all phases use the default model above.
+                        type: object
+                        x-kubernetes-validations:
+                        - message: 'phaseModels keys must be one of: rca, workflow_discovery,
+                            validation'
+                          rule: self.all(k, k in ['rca','workflow_discovery','validation'])
+                      provider:
+                        description: LLM provider name (e.g. "openai", "vertexai",
+                          "bedrock", "azure").
+                        minLength: 1
+                        type: string
+                      runtimeConfigMapName:
+                        description: |-
+                          Name of a pre-existing ConfigMap for the LLM runtime configuration.
+                          When set, the operator skips generating kubernaut-agent-llm-runtime
+                          and mounts this ConfigMap instead. Must contain key "llm-runtime.yaml".
+                        type: string
+                      temperature:
+                        description: |-
+                          Sampling temperature for LLM responses (e.g. "0.7").
+                          Serialized as string to avoid CRD float portability issues.
+                        type: string
+                      timeoutSeconds:
+                        default: 120
+                        description: Timeout in seconds for LLM API calls.
+                        type: integer
+                      tlsCaFile:
+                        description: Path to a CA certificate file for TLS to the
+                          LLM endpoint.
+                        type: string
+                      tlsCertFile:
+                        description: |-
+                          Path to a client certificate file for mTLS to the LLM endpoint.
+                          Must be set together with TLSKeyFile.
+                        type: string
+                      tlsClientSecretRef:
+                        description: |-
+                          Name of the Secret containing the TLS client certificate and key
+                          for mTLS to the LLM endpoint. The Secret must contain tls.crt and
+                          tls.key entries. Required when TLSCertFile and TLSKeyFile are set.
+                        type: string
+                      tlsKeyFile:
+                        description: |-
+                          Path to a client key file for mTLS to the LLM endpoint.
+                          Must be set together with TLSCertFile.
+                        type: string
+                      vertexLocation:
+                        description: GCP Vertex AI location (e.g. "us-central1").
+                        type: string
+                      vertexProject:
+                        description: GCP Vertex AI project ID.
+                        type: string
+                    required:
+                    - credentialsSecretName
+                    - model
+                    - provider
+                    type: object
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  maxTurns:
+                    default: 40
+                    description: |-
+                      MaxTurns is the maximum number of LLM conversation turns the
+                      investigator may execute per analysis session.
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  safety:
+                    description: Safety guardrails for LLM interactions.
+                    properties:
+                      anomaly:
+                        description: Anomaly detection thresholds.
+                        properties:
+                          maxRepeatedFailures:
+                            default: 3
+                            description: Max repeated failures before circuit-breaker.
+                            type: integer
+                          maxToolCallsPerTool:
+                            default: 10
+                            description: Max tool calls per individual tool.
+                            type: integer
+                          maxTotalToolCalls:
+                            default: 40
+                            description: Max total tool calls across all tools.
+                            type: integer
+                        type: object
+                      sanitization:
+                        description: Input sanitization rules.
+                        properties:
+                          credentialScrubEnabled:
+                            default: true
+                            description: Whether credential scrubbing is enabled.
+                            type: boolean
+                          injectionPatternsEnabled:
+                            default: true
+                            description: Whether prompt injection pattern detection
+                              is enabled.
+                            type: boolean
+                        type: object
+                    type: object
+                  serverRateLimit:
+                    description: Server-level rate limiting for the KA HTTP endpoint.
+                    properties:
+                      burst:
+                        default: 100
+                        description: Burst size (max concurrent requests above the
+                          steady-state rate).
+                        minimum: 1
+                        type: integer
+                      requestsPerSecond:
+                        default: 50
+                        description: Requests per second allowed.
+                        minimum: 1
+                        type: integer
+                    type: object
+                  session:
+                    description: Session configuration.
+                    properties:
+                      ttl:
+                        default: 30m
+                        description: Session time-to-live.
+                        type: string
+                    type: object
+                  shutdown:
+                    description: Graceful shutdown configuration.
+                    properties:
+                      drainSeconds:
+                        default: 15
+                        description: Seconds to wait for in-flight requests to drain
+                          during shutdown.
+                        maximum: 300
+                        minimum: 0
+                        type: integer
+                    type: object
+                  summarizer:
+                    description: Summarizer configuration for tool output compression.
+                    properties:
+                      maxToolOutputSize:
+                        default: 100000
+                        description: Maximum tool output size in bytes before truncation.
+                        type: integer
+                      threshold:
+                        default: 8000
+                        description: Token threshold above which tool output is summarized.
+                        type: integer
+                    type: object
+                required:
+                - llm
+                type: object
+              monitoring:
+                description: OCP monitoring integration (Prometheus, AlertManager).
+                properties:
+                  enabled:
+                    default: true
+                    description: |-
+                      Whether OCP monitoring integration is enabled.
+                      When true, the operator auto-derives Prometheus/AlertManager URLs
+                      and provisions monitoring RBAC.
+                    type: boolean
+                type: object
+              networkPolicies:
+                description: |-
+                  NetworkPolicies controls the creation of Kubernetes NetworkPolicy
+                  resources that enforce a default-deny posture with explicit allow rules.
+                properties:
+                  enabled:
+                    default: false
+                    description: |-
+                      Whether the operator creates NetworkPolicy resources.
+                      When true, a default-deny posture is applied with explicit allow rules
+                      matching the upstream Helm chart traffic matrix. Monitoring namespace,
+                      ingress namespaces, and API server egress are auto-detected.
+                    type: boolean
+                type: object
+              notification:
+                description: Notification controller settings.
+                properties:
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requirements for the notification controller.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  routing:
+                    description: |-
+                      Optional routing ConfigMap reference for advanced notification routing.
+                      Must contain key "routing.yaml" with Alertmanager-style routing rules.
+                    properties:
+                      configMapName:
+                        description: Name of the ConfigMap.
+                        type: string
+                    required:
+                    - configMapName
+                    type: object
+                  slack:
+                    description: Slack quickstart shortcut.
+                    properties:
+                      channel:
+                        default: '#kubernaut-alerts'
+                        description: Slack channel for notifications.
+                        type: string
+                      secretName:
+                        description: |-
+                          Name of the Secret containing the Slack webhook URL (key: "webhook-url").
+                          Empty = no Slack, console-only delivery.
+                        type: string
+                    type: object
+                type: object
+              postgresql:
+                description: |-
+                  BYO PostgreSQL connection. The operator validates the secret and derives
+                  the DataStorage db-secrets.yaml Secret automatically.
+                properties:
+                  host:
+                    description: PostgreSQL hostname or service DNS.
+                    minLength: 1
+                    type: string
+                  port:
+                    default: 5432
+                    description: PostgreSQL port.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  secretName:
+                    description: |-
+                      Name of the Secret containing PostgreSQL credentials.
+                      Required keys: POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB.
+                    minLength: 1
+                    type: string
+                  sslMode:
+                    default: verify-full
+                    description: PostgreSQL SSL mode (disable, require, verify-ca,
+                      verify-full).
+                    enum:
+                    - require
+                    - verify-ca
+                    - verify-full
+                    type: string
+                required:
+                - host
+                - secretName
+                type: object
+              remediationOrchestrator:
+                description: RemediationOrchestrator controller configuration.
+                properties:
+                  asyncPropagation:
+                    description: Async propagation delay configuration.
+                    properties:
+                      gitOpsSyncDelay:
+                        default: 3m
+                        type: string
+                      operatorReconcileDelay:
+                        default: 1m
+                        type: string
+                      proactiveAlertDelay:
+                        default: 5m
+                        type: string
+                    type: object
+                  dryRun:
+                    default: false
+                    description: |-
+                      DryRun enables dry-run mode: the pipeline stops after AI analysis
+                      without executing remediation workflows. Operators use this to
+                      build confidence before enabling fully autonomous remediation.
+                    type: boolean
+                  dryRunHoldPeriod:
+                    default: 1h
+                    description: |-
+                      DryRunHoldPeriod suppresses re-triggering of the same signal after
+                      a dry-run completion. Must be a valid Go duration string.
+                      Only effective when DryRun is true.
+                    type: string
+                  effectivenessAssessment:
+                    description: Effectiveness assessment configuration.
+                    properties:
+                      stabilizationWindow:
+                        default: 5m
+                        type: string
+                    type: object
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  notifications:
+                    description: Notification behaviour for remediation events.
+                    properties:
+                      notifySelfResolved:
+                        default: false
+                        description: Whether to notify on self-resolved remediations.
+                        type: boolean
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  retention:
+                    description: Retention policy for completed remediation records.
+                    properties:
+                      period:
+                        default: 24h
+                        description: How long to retain completed remediation records.
+                        type: string
+                    type: object
+                  routing:
+                    description: Routing thresholds for failure detection and cooldowns.
+                    properties:
+                      consecutiveFailureCooldown:
+                        default: 1h
+                        type: string
+                      consecutiveFailureThreshold:
+                        default: 3
+                        type: integer
+                      exponentialBackoffBase:
+                        default: 1m
+                        type: string
+                      exponentialBackoffMax:
+                        default: 10m
+                        type: string
+                      exponentialBackoffMaxExponent:
+                        default: 4
+                        type: integer
+                      ineffectiveChainThreshold:
+                        default: 3
+                        type: integer
+                      ineffectiveTimeWindow:
+                        default: 4h
+                        type: string
+                      noActionRequiredDelayHours:
+                        default: 24
+                        type: integer
+                      recentlyRemediatedCooldown:
+                        default: 5m
+                        type: string
+                      recurrenceCountThreshold:
+                        default: 5
+                        type: integer
+                      scopeBackoffBase:
+                        default: 5s
+                        type: string
+                      scopeBackoffMax:
+                        default: 5m
+                        type: string
+                    type: object
+                  timeouts:
+                    description: Timeout configuration for remediation phases.
+                    properties:
+                      analyzing:
+                        default: 10m
+                        type: string
+                      awaitingApproval:
+                        default: 15m
+                        type: string
+                      executing:
+                        default: 30m
+                        type: string
+                      global:
+                        default: 1h
+                        type: string
+                      processing:
+                        default: 5m
+                        type: string
+                      verifying:
+                        default: 30m
+                        type: string
+                    type: object
+                type: object
+              signalProcessing:
+                description: SignalProcessing controller configuration.
+                properties:
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  policy:
+                    description: |-
+                      Policy ConfigMap reference. Required.
+                      The ConfigMap must contain key "policy.rego".
+                    properties:
+                      configMapName:
+                        description: Name of the ConfigMap.
+                        type: string
+                    required:
+                    - configMapName
+                    type: object
+                  proactiveSignalMappings:
+                    description: |-
+                      Optional proactive signal mappings ConfigMap reference.
+                      Must contain key "proactive-signal-mappings.yaml".
+                    properties:
+                      configMapName:
+                        description: Name of the ConfigMap.
+                        type: string
+                    required:
+                    - configMapName
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                required:
+                - policy
+                type: object
+              valkey:
+                description: BYO Valkey/Redis connection.
+                properties:
+                  host:
+                    description: Valkey hostname or service DNS.
+                    minLength: 1
+                    type: string
+                  port:
+                    default: 6379
+                    description: Valkey port.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  secretName:
+                    description: |-
+                      Name of the Secret containing Valkey credentials.
+                      Required key: valkey-secrets.yaml (YAML content: "password: <value>").
+                    minLength: 1
+                    type: string
+                  tls:
+                    description: |-
+                      TLS configures client-side TLS for the Valkey/Redis connection.
+                      Server-side TLS provisioning is the platform admin's responsibility
+                      (Valkey is BYO).
+                    properties:
+                      caSecretName:
+                        description: |-
+                          Name of the Secret containing the CA certificate to verify the server.
+                          Required key: ca.crt
+                        type: string
+                      clientCertSecretName:
+                        description: |-
+                          Name of the Secret containing client certificate and key for mTLS.
+                          Required keys: tls.crt, tls.key
+                        type: string
+                      enabled:
+                        description: Whether TLS is enabled for the Valkey/Redis connection.
+                        type: boolean
+                    required:
+                    - enabled
+                    type: object
+                required:
+                - host
+                - secretName
+                type: object
+              workflowExecution:
+                description: WorkflowExecution controller configuration.
+                properties:
+                  cooldownPeriod:
+                    default: 1m
+                    description: Cooldown period between workflow executions.
+                    type: string
+                  logging:
+                    description: LoggingSpec configures the log level for a service.
+                    properties:
+                      level:
+                        default: info
+                        description: 'Log level. One of: DEBUG, INFO, WARN, ERROR.'
+                        enum:
+                        - DEBUG
+                        - INFO
+                        - WARN
+                        - ERROR
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  resources:
+                    description: Resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  tekton:
+                    description: Tekton integration configuration.
+                    properties:
+                      enabled:
+                        description: Whether Tekton integration is enabled. When nil,
+                          auto-detected.
+                        type: boolean
+                    type: object
+                  workflowNamespace:
+                    default: kubernaut-workflows
+                    description: Namespace for workflow Job/PipelineRun execution.
+                    type: string
+                type: object
+            required:
+            - kubernautAgent
+            - postgresql
+            - valkey
+            type: object
+          status:
+            description: KubernautStatus defines the observed state of a Kubernaut
+              deployment.
+            properties:
+              boundAdditionalClusterRoles:
+                description: |-
+                  ClusterRole names for which the operator has created additional
+                  agent ClusterRoleBindings. Used for stale-pruning on spec changes
+                  and finalizer cleanup.
+                items:
+                  type: string
+                type: array
+              boundToolRoleBindings:
+                description: |-
+                  BoundToolRoleBindings tracks the set of tool role binding CRB names
+                  currently managed by the operator for stale-pruning and finalizer cleanup.
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: Standard conditions following the metav1.Condition contract.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastMigrationHash:
+                description: |-
+                  Hash of the last successfully completed migration Job spec.
+                  Used to skip re-running migration when the Job has been deleted
+                  (e.g. TTL cleanup, manual deletion) but nothing has changed.
+                type: string
+              lastMigrationTime:
+                description: Timestamp of the last successfully completed migration.
+                format: date-time
+                type: string
+              phase:
+                description: Aggregate lifecycle phase.
+                enum:
+                - Validating
+                - Migrating
+                - Deploying
+                - Running
+                - Degraded
+                - Error
+                type: string
+              services:
+                description: Per-service readiness.
+                items:
+                  description: ServiceStatus reports the readiness of a single managed
+                    service.
+                  properties:
+                    desiredReplicas:
+                      description: Desired number of replicas.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Service name (e.g. "gateway", "datastorage").
+                      type: string
+                    ready:
+                      description: Whether the service has all desired replicas ready.
+                      type: boolean
+                    readyReplicas:
+                      description: Number of ready replicas.
+                      format: int32
+                      type: integer
+                  required:
+                  - desiredReplicas
+                  - name
+                  - ready
+                  - readyReplicas
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/kubernaut-operator/1.5.2/metadata/annotations.yaml
+++ b/operators/kubernaut-operator/1.5.2/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kubernaut-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/kubernaut-operator/catalog-templates/semver.yaml
+++ b/operators/kubernaut-operator/catalog-templates/semver.yaml
@@ -10,3 +10,4 @@ Candidate:
   - Image: quay.io/community-operator-pipeline-prod/kubernaut-operator:1.4.1
   - Image: quay.io/community-operator-pipeline-prod/kubernaut-operator:1.5.0
   - Image: quay.io/community-operator-pipeline-prod/kubernaut-operator:1.5.1
+  - Image: quay.io/community-operator-pipeline-prod/kubernaut-operator:1.5.2


### PR DESCRIPTION
## Summary

Publish kubernaut-operator v1.5.2 to the community catalog.

### Changes from v1.5.1

- All operand images now reference `quay.io/kubernaut-ai/` (production registry)
- Console and oauth2-proxy images pinned by digest via `RELATED_IMAGE_*` env vars (air-gap support)
- Added `ingresses` resource to `config.openshift.io` RBAC for cluster ingress domain auto-detection
- CRD updates: multi-provider JWT auth (`jwtProviders`), console redirect URL improvements


Made with [Cursor](https://cursor.com)