### PR TITLE
operator fqdn-egress-operator (1.0.6)

### DIFF
--- a/operators/fqdn-egress-operator/1.0.6/bundle.Dockerfile
+++ b/operators/fqdn-egress-operator/1.0.6/bundle.Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=fqdn-egress-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fqdn-egress-operator
+    control-plane: controller-manager
+  name: fqdn-egress-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: fqdn-egress-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: fqdn-egress-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-networkpolicy-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-networkpolicy-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fqdn-egress-operator
+  name: fqdn-egress-operator-networkpolicy-admin-role
+rules:
+- apiGroups:
+  - networking.turbosimone.com
+  resources:
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.turbosimone.com
+  resources:
+  - networkpolicies/status
+  verbs:
+  - get

--- a/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-networkpolicy-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-networkpolicy-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fqdn-egress-operator
+  name: fqdn-egress-operator-networkpolicy-editor-role
+rules:
+- apiGroups:
+  - networking.turbosimone.com
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.turbosimone.com
+  resources:
+  - networkpolicies/status
+  verbs:
+  - get

--- a/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-networkpolicy-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator-networkpolicy-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: fqdn-egress-operator
+  name: fqdn-egress-operator-networkpolicy-viewer-role
+rules:
+- apiGroups:
+  - networking.turbosimone.com
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.turbosimone.com
+  resources:
+  - networkpolicies/status
+  verbs:
+  - get

--- a/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator.clusterserviceversion.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/fqdn-egress-operator.clusterserviceversion.yaml
@@ -1,0 +1,382 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "networking.turbosimone.com/v1alpha1",
+          "kind": "NetworkPolicy",
+          "metadata": {
+            "name": "allow-rhel9-egress-redhat"
+          },
+          "spec": {
+            "egress": [
+              {
+                "ports": [
+                  {
+                    "port": 53,
+                    "protocol": "UDP"
+                  },
+                  {
+                    "port": 53,
+                    "protocol": "TCP"
+                  }
+                ],
+                "toFQDNs": [
+                  "dns.example.com"
+                ]
+              },
+              {
+                "ports": [
+                  {
+                    "port": 443,
+                    "protocol": "TCP"
+                  },
+                  {
+                    "port": 80,
+                    "protocol": "TCP"
+                  }
+                ],
+                "toFQDNs": [
+                  "www.redhat.com",
+                  "consent-pref.trustarc.com",
+                  "consent.trustarc.com",
+                  "static.redhat.com",
+                  "sso.redhat.com",
+                  "assets.adobedtm.com",
+                  "consent-st.trustarc.com",
+                  "adobedc.demdex.net"
+                ]
+              }
+            ],
+            "matchExpressions": [
+              {
+                "key": "vm.kubevirt.io/name",
+                "operator": "In",
+                "values": [
+                  "rhel9-minimum",
+                  "rhel9-gui-server"
+                ]
+              }
+            ],
+            "targetNetwork": "cudn-secondary-localnet2"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Networking, Security, Monitoring
+    containerImage: quay.io/turbosimone/fqdn-egress-operator:v1.0.6
+    createdAt: "2026-06-23T12:09:52Z"
+    description: Creates and maintains NetworkPolicies that supports outbound flows
+      based on FQDNs
+    olm.skipRange: '>=1.0.0 <1.0.6'
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/mransonwang/fqdn-egress-operator
+    support: Community
+  name: fqdn-egress-operator.v1.0.6
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: |-
+        NetworkPolicy is the Schema for the networkpolicies API.
+
+          - Ensure that the target Pods selected by this NetworkPolicy have an independent policy allowing outbound traffic to their configured DNS servers. Once this NetworkPolicy takes effect, its implicit default-deny behavior for unspecified traffic will block DNS queries, disrupting workload connectivity.
+          - If no valid IP addresses can be resolved from the FQDNs defined in the Egress rules, this NetworkPolicy will default to blocking all outbound traffic. This strictly conforms with the default security posture of the native Kubernetes NetworkPolicy (networking.k8s.io/v1).
+      displayName: Network Policy
+      kind: NetworkPolicy
+      name: networkpolicies.networking.turbosimone.com
+      specDescriptors:
+      - displayName: Target Network
+        path: targetNetwork
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:k8s.cni.cncf.io:v1:NetworkAttachmentDefinition
+      - displayName: Match Labels
+        path: matchLabels
+      - displayName: Label
+        path: matchLabels[0].label
+      - displayName: Value
+        path: matchLabels[0].value
+      - displayName: Match Expressions
+        path: matchExpressions
+      - displayName: Key
+        path: matchExpressions[0].key
+      - displayName: Operator
+        path: matchExpressions[0].operator
+      - displayName: Values
+        path: matchExpressions[0].values
+      - displayName: Value
+        path: matchExpressions[0].values[0]
+      - displayName: Egress
+        path: egress
+      - displayName: To FQDNs
+        path: egress[0].toFQDNs
+      - displayName: FQDN
+        path: egress[0].toFQDNs[0]
+      - displayName: Ports
+        path: egress[0].ports
+      - displayName: Protocol
+        path: egress[0].ports[0].protocol
+      - displayName: Port
+        path: egress[0].ports[0].port
+      - displayName: End Port
+        path: egress[0].ports[0].endPort
+      - displayName: Block Private IPs
+        path: egress[0].blockPrivateIPs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - displayName: Enabled Network Type
+        path: enabledNetworkType
+      - displayName: Resolution Timeout Seconds
+        path: resolutionTimeoutSeconds
+      - displayName: Retry Timeout Seconds
+        path: retryTimeoutSeconds
+      - displayName: TTL Seconds
+        path: ttlSeconds
+      - displayName: Block Private IPs
+        path: blockPrivateIPs
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      version: v1alpha1
+  description: |-
+    The FQDN Egress Operator provides OpenShift with domain-based outbound traffic control capabilities.
+
+    ### &#128640; Why FQDN Egress Operator?
+    Native OpenShift MultiNetworkPolicy objects do not support rules based on Fully Qualified Domain Names (FQDNs). However, in many VMware replacement scenarios, customers need to use MultiNetworkPolicy objects to support east-west network traffic control and want to implement outbound rule control based on FQDNs.
+
+    The FQDN Egress Operator addresses this gap by rewriting a community [fqdn-controller](https://github.com/konsole-is/fqdn-controller) project; it can dynamically resolve FQDNs to IP addresses and maintain them as standard MultiNetworkPolicy objects. Distributed as an Operator, it can be easily installed and run on the OpenShift platform. The FQDN Egress Operator avoids intrusive changes to the network and works with the default CNI, making it a powerful complement to most VMware replacement scenarios.
+
+    ### &#128736; Key Capabilities
+    * **Dynamic Resolution**: Periodically resolves FQDNs to ensure policies remain up-to-date with changing IP addresses.
+    * **Status Visibility**: Provides real-time insights into the status of resolved and applied IPs for easy troubleshooting.
+    * **Automated Configuration**: Automatically injects the critical annotation for MultiNetworkPolicy enforcement on the target network.
+    * **Non-Intrusive**: Works natively with the default CNI and standard Multus-based secondary networks.
+
+    ### &#128214; Quick Example
+    To allow egress traffic to specific [www.redhat.com](https://www.redhat.com) on a secondary network, use the following YAML:
+
+    ```yaml
+    apiVersion: networking.turbosimone.com/v1alpha1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-rhel9--egress-redhat
+      namespace: demo-app
+    spec:
+      targetNetwork: cudn-secondary-localnet2
+      matchExpressions:
+        - key: vm.kubevirt.io/name
+          operator: In
+          values:
+            - rhel9-minimum
+            - rhel9-gui-server
+      egress:
+        - toFQDNs:
+            - dns.example.com
+          ports:
+            - protocol: UDP
+              port: 53
+            - protocol: TCP
+              port: 53
+        - toFQDNs:
+            - www.redhat.com
+            - consent-pref.trustarc.com
+            - consent.trustarc.com
+            - static.redhat.com
+            - sso.redhat.com
+            - assets.adobedtm.com
+            - consent-st.trustarc.com
+            - adobedc.demdex.net
+          ports:
+            - protocol: TCP
+              port: 443
+            - protocol: TCP
+              port: 80
+    ```
+
+    ### &#128161; Important Notices
+    * **Website Dependencies**: Modern websites often load resources from multiple external sources (e.g., CDNs, APIs). For example, accessing [www.redhat.com](https://www.redhat.com) requires whitelisting not just the primary FQDN, but also its associated FQDNs. We recommend using tools like [urlscan](https://urlscan.io) to identify the full list of required FQDNs.
+    * **DNS Accessibility**: Ensure that the target pods have network access to the cluster DNS server. Successful FQDN resolution is a prerequisite for accessing external websites.
+  displayName: FQDN Egress Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAI4AAACNCAYAAAEWbnIwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAAFxEAABcRAcom8z8AACasSURBVHhe7Z0J3B5VlacLBGRoZbMVHGxlERVFUWHYBGwQQVHbthE3JKAw6tiI0ohIt4io09D401EbAcdoGhBbFMMiCqIsgihhkH0nIU2A7AESliwkYZ6nOLesd9/f7/vg/f++81XVXc4995xzl6q6761sYmFJlj39MPRIHLleFFHtwUxxWsCwmVm27uIsmwbDeyO4MR6tw2R2lr04TgssrZOuQD1JGsECkW7ruPwL4LCGx9DJNXlgYBlhT1QV8jjX9aTPGRBxRlya4nlxWkClx2m2IMteHaeVqK7Wk/VKCzyWG/QZUPgBcfoMyqWJZvqCy9w4Velfi9NnUJ1RH4rTCjQrIAciPmB1kOzoCKoA4WeUmZN+K67PjMtKEDHPI6XOtOREMLk5T1ACjO6pVkcB/GJqnLZEyyoi1WM0hQ3jsm4GCmzOpAwZ0EJ39Rxz62M/gMEqz/ME3YCca8XpCCXgI2eGDxX+hK5qGnJDkPEwLLQ8LnOEx3Now38EpuWvEvV8pqULUGrhiM1Ai9+ioWShhymhkw0i2Db1xepMSHSUR8L3yAPKqE5MV3pqnOYgcs3U2aWqVeepi4VZ9r44rQGM6MZzaSsZzciyTeK0JcqDgANAnP4FcD8rTnNwvVGcFsCCD8RpDvUZp38BiVY3q3M5LukIZ6tNnxTJv3X0HTNKnhO2Zp4oQJ+1EPpkXNaiLSsAmCxHKg5NUM2MDFfGaYGm434ZVOepskVkTm/5Oo/XZ9l6ETzCGIAZzgtxhZpJ3cBB61uqA+gYHHeP4BoQlzc2yfbys056+lageS8M5kWXWQ289yjTcCR5fdhg224O9YAJfmIhcdkX0CHuL8+Wjb0a9qRkIu8zoOveyX7M7lmGZbKDNI7j9yN5Q5DmTU7X4fMJ80Vwc5DYfi8vTAGYTm4VUW0B08wPQX8bQQXUDHSf56SbXLeTrobMHsqyl8dlDRD2QQh+raFDQ6+Iy5put6WWuB/YpFUitUaCdeOybVQLI2ytNbce1aiXsYwQOL+laweocpEtLC4rYOWgypuqaligQsFkRQRVAAZT4rQpbBjV2k5jeEKryhdICWldO1sLrzku5XrvPEEV8Kn32dKiIk/Tc//3iKoAPFZRy5/Euekbdq41kDkCrB+XfQFCzMNv7gzBXxXB7YPMy61JXNYApq8mzaVx2RJqsdpsXQGhjotaVdxMJBhni4nLCpD3z5F3dgT1HzCfrAAWJOm8qTEkIs3i1Vn2/MgywggjdAx65xfTmhrOIgcGeuvN6NBWlpt0dROPLuDLkaX/QIi3p76Fjm0qPV7FzWsCcfnjiERo7eKI6g+chCsEI/X/iKAaUOjJUbhCHGwYgm3ktXkRvu2pSUNYAEzRfGM4nSDN03OybPMIqgBx54egtQ9q2oUMqFX9x7MBpLyNQp6Ky4bgpn2X4PfGCGofqhZH/X1c9gUKI8Vle9DOqj4u+wZNSSWXyD+CmgO7/1W19DC4IDliql0iC5AYsVtOoszPrdKmHqH3R3Bj2EdQ8FykeZ7asUBbEzav+8xpfpa9FMa3lYT7UkTVwHiPmP9DCN9aO2ZAmOnB+JYIbgvOpyNf3YKSMMLz27JsnbisBQneaqJmUhN3U5w2BGlukA9afnME5bw1T1zmJiP+2risBeqb2Up9FhKnTQGfd3ovHpf5azT4Xx2XlvVvTR05/OXYuKyBD5baFaYa1flmZdnGTSseTxUadvnMzj+swHHZNuC5ul6+stlq0EoY4k6mq+1IGFrhto202VQYpSdjw6Gf+GO4W+xIGAWBJsVlAV8ONzWTDtxMWuL2atRsq0GiNRSEAq+PoApQsW81dWAK2iFqIpPat84ABlfEaUPA54PyIO3vIsiwLeF5XlzmQw6VnxaX9SETNPAxj52OTz4VTb22FYvgHHSIO5a1bpqmnZ5AWjuj/GUI0i8yk2EwP+P4OrM7uK9N3AVQEqJhr228RzR0cFN/SXDZQsqUoKZ07lRgmQwzjjT/EMkbIvGNfM0fJCWgkdWDmEIoBBq5Q3+JoPagfcnU0lk7QdJmXLYPcuRNE3U2nHYStzpOWwJe+SCMSd8UQZ0BgdYKgeBRC1S+uNxCGoH8v5LPk71MyBN8AmWhNM+dIqgAprzXgphkvTWCCiDlhvqH8VYsgnsHgrxfgSRq+gvNGFF2B3taoE5/T5Y9n/hvQKm1tZz/dA2nmRSevypKpIDla4XChP8aWYYLtNS/91EjjDDCCCMMGg9m2Yu4qfoUg9fNjCePcVzt4w5HZccTyXPJgY40S6BrOf/AvCx7QbCZ+KBCb4ced3KfBlSnF/Ek9WEG1usJ+xb0UWh3pyQc90B5BxB/Anmv5nquCuNYEHH5DQPnlzFG1qy0GpfwoQUVmgUViuB8DpXdL5K0jYeybD2Ud65KUBlJMS4y4HoOcdep5BSuAinrHyP7+AFCXZ4UEpPWuguDWwEeW6LQYirnHZpKYN75skhSFxjlNaRbnvKFUbaM6OHD+18EWKYwWpbz4rlZp8A7TkveoQdw/vmI6hjkPUSlyiu8bq+IGg6wzKySUopl9r2Apvfhfs6xke00ZUwK9yF8RA0GKGUP3De5LofxC+9FNV5SUMh8dkT3FzJOheAtn4nguvBeFE/YFzrV5oaQ0zkuTMT1POguzq+gEt+od1PdK+j7XgH/5DXbphGPJkdxfQQMfxuMVUzFwzzCT8ObVqC8wkIKZdoIWwEtQlHXcbxGQjE3E7eY85WmqR6RYuR5DL6fi2I6Bvn3kZejm6OoYfB73DCOq/JEvQLBj0yCw3QnCv1UsoKkEoifiwB7lp9edAt4+NxoEjyfUGmWYfmcL6f8XSJZSyDXleZF3op1Qkl2+N0QQd3BDtLKy6xMCLkUT9g2kg0ceJdr1Fal8qnwUyis6e8bkicj6+kRlIOJ5qtUkAqnbu+K4M4Bk3xtrSRDGmvdBXbNgHAnpPwR1BNQzHHJYDYZlPaSiCpAmecZX35NVwZ5bjRehUdQ50C79hdWrOuHx1ooBPlVBPUFGGp9ZtF/HZcFUN4BUZ70txFcAQcA0uVpkG+LCG4fTt+1jAVB74ngjoAFd1YABUHBdZdr9hPI+d7UnKAjIrgukC1vWnjXFyKofbiyQLeUAZXbPoI7AoJ+wfwquR+ddTNghO+rFCsN1by5rEYMJI6op0RQ+yh7DoV15TkoNV+j1Ol74k6RvMX7utUxbLdCT54jqFx+E4hVboygjoByJ0WT0nOav8jsAsh1n/KFAc+J4JYg/W4qpus+R+B6Z6XCZYYAHSnJB1vpsQKd4I4R3BO8R8JT8smchEx3RFTboF63mBfldD9aYe3814cyYl6zWi/wXE9AqMHcp9SBL6Qxzl02BcuP/uLEiK4Blf6KxtQw1iGCc6DYbVJ/w7H7eY6ggENUisw47jgry/4bBdxjAQpqONerOZ7NsWZo7QaUuTn8pmkEy0gGgf8FkaQpXLuQ5MOon4jgHIknCuxthpwAo3xSZYEU9voIzuGDJpR2u1ZSUakyVCRPH962jKO/GruTNFfB41684FHOvSXI0yWvkMwT3nk19KIoqiPAM296yP6nCLITzp8/cezPvVUClZ2ShOf8sAhuCEcNhDgIBZwJ/RG6h+tZHBdReY93c/wD/CajrA/0u8OG9zxlRcn3e508iWN/78oTvH2ggnkhHHGa8QuUsEQ5MULhkcic/zZooMBz8h9WWjAWauvXVcOGzTopxSY68CeBZcROLOU75Y6eIWPZf6E5JYv+PIJ7BnJ8IjUh+htpuM+Qq4GVfEGXC2THzHXbs04Uk7t/VGZWN78dRsnbopTi7YOeQpuvvy3MWIHKvYTKPoyguZC6NkrzHdM7I0lDkO4s0hUW5/ra6jlKApXfzHgNkRSit5DvhEgy/oFF34XgT1rZVAkVZqVQoM+SpxH2DdJ9hONuxO3OcXfCfYRa5DF9aiqJvIaH+9jU/UnHhIRDPJV7L3QxFfOB+3IV5kw8UTRNK+9vNeejvAs5vgNPGu3vMMIII4wwwggjjDDCcwDMfNeaw30Zs+IXe/Q6op47uD7L1uaW4U3cOvyI24G53h54j+Qtg3fSibyOe6cV0BzynMLxlShtoC8GxwQLs+xQFHJ3+S66mlBAxVO7akI5+cIAzi9Dcd39Lmq8wBtMKnRu3EAWldQruF7JzeR9KOMC6POE/51rkCWu30b8p4n/D87v5Hxp+a5eikcay6H9o7iJAZ/BUKGpZS8JBT0CfQarbxpJ28I8mhNKuLmsnESE+xRxBdTV6+qhQovbVyThVRAVOMffpUWStkG+PaH8cUbip8dw7Tuya1HIkyrHcMqVHhqXy/+vYHRB2PsUMlWC68ktf+hbB/7mDj6zyV9UXH4cL6Dvem0ky0HYB6OJ5Wk1Btcfieixx/Is267sLQh8/4wuN+qhkqdb2cQLvi5vOyaiG4I0ZyYZQpl9e2DfNRDmIDvYqIje8pWI6gj0U+tQwYdLSrGSJ0V0W6C5bVNWLOe3R9TwgQCf1UqlynS1isIJX1KwRCVn9dJ3oJQHEi/OW2/g328wzB6WrOQRxWwcUR2DfmQzF0nJB+9puXdoO0CeYnTDm2+N4MEDy74ljSB6zJ1trqRqBiqwKxVquItIN0h9UMj5swgeHLDy+mn+EtP8hvumjjViNp2TxkT5gx3FcP38HbnDLAW+N4LHJVDGk0k5kv0a/VvHe8q2BRTzNfqEvCCU0/Z3H8YKyDsnFPNYkhuD5stR+gpXKKTmpItGcEPQ/F4GHYn1folgN6PMBzhPv5jJ1+dAf4bOZdJ3mM01svYNyDk7DHkrivpBkp3BpLelbtWAaf6rGZsTBe0ZwQXQ1guo6OHQghjWi1lrKzKdfM3H+T3k/SD86r4j7wTwzBcowPcPXiuT14TX3ai4KyDo2igkZ8xxZgTnYD7yRsJnlG8yJS0UlXWR5ROEuSQ2/zkR9AfC74eeVGDTqRzzSSor7sn+H3Ed3aSWkXgycFziNbIfkMLwno5/kFsXMM0/JhKMtzMMwf8WetyKGCepQNK4zu90msnOeeY2gPLXQEn7wuMcjqtUbOKp8uB3D0boaEtzEQpW+cUKdeTL11VTBoc+IHkNjJfrRRzvSxWw8FCaT/b68vtuLL0ZvK6w3KR8pw2EXV5v06l6UOHKpXKhYu9Czg+XnyMXvHtbnYHW3xyVl9nvFdLzksANN8brByj736tuLTzuFtENgVzbq5gwbDEX07ipC4B3b7NxCrgwCZZIpaCon0aSgcMKIcdNyVvtozj/PxFdF8g42bTmiaACKOV24zj2ttwW5k8lpURhPnXraDkZ6Y+gcneTt6fvdlD+e1RMkgWeFZ9WK4My8zkOZWLHSuBNn7O5kqa3SaGat5BgdlsEd4TULBCq59+fr35mp6vidw8o67KIKnAPc6b0ax/S1my0SOe+aeoeFmTZ30dwZ4Dxlqkz5ryrGbH3XlpIYgTbJ4J7BkabLk8qWbMNGHHHKLNGURERXAHzhnKL/RI7AoW4jUtesQjqGPD4sl6nB0ZQ38Cs/XVxWgHKyr9sw7H4rF81UEpa+v9fEdQZYP5dK2bvHkEdAx6XKYRuHEEDBZO7d2jQMOohEVwD5LpbuUiHfroAufKRqpeKIWC+5wXCVHw5bFCgnEfCI5rKTJPLb4c0fgR1BlzvKhlQQU67A5ZJC6d/E0EDA4o51MpGM/5fEVwXpPmxcpGuZ+V053pAC4YQJ0fQQEAN10TeVBbO3hwoJ9+XwzwR1BnI+HsZYP2WhTWC/RX9gArOP1Y4KMD/jjCkntPyPToy5crp2nP60eck5cDryAjqO1DIiTYlZaWctn7JR59zuenNF0GdAc/5jpmdL0RQx0iujoK/HkF9BfL9Q6npUlx7QKEzzNP1aEVJ+W87ddVu3yORP/9SCMdzI6hvYFL59qR8j53IiLF8xtT9PMdnKMkqHrFMxz9uRSn5TwkRnll9/4DH/H1SjJ6NoireobeCBg+5upshCzssmUj2H9yL1N04oxGw0B/NS2VWRlDPgNeJyWgqCJk6et+FIl9mPxpydXdvJRCi4vWGGscbfhjRLcEUfwvSO5L0vH7GH6lRmfxxg6SxGnkMcv5GBUI138ldlmVHwyeviz8Dj+DOQcWKXwTDrPgaJ8yX4VWviWQDB2VOStYOWZaimIZvLFJa0k2OoALIfY9x1I2b/B4Ao21sWmoaOlTGnkfBFnAr193tBdEG7HThXzyioDzp/IhuCOS8P2RkJvEXMOyuo8dFXO/v5WGSjzgc6fvy60kUXniR7Z4KLKQi+1B4z/v8+cwGvv8IT70zL0ODUO4yjm0tlKQ55ZsE2LQiKAf5jzbcTpzz3n/hh4CnhHDFj0pVAmGnWYiFJfL9NJa9gbijSNv2ZkLk2xr+XyXvfcmyiWwi8oukbQF3yfsVlRtBOVBWviMB4Rz6ALiX71tqhmTCT6JSS1MaScG0msJxvpL4xxB4BueOXtdx/l+E+Won/zi/ZJ6UPyz7KPkPjWI6Avl2h39efpr/wPcgDSx/yu/PeyuB8On7YFqy7oaHxL8BgaYogJVVuHKFG5FpTBt53DfwWyin+FJtN4DPKxNPKB+xkmI49u+Np3DIS+6ugiK4KRBuByz0VdL/hny3ce378fnQXBTiXha3cP5r4v6l0ZDcLeC9Obxz5TCd2JxjPuoqO8pp+TPujoHHnKCVJQoY2quZblBWjsoodQv9X2WRQIGPWoguOhAL9An0M29UOUlWj/ZjuPxg1ucICtwoNS8Lw5uabuI8VmCk/IgerpySzYnjgRE9OKCcfZM1dFvmJcPbXaRNYLhTkmIkmtXw1iWjlKPCGqldd7w7Evmm4Ymr7B8iqG+Ab/5gX0K2rl5G9gSscXxyXSdqjDgdrUN270DzxgjS1dZT1aBPWQOl5yu6JM6Hvw45gcL/KY0EHlFW2yvYyTNJrzOv/VevwznThtcnWUIxY7eCPQEh9tZzklB4gS7d1m8fUOYhqXmGcj8eUR2BfGclRTtKcf3riBp72Ckj1IKkIAXl+ke4+dqRpCFQ5rvTCGjFuL46oloCb/mIZaGMPL8eCI/DI3p8AQGPK3uRwiL4T1FS058WzeZ2AQ8q7vThsZJ8DT9FS9zRKMFf6pWVugRF1eyNPK6AIvzt1aUqJlU2Ol13ZPo05w3X6RB/VWpmVpw8foplr9hhcn/olnK/IqFIlTr+vhTSDMzTN6IyF1pZLZsqE67voqjpxJ+DAo7k/D2k253znWkqJ5bTE5YehRRh8iTvauK6/njGuAEVcsP5W6srWSbii76jHpnPvok0fiqhZi30hIfzECq5FZX7OuTHEn2mk3+s14rrVR7ttwyHXJo/gzzHk/bl5g9Wzz34iDRORxhhhBFGGGGEEUYYYYQRRhhhhBFGGGGEEUboN57OsjUXZtlmc7Jsr8VZ9jHXnT2cZT/g/BfQpY888yOqaRyvrSI/JPUbyDWqk7n202Ifn59lu8/Nsk2e00+2nw1wJ8fZWfbaR7PsQziF2+DegoFX+r5YSi/QJMKbvgdqRCmfJB+cKedb4u+K8ss4Hsv1HsjT004DI/QZ9h4Yz3V/34b84ckKXxjGSo0agycjJydKhpZIvxpH85Wyb2GrydX7+YcWU/qUX36G1ytPMq3v4EjrAq2HoJ9Cfpm7b1/zH6EFFmTZC1G66wguwiDLmjlIemlK/ALoasImM0QdiXPs6y+c+mE4P0+K4+xEmQdSxlehaTpfPZnKZHw43Srocs4PRL6+bDs0QgAlu8z6B9AS35zbwqsNEA7kTz2ux3BHkebVg17biuOtgyO6FuRsyp6rXPYuSbYyKadxyi/p2OV4r6Nuj3F+Fg7/yihmhE6A8naAzsMpVtQzRqyGmodBvofh3jKsiallIdcUyl2iDDpEtWyG6ciQw56by/8EcuHRHjOzbEPyb8y563D8fWXea6a8iayzdceRfk58vnPcCA3A8OEHCk9FoU9VK9NrFPkUhnOx0tuGNT+wHIz4fox9mz2bVJYLWVJPsRJya3W/Cfh68rVcHJoAnw3gcxR5Z1lP+NTjvww6sR+7Bj9rgKLfhcJuj16kQmkqEYVe2OmC+F5BuftB18UcqUIu5EnG9LvQR3prH9l6Bg63HmX4s9m7LaNcrqSOKNfG8+bI8twDBjgcBblauEI5YZTpxA11h2XkcQiZTNm5w5ZlUkaM5UT2Yhx9l8gyUNAD/xXlfR25nqjugXUg9HMvcnW0J8SEhXMRlPE5aCkVLxRRasVTuR76XuXzmIwur2rl9jReI5srxXdT9kg+dCDDPtBd1b2y8uE89yLfWyPpsw9Ubn8c41Gowjg6EEqZYguLpGMCZPgUsjyIXH6CdxZyHomz9LxJdT8xl/kTOrsX+SocKHqga9Dhs+e7yVTylVTqunJr0WFivJ4K9eVHec8VoLsjnXuVHSfpNCbXJ0bSiQsc5hgcp+KBmPMFyI3C3xjJRugA6HOfcq9dTTHk3+HdXWSZOMBRNkT4P5QndXavhK3Gmb4YyUboAuh0O3S4uNwYPS8PX3Ftgz0sso1/UKndcJAH7VlSRWwh0P1UZvtI1je4Fw5lvBzazjsebo/34bhvFb0DJe5J+TsuyLLXuMnRRP2pEkO8v32dnRwlJvA3cX4y4Y+mcJ0nevfvM1cb3+/FcI6/Q/j8ox8KnypG2MWd7jDnZFkl4QjvQwnfhlzq4HsnP7iYb87kPEn+cXeRE2XVpRRvLyilvDo1/J5C5iWQk+NLoH8mz26k36Sb7yMOEsxvtkCuOUnH1gNZb3Bi/GCW/Q3nM61T0r8vfbmeih77/umevgDB3o/Q+R5wiawUlTy1lfJRwpbQZ6iga13mOvkzb1JOI8LgFaTCJB2lmgyXXzl9PZ5lMl8o3l+030H+/0vvdYAvW0P0oQNZdkaOpUn+WA1w5T2xdAOZ/xq6tDyBtoGQ5tJxtzcNlXk3DmKLzQW1UtG6az7h8VCWrUf6XUjnO5wnTCfVM6TG1oFCCStIY0tzfc2FHE8i7GBoD663QCnr20tdkWXr0jWvU4fWNZ58G+Pkr8UB9iPv4RxPpZwrCL8LPg9zvjotzUj1KZMyGadTEX8/x2ORb8uo3sCBrj6gfEkedYNMP/XT3ZEk762R6yIdJqVTx4YRPT4WnKHENyPUDJWZhAylnxlJ7F79zbgGmmulqw1CXG4QK0ec61amEX4cLfttVL7tTRf7BZ1sfpa9yt4Fub6ngyibpKxl2SXDkdPJqDvVHd7Txq8tAP8fJV0nvdG46n0B5QU4ynU6eErrOfSdSDJ2QKANUNoF6RMukpUi7JdUyE9w+pzGO6kahUf3mQ8BkDtsDq3Vdgsc6nnx6fSzoIdiflFRL+sZDWcxjvcV4jveS7sR0OWL4Dcd3nlZlk1ZC2lgdXepQD4n0g+l9B6hFdjno5FkbIAQny53mxLKcg+SvBWWwxVaZ+E4l+vjnMwFmwkL5242EOpzDg6TT9h1nFRnz8O5HoA+6bLWyNoV0O0nKc/vbef8dRzKvKrZV99Jsz86txfP8ygjYQ7LA9uQuSkQYBMVUlZUNRkXznIbFf5oeRzuJzQIZW2OYl83qDLaQXxt/hvQYutd1gVhudE4ng91vFCLPBuj7z+V+cqP40GRpC50KvKcUR4VYrrwb5FkuMBQXwjBayi66keJ/wyT1oGN94JydkQxj9myg1ZBA/3YYTugR90CQ/8Yynvgsn6Uk7CbGWJ2iOQtQZ7Pw6vo0TzXkZyPRZKGII+/6JhnHvPKg+tHfLkbSYaDmLX/qew4CqPDcH45cdtE0oHCOQdlXZ4Moww4kr3cCZFkXAD53BPygbK+lBN9PUwdWr56If9OpK82/FJuOtpaVkEZa1DWL8rlywseJ0WS4YDb2b0RYmGqiErgeibnQ10SwdC0HwpxnW5ZGTOQpeZzF+MByOYzGHea95XBvcj/wYhqCIzuDciNSddS3IJ/LZK0BfJNIo+PNHIeOhHXN7icNZIMHoyRX6LQotu0p6FiUyJ6aKDyU6KXK5SBTF+N6AkPnMbJ96XWK9XROQ51vqDTW34cdkt4LSg3MvjMw3l3jSSDBZXxy9Ln6PWpMnFnNSmSDAXuV4oSb3S+kORAKcugvr8PGws4qcWwP9NRUv2iR72JxtFxL4Hd1sJmf7LBh65sZCvg3/Tji32DQmOsS8uzdMJ8+PW2SDIUoNR3o4TFSREeaZk3+OArkkxY0JtsjGF/XW6c4TS3cOz6V6HkPzf1Xtgr54ktj4/owQLDbIrRrkrPbxQAgZxnDLWlo9RPUmax1kclc/1DW1YkmZCgPt6NzdCoyWmsGwa/mt6hp6fo8D4b2xV28xz694geLMaL46DYfEvu5DgrIJTb9u734xHIfyD1etzeMzmNxiV8Kg1ivUjWNcbUcRh716d7u7g8VOE00t6RZCigvJNTV84E72m/EYGC/ymiJxR8QUt9zivP1yR7HQz8hUjWM3TA1JPpOJ4PbajyKS0t4sflSupEeO5QJ8dU/H+XZbDHQRH/HNETBsj8CZzGBfJFXexJMbLvpPrWi/tEHX1NS72Z5aHD4U2OBcPUsVFwLgSVdLj6SUQPBVT4iGiRuQwOnVx/18+cRpJxDfS3L/Lel4aOROqSun2doamvyx+wz9aU54cj8nLUHWV7O/6WSDJ4UPAeFDrfwlOFFQj60bBWmuEovrwrVhsqC+d/7MdcYJDAMfZG1gfsVZLudH6HXcJ/R/hAlpGgG28mXI2QlxmN/fqhrgz0/ROVvMbCU+WTAgwj7iI9PJIPBLOzbBuc945kAMumTBdi5R9YHU+w99Bw6GZOdQ/jNTLfCtX9tGc/4PSCsi8sl21DI2y4rxwEhR9e7TiJNKIGRVl+jvPTg1q3iyJOcX7lXMcjZd49q4+/5e4VNh7qf75Gksr6UWbib+S87d+Bz8myl6DzPcnrh2vb3k+Hct4JLUoyRCMb/ktOgQAbYLg7qUChkHpUUpIr8Q/stxPRmtdZQC8D/3Hxwz70sSXGPR0jPW4L946vrIvoYc7muqP3evDMP7ynvuVjQ4HPwRHdEL6aQJb/LN8Fx3zw5EgyfFCZD+sUSaColBOw31GpJVY0xaV4eymO9kRfIq2LiSb0pouuFHAFHvX5NXVeZavWsKnOnjt/Ie4+rj/a7aQXPR9MGcXdF/w0/o2tlq2Q78OmTTKpf/KN3UIu4cJzhDi77M0OUTjM+ShoXVrb66noufUUmtIS7t56LvQ6kZbwmmA9buE7JGR/NzQVuReEU1TUS+PGUO3PeY7pxxtoN6BEV9fLN5XDtasOG37cDNm2Qrb5Se/KxflThDVd/DUUIMSrcJRbyxWyp6FCp0WSHMRvhuDfRPCH4g6iSJ/IikV37KuEmzmehPO9i3P37BvqqwTfeSHTG1QycpyBDPOjtdY0AMn6I7vLOq/j+uBByEvv8W2dNJWvLNA3I7oC3i0h7w2mN615TE9dxn6xegKC7Y6Q3tFUCEnYv0aSCqDUtanADqT7PvSwBpEIKwyRyDCNEs7m77YWQXcTfiV5T+P8swwV753PJBPDbcr5C29i+LALp5x1nFNx/nx7R4cV8mzIcXMcY1ec8kPw+RLHszhei/xuvZYPsc4DlInrGpmsp2nCiHcrA4Ya+AfHqeMH0MGyJJM6RjeXUM+KXTWsI3He2hcyWxfCLjp+nO3A4aRwHwRbkQSVFJywb7bzUM53YFT44xjjxxhypoZx/qRyyjzrkYoskwaVzJsohVWnrcevTCpcJ6J+btf2Z/J8F/n20ylD9KEBed6ATovfr0Vju51GUfySgrr6g7zf2tBSHbQD+rwUmcfnMy4q4dPQJRqoLDTX59nLRLK2EWtSXgrPPeDl984vhmZBKs+JYv5NTx0slJOTCo0WVlAKS2lMbz7D4Oc8y11LH+F8OsefQ0cQtr1zC2QfF0+jkW1zaB5yFY5DXe63B03xhFW8Wdfp0f/4/QlwAq1xFwStWF8bxnNJ50C23rCrhhyCtqD8bSl/JxS1M7Q31+9EoXsahsJ3JOy1yPQKhq8XkmdC3dHpGNShwnFoAPf77Iow36w/keJImxrL+N90IAHhN0Lgabbs5DxWCOP5+56J/93nMQJznK3R4aLkHB4he2DX6hS61mkI9wbjf0bWiQNbM8J/2d7GiqRKxVAyMTf+GWOgv93Q3+PJcepRTA3unPD6pQKvo7K3VLcI5xeE/9xt7SPpCC1AI/wiuitWPZbJMBslTnXSRBuCm4KKHUZLcDF5RWUJ83yKt8uRdODw1pmyP0bZPqPZOILHNbwzpac+X+dI+ksUd5/XUKdnz+aRZfg8hZ7nBCrvdvNFxXWm6GJdBfc3kXwgoIyjXC2o00pxZ/UrHwdEknEHZPYh6HTkrHAYdUbYs3u72jLoStfCeY6n0j7+rlEGipiOot4XyfsKHGVXyp1dbrk6UJT7S66Hvs9yPSDHBujmJBrV0upeJpz93qXPlQ2yq+FYjHIOgeZouLJyNKZOxdENgvq+JT98fdi4GGepKFc5MJbLHfaKpEODwzXlqo8Z1fqQYki6lrhnxW/H+gKU5a3meRqy2pi2OHsnlHqVBu3ncwn4HwTPRdWGskwcaBmyfKf8ZLbfoKwNuIE4BhketEwbS7UchPmFv+8x1E+I+diYAUXui9GuRFn5/KesSMmWx9H1st9jbtKXzw5hnJ2g/HkIRqwoL3ohH7wdz8S6p4ViOOKLKedgymj42SHrHHVXB8/N4agX+EIORW4HnYcSn9BhVGpSsAZWwSqfc1/+XYdhP4thtvaFZrDpCDjhuuQ/mnIWVjuR59ETLef8QpzgLU74I2sF4LMmMryEtHuTdzLHefBdGfkLnomvZRHva5QrCfPbEePrZeREBop9EUqdBF2G0ZbrNGXDJtIwOpkv+oifC2mM03GqIxYw1Hk73s6LV8rwheFx5M2/gFcuQ7Jsy0COhVz/AppK2F2UvzLCa/JI5lPGcCJXUX4RGvdb2T1rYKtE4dtD7oN8O7TUl3r1hptkLB1Ag0o4RU7hFH7RzlcibgVSpuWE+wJ0lXw6JXnrxDiJD+7cLeIyjoci+/C2FxmhNexJfKeD0d6Dgfze0+855ndPtvDkMDpRIuJrHK0ZpfTm1TGqnZE0i4i/CDqGsD0p96Uh3ggTGTOZx2D0rRiy9sa4h2DoY5lo+wnqH+IELgk9n/BLOF7G9SXQ+dB5pJkCfYdwH/0fYn4m51vRe4yr3ddHGGGEEUYYYYQRRhhhhBFGGN/Isv8P4vu2hano8sAAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - multi-networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.turbosimone.com
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.turbosimone.com
+          resources:
+          - networkpolicies/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - networking.turbosimone.com
+          resources:
+          - networkpolicies/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: fqdn-egress-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: fqdn-egress-operator
+          control-plane: controller-manager
+        name: fqdn-egress-operator-controller-manager
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: fqdn-egress-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: fqdn-egress-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: quay.io/turbosimone/fqdn-egress-operator:v1.0.6
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: "4"
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: fqdn-egress-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: fqdn-egress-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - operator
+  - network
+  - fqdn
+  - egress
+  links:
+  - name: FQDN Egress Operator
+    url: https://github.com/mransonwang/fqdn-egress-operator
+  maintainers:
+  - email: fewang@redhat.com
+    name: Feng Wang
+  maturity: alpha
+  minKubeVersion: 1.32.0
+  provider:
+    name: Feng Wang
+  replaces: fqdn-egress-operator.v1.0.5
+  version: 1.0.6

--- a/operators/fqdn-egress-operator/1.0.6/manifests/networking.turbosimone.com_networkpolicies.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/manifests/networking.turbosimone.com_networkpolicies.yaml
@@ -1,0 +1,434 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: networkpolicies.networking.turbosimone.com
+spec:
+  group: networking.turbosimone.com
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    shortNames:
+    - fe
+    - fnp
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready condition status
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Resolved condition status
+      jsonPath: .status.conditions[?(@.type=="Resolved")].status
+      name: Resolved
+      type: string
+    - description: FQDNs with valid IPs
+      jsonPath: .status.activeFQDNCount
+      name: Active FQDNs
+      type: integer
+    - description: Number of resolved IPs
+      jsonPath: .status.totalAddressCount
+      name: Resolved IPs
+      type: integer
+    - description: Number of applied IPs
+      jsonPath: .status.appliedAddressCount
+      name: Applied IPs
+      type: integer
+    - description: FQDNs failing to resolve
+      jsonPath: .status.failingFQDNCount
+      name: Failing FQDNs
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NetworkPolicy is the Schema for the networkpolicies API.
+
+            - Ensure that the target Pods selected by this NetworkPolicy have an independent policy allowing outbound traffic to their configured DNS servers. Once this NetworkPolicy takes effect, its implicit default-deny behavior for unspecified traffic will block DNS queries, disrupting workload connectivity.
+            - If no valid IP addresses can be resolved from the FQDNs defined in the Egress rules, this NetworkPolicy will default to blocking all outbound traffic. This strictly conforms with the default security posture of the native Kubernetes NetworkPolicy (networking.k8s.io/v1).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkPolicySpec defines the desired state of NetworkPolicy.
+            properties:
+              blockPrivateIPs:
+                description: "BlockPrivateIPs controls whether to automatically intercept
+                  and drop all private IP address ranges from the DNS resolution results.
+                  When enabled (true), private IPs are blocked unless explicitly overridden
+                  and allowed at a specific EgressRule level.\n\nConfiguration:\n\t▸
+                  Default: false"
+                type: boolean
+              egress:
+                description: Egress defines the outbound network traffic allowance
+                  rules for the selected Pods.
+                items:
+                  description: |-
+                    EgressRule defines the rules for outbound network traffic.
+                    The system will periodically resolve the IP addresses of the FQDNs in the rule to dynamically update the underlying network policy.
+                  properties:
+                    blockPrivateIPs:
+                      description: "BlockPrivateIPs overrides the default configuration
+                        of the same name at the NetworkPolicySpec level for the current
+                        rule.\n\nConfiguration:\n\t▸ Default: Inherits from NetworkPolicySpec.BlockPrivateIPs"
+                      type: boolean
+                    ports:
+                      description: Ports specifies the list of network ports allowed
+                        for outbound traffic access.
+                      items:
+                        description: |-
+                          MultiNetworkPolicyPort is a shadow struct used to apply custom kubebuilder validations.
+                          It mirrors the underlying network policy port definition while enforcing strict port range and protocol constraints on user inputs.
+                        properties:
+                          endPort:
+                            description: EndPort is the specific end port number allowed
+                              for traffic.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          port:
+                            description: Port is the specific port number allowed
+                              for traffic.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          protocol:
+                            default: TCP
+                            description: Protocol defines the transport layer protocol
+                              of the container network port.
+                            enum:
+                            - TCP
+                            - UDP
+                            - SCTP
+                            type: string
+                        required:
+                        - protocol
+                        type: object
+                        x-kubernetes-validations:
+                        - message: endPort must be greater than or equal to port,
+                            and port must be present when endPort is defined
+                          rule: '!has(self.endPort) || (has(self.port) && self.endPort
+                            >= self.port)'
+                      maxItems: 10
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    toFQDNs:
+                      description: ToFQDNs contains the list of target FQDNs allowed
+                        for outbound traffic communication.
+                      items:
+                        description: "FQDN represents a Fully Qualified Domain Name
+                          used to uniquely identify a host on the internet.\n\nFormat
+                          constraints:\n\n\t▸ Rule: Labels separated by dots (e.g.,
+                          api.example.com)\n\t▸ Rule: Alphanumeric and hyphens only\n\t▸
+                          Rule: No leading or trailing hyphens\n\t▸ Rule: Top-level
+                          domain must be 2+ characters"
+                        minLength: 1
+                        pattern: ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$
+                        type: string
+                      maxItems: 100
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: set
+                  required:
+                  - toFQDNs
+                  type: object
+                maxItems: 30
+                minItems: 1
+                type: array
+              enabledNetworkType:
+                default: ipv4
+                description: "EnabledNetworkType determines the IP address families
+                  used for DNS resolution and subsequent traffic allowance.\n\nConfiguration:\n\t▸
+                  Default: ipv4"
+                enum:
+                - ipv4
+                - ipv6
+                - all
+                type: string
+              matchExpressions:
+                description: MatchExpressions defines a collection of advanced label
+                  expressions used to select the Pods to which this NetworkPolicy
+                  applies.
+                items:
+                  description: |-
+                    LabelSelectorRequirement is a shadow struct of the standard metav1.LabelSelectorRequirement.
+                    It is specifically designed to apply custom kubebuilder validations (e.g., Enum constraints, MaxItems) to the label selector filter conditions.
+                  properties:
+                    key:
+                      default: vm.kubevirt.io/name
+                      description: Key is the target label key that the selector applies
+                        to.
+                      enum:
+                      - vm.kubevirt.io/name
+                      - app.kubernetes.io/name
+                      type: string
+                    operator:
+                      default: In
+                      description: Operator represents a key's relationship to a set
+                        of values. Valid operators are In and NotIn.
+                      enum:
+                      - In
+                      - NotIn
+                      type: string
+                    values:
+                      description: Values is an array of string values. If the operator
+                        is In or NotIn, the values array must be non-empty.
+                      items:
+                        description: Value represents a single string value in the
+                          label selector requirement.
+                        minLength: 1
+                        type: string
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-list-type: set
+                  required:
+                  - key
+                  - operator
+                  - values
+                  type: object
+                maxItems: 30
+                type: array
+                x-kubernetes-validations:
+                - message: spec.matchExpressions in body should not contain overlapping
+                    values for the same key and operator
+                  rule: self.all(i, self.filter(j, i.key == j.key && i.operator ==
+                    j.operator && j.values.exists(v, v in i.values)).size() == 1)
+              matchLabels:
+                description: MatchLabels defines a collection of label key-value pairs
+                  used to select the Pods to which this NetworkPolicy applies.
+                items:
+                  description: |-
+                    MatchLabel is a shadow struct used to apply custom kubebuilder validations.
+                    It defines the label key-value pair used to select target Pods while enforcing strict input constraints.
+                  properties:
+                    label:
+                      default: vm.kubevirt.io/name
+                      description: Label is the label key that the target resource
+                        must contain.
+                      enum:
+                      - vm.kubevirt.io/name
+                      - app.kubernetes.io/name
+                      type: string
+                    value:
+                      description: Value is the string value corresponding to the
+                        label key.
+                      minLength: 1
+                      type: string
+                  required:
+                  - label
+                  - value
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - label
+                - value
+                x-kubernetes-list-type: map
+              resolutionTimeoutSeconds:
+                default: 3
+                description: "ResolutionTimeoutSeconds defines the maximum timeout
+                  duration for a single FQDN during DNS queries.\n\nConfiguration:\n\t▸
+                  Default: 3s\n\t▸ Range: 1s to 60s\n\t▸ Constraint: Must be strictly
+                  less than TTLSeconds"
+                format: int32
+                maximum: 60
+                minimum: 1
+                type: integer
+              retryTimeoutSeconds:
+                default: 3600
+                description: "RetryTimeoutSeconds defines the tolerance duration when
+                  FQDN resolution errors occur. Within this time window, previously
+                  successfully resolved IP addresses will be retained in the underlying
+                  network policy to prevent intermittent DNS failures from disrupting
+                  business traffic.\n\nConfiguration:\n\t▸ Default: 3600s (1 hour)\n\t▸
+                  Range: 1s to 86400s (24 hours)"
+                format: int32
+                maximum: 86400
+                type: integer
+              targetNetwork:
+                description: TargetNetwork specifies the target NAD resource where
+                  this NetworkPolicy takes effect. If the selection dropdown is empty,
+                  no NADs are available in the current project, preventing the policy
+                  from taking effect. Please ensure at least one valid NAD is created
+                  before proceeding.
+                minLength: 1
+                type: string
+              ttlSeconds:
+                default: 60
+                description: "TTLSeconds defines the polling interval to re-evaluate
+                  and resolve all FQDN addresses.\n\nConfiguration:\n\t▸ Default:
+                  60s\n\t▸ Range: 5s to 1800s\n\t▸ Constraint: Must be strictly greater
+                  than ResolutionTimeoutSeconds"
+                format: int32
+                maximum: 1800
+                minimum: 5
+                type: integer
+            required:
+            - egress
+            - targetNetwork
+            type: object
+          status:
+            description: NetworkPolicyStatus defines the observed state of NetworkPolicy.
+            properties:
+              activeFQDNCount:
+                description: ActiveFQDNCount represents the number of FQDNs currently
+                  holding valid IPs (including cached ones).
+                format: int32
+                type: integer
+              appliedAddressCount:
+                description: AppliedAddressCount is the number of unique IP addresses
+                  successfully applied to the underlying network policy.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the NetworkPolicy's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              failingFQDNCount:
+                description: FailingFQDNCount represents the number of FQDNs that
+                  failed to resolve and have no cached IPs.
+                format: int32
+                type: integer
+              fqdns:
+                description: FQDNs contains the detailed resolution status for each
+                  FQDN defined in the egress rules.
+                items:
+                  description: FQDNStatus defines the resolution status of a specific
+                    FQDN.
+                  properties:
+                    addresses:
+                      description: |-
+                        Addresses is the list of resolved IP addresses for the given FQDN.
+                        This list is cleared immediately upon a non-transient error, or if a transient error persists longer than the limit specified by NetworkPolicySpec.RetryTimeoutSeconds.
+                      items:
+                        type: string
+                      type: array
+                    failingSince:
+                      description: |-
+                        FailingSince records the exact time the FQDN first started failing to resolve.
+                        It is nil when the FQDN is resolved successfully.
+                        This timestamp is used to calculate whether a continuous transient failure has exceeded the tolerance defined by NetworkPolicySpec.RetryTimeoutSeconds.
+                      format: date-time
+                      type: string
+                    fqdn:
+                      description: FQDN specifies the exact fully qualified domain
+                        name that this resolution status tracks.
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the resolution
+                        reason transitioned from one state to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message is a human-readable description detailing
+                        the reason for the current status.
+                      type: string
+                    reason:
+                      description: Reason describes the specific condition or error
+                        encountered during the last resolution attempt.
+                      type: string
+                  required:
+                  - fqdn
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration represents the most recent generation
+                  observed by the controller.
+                format: int64
+                type: integer
+              totalAddressCount:
+                description: TotalAddressCount is the total number of IP addresses
+                  resolved from all FQDNs before filtering and deduplication.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/fqdn-egress-operator/1.0.6/metadata/annotations.yaml
+++ b/operators/fqdn-egress-operator/1.0.6/metadata/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: fqdn-egress-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: "v4.19"


### PR DESCRIPTION
Title:

feat: support port ranges via 'endPort' in FQDN egress rules (v1.0.6)
📝 Summary

This PR introduces support for Port Ranges in FQDN network policies. Building upon the existing single-port matching, users can now define a continuous range of allowed ports using the newly added endPort field, which is seamlessly translated into the underlying MultiNetworkPolicy structure.

Additionally, this update implements strict OpenAPI type constraints and CEL logical validations to prevent security risks (e.g., unintended broad permissions) caused by the silent data pruning behavior of certain frontend UI forms when handling invalid inputs.
✨ Key Changes

    CRD API Upgrade: Added the optional EndPort *int32 field to the MultiNetworkPolicyPort struct.

    Core Translation Logic: Updated the toMultiNetworkPolicyEgressRule method. When a valid endPort is detected in the Custom Resource, its pointer is safely passed down to the underlying MultiNetworkPolicyPort object.

    Strict CEL Validation:

        Introduced the cross-field CEL rule: !has(self.endPort) || (has(self.port) && self.endPort >= self.port).

        Semantics: Allows omitting ports entirely (allow-all behavior); however, if endPort is specified, the starting port must also be explicitly defined, and endPort must be greater than or equal to port.

    Enforced OpenAPI Type Locking: Explicitly added the +kubebuilder:validation:Type=integer kubebuilder marker to both Port and EndPort. This overrides the ambiguity inherited from the native Kubernetes IntOrString port types, ensuring the API Server immediately rejects invalid string inputs (e.g., "abc") and prevents silent field dropping.

    OLM Bundle & Version Upgrade (v1.0.6):

        Bumped the version to 1.0.6 in the Makefile and CSV.

        Configured a smooth upgrade path by setting replaces: fqdn-egress-operator.v1.0.5 and olm.skipRange: '>=1.0.0 <1.0.6'.

        Regenerated CRD manifests and the Bundle image. The operator maintains native compatibility with OCP 4.21 and 4.22 (leveraging the com.redhat.openshift.versions: "v4.19" annotation for automatic upward compatibility).