### PR TITLE
operator libredb-studio-operator (0.9.59)

### DIFF
--- a/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+    control-plane: controller-manager
+  name: libredb-studio-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: libredb-studio-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-libredbstudio-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-libredbstudio-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+  name: libredb-studio-operator-libredbstudio-admin-role
+rules:
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios
+  verbs:
+  - '*'
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios/status
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-libredbstudio-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-libredbstudio-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+  name: libredb-studio-operator-libredbstudio-editor-role
+rules:
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios/status
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-libredbstudio-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-libredbstudio-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+  name: libredb-studio-operator-libredbstudio-viewer-role
+rules:
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios/status
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: libredb-studio-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -1,0 +1,363 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "studio.libredb.org/v1alpha1",
+          "kind": "LibreDBStudio",
+          "metadata": {
+            "name": "libredbstudio-sample"
+          },
+          "spec": {
+            "persistence": {
+              "enabled": true,
+              "size": "1Gi"
+            },
+            "replicaCount": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Database, Developer Tools
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.9.59
+    createdAt: "2026-07-20T09:40:28Z"
+    description: Open-source web-based SQL IDE for PostgreSQL, MySQL, Oracle, SQL
+      Server, SQLite, MongoDB and Redis, with AI-powered query assistance.
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://github.com/libredb/libredb-studio
+    support: LibreDB
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+  name: libredb-studio-operator.v0.9.59
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: A LibreDB Studio instance managed by the operator. The spec mirrors
+        the Helm chart values; every field left unset falls back to the chart defaults.
+      displayName: LibreDB Studio
+      kind: LibreDBStudio
+      name: libredbstudios.studio.libredb.org
+      version: v1alpha1
+  description: |
+    LibreDB Studio is an open-source, web-based SQL IDE. Query PostgreSQL,
+    MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis from the browser —
+    with AI-powered query assistance (natural-language-to-SQL, explain, fix),
+    an ERD viewer, schema diff and a data profiler. No desktop client required.
+
+    This Helm-based operator installs and manages LibreDB Studio through the
+    `LibreDBStudio` custom resource, which exposes the full Helm chart
+    configuration. With no credentials provided, the instance starts in
+    zero-config bootstrap mode: a JWT secret is generated automatically and a
+    first-run admin account is created. For production, switch
+    `config.authBootstrap` to `"off"` and supply an existing Secret.
+
+    ### Usage
+
+    Create a `LibreDBStudio` resource; every field left unset falls back to
+    the chart defaults. See the sample on this page for a minimal start.
+  displayName: LibreDB Studio
+  icon:
+  - base64data: PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDIwMCAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImxvZ28tZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNEY0NkU1IiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM5MzMzRUEiIC8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJjb2RlLWdyYWRpZW50IiB4MT0iMCUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIxMDAlIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzEwQjk4MSIgLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjM0I4MkY2IiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDxmaWx0ZXIgaWQ9Imdsb3ciIHg9Ii0yMCUiIHk9Ii0yMCUiIHdpZHRoPSIxNDAlIiBoZWlnaHQ9IjE0MCUiPgogICAgICA8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIzIiByZXN1bHQ9ImJsdXIiIC8+CiAgICAgIDxmZUNvbXBvc2l0ZSBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJibHVyIiBvcGVyYXRvcj0ib3ZlciIgLz4KICAgIDwvZmlsdGVyPgogIDwvZGVmcz4KICAKICA8IS0tIEJhY2tncm91bmQgU2hhcGUgLS0+CiAgPHBhdGggZD0iTTEwMCAyMEwxNjkuMjgyIDYwVjE0MEwxMDAgMTgwTDMwLjcxOCAxNDBWNjBMMTAwIDIwWiIgZmlsbD0idXJsKCNsb2dvLWdyYWRpZW50KSIgZmlsbC1vcGFjaXR5PSIwLjA1IiBzdHJva2U9InVybCgjbG9nby1ncmFkaWVudCkiIHN0cm9rZS13aWR0aD0iMS41Ii8+CiAgCiAgPCEtLSBEYXRhYmFzZSBMYXllcnMgKERlLWVtcGhhc2l6ZWQpIC0tPgogIDxnIG9wYWNpdHk9IjAuMyI+CiAgICA8cmVjdCB4PSI3MCIgeT0iODAiIHdpZHRoPSI2MCIgaGVpZ2h0PSIxMCIgcng9IjIiIGZpbGw9InVybCgjbG9nby1ncmFkaWVudCkiIC8+CiAgICA8cmVjdCB4PSI3MCIgeT0iOTUiIHdpZHRoPSI2MCIgaGVpZ2h0PSIxMCIgcng9IjIiIGZpbGw9InVybCgjbG9nby1ncmFkaWVudCkiIC8+CiAgICA8cmVjdCB4PSI3MCIgeT0iMTEwIiB3aWR0aD0iNjAiIGhlaWdodD0iMTAiIHJ4PSIyIiBmaWxsPSJ1cmwoI2xvZ28tZ3JhZGllbnQpIiAvPgogIDwvZz4KICAKICA8IS0tIENvZGluZyBCcmFja2V0cyAoRW1waGFzaXplZCkgLS0+CiAgPGcgZmlsdGVyPSJ1cmwoI2dsb3cpIj4KICAgIDxwYXRoIGQ9Ik01NSA3MEwzNSAxMDBMNTUgMTMwIiBzdHJva2U9InVybCgjY29kZS1ncmFkaWVudCkiIHN0cm9rZS13aWR0aD0iNiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiAvPgogICAgPHBhdGggZD0iTTE0NSA3MEwxNjUgMTAwTDE0NSAxMzAiIHN0cm9rZT0idXJsKCNjb2RlLWdyYWRpZW50KSIgc3Ryb2tlLXdpZHRoPSI2IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIC8+CiAgPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - studio.libredb.org
+          resources:
+          - libredbstudios
+          - libredbstudios/status
+          - libredbstudios/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: libredb-studio-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: libredb-studio-operator
+          control-plane: controller-manager
+        name: libredb-studio-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: libredb-studio-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: libredb-studio-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --leader-election-id=libredb-studio-operator
+                - --health-probe-bind-address=:8081
+                image: ghcr.io/libredb/libredb-studio-operator:0.9.59
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: libredb-studio-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: libredb-studio-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - sql
+  - database
+  - ide
+  - sql-editor
+  - postgresql
+  - mysql
+  - mongodb
+  - redis
+  - oracle
+  - sql-server
+  - sqlite
+  links:
+  - name: Website
+    url: https://libredb.org
+  - name: Source Code
+    url: https://github.com/libredb/libredb-studio
+  - name: Helm Chart
+    url: https://libredb.org/libredb-studio/
+  maintainers:
+  - email: yusuf.gundogdu@sekoya.tech
+    name: Yusuf Gündoğdu
+  - email: cevheri.bozoglan@sekoya.tech
+    name: Mehmet Cevheri Bozoğlan
+  maturity: alpha
+  minKubeVersion: 1.26.0
+  provider:
+    name: LibreDB
+    url: https://libredb.org
+  version: 0.9.59

--- a/operators/libredb-studio-operator/0.9.59/manifests/studio.libredb.org_libredbstudios.yaml
+++ b/operators/libredb-studio-operator/0.9.59/manifests/studio.libredb.org_libredbstudios.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: libredbstudios.studio.libredb.org
+spec:
+  group: studio.libredb.org
+  names:
+    kind: LibreDBStudio
+    listKind: LibreDBStudioList
+    plural: libredbstudios
+    singular: libredbstudio
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LibreDBStudio is the Schema for the libredbstudios API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of LibreDBStudio
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of LibreDBStudio
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/libredb-studio-operator/0.9.59/metadata/annotations.yaml
+++ b/operators/libredb-studio-operator/0.9.59/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: libredb-studio-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/libredb-studio-operator/0.9.59/tests/scorecard/config.yaml
+++ b/operators/libredb-studio-operator/0.9.59/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/operators/libredb-studio-operator/Makefile
+++ b/operators/libredb-studio-operator/Makefile
@@ -1,0 +1,102 @@
+# This Makefile provides a set of targets to generate and validate operator catalogs
+# using the Operator Package Manager (opm) tool.
+
+# The makefile should be placed in the root of the operator repository.
+# for example at: <operator-repo>/operators/<operator-name>/Makefile
+
+PWD=$(shell pwd)
+OPERATOR_NAME=$(shell basename $(PWD))
+TOPDIR=$(abspath $(dir $(PWD))/../)
+BINDIR=${TOPDIR}/bin
+
+# Add the bin directory to the PATH
+export PATH := $(BINDIR):$(PATH)
+# A place to store the generated catalogs
+CATALOG_DIR=${TOPDIR}/catalogs
+
+# The operator pipeline image to use for the fbc-onboarding target
+OPERATOR_PIPELINE_IMAGE ?= quay.io/redhat-isv/operator-pipelines-images:released
+
+# Define the paths for both auth files
+DOCKER_CONFIG := $(HOME)/.docker/config.json
+CONTAINERS_AUTH := $(XDG_RUNTIME_DIR)/containers/auth.json
+
+
+.PHONY: fbc-onboarding
+fbc-onboarding: clean
+	@if [ -f $(DOCKER_CONFIG) ]; then \
+		echo "Using Docker config file: $(DOCKER_CONFIG)"; \
+		CONFIG_VOLUME="-v $(DOCKER_CONFIG):/root/.docker/config.json"; \
+	elif [ -f $(CONTAINERS_AUTH) ]; then \
+		echo "Using containers auth file: $(CONTAINERS_AUTH)"; \
+		CONFIG_VOLUME="-v $(CONTAINERS_AUTH):/root/.docker/config.json"; \
+	else \
+		echo "No authentication file found."; \
+	fi; \
+	podman run \
+		--rm \
+		--user $(id -u):$(id -g) \
+		--security-opt label=disable \
+		--pull always \
+		-v $(TOPDIR):/workspace \
+		$$CONFIG_VOLUME \
+		$(OPERATOR_PIPELINE_IMAGE) fbc-onboarding \
+			--repo-root /workspace \
+			--operator-name $(OPERATOR_NAME) \
+			--cache-dir /workspace/.catalog_cache
+
+.PHONY: catalogs
+
+# Catalogs are generated based on the mapping in ci.yaml file
+# The example of the mapping is:
+# fbc:
+#   enabled: true
+#   catalog_mapping:
+#     - template_name: basic.yaml
+#       catalog_names: ["v4.14", "v4.15", "v4.16"]
+#       type: olm.template.basic
+#     - template_name: semver.yaml
+#       catalog_names: ["v4.13", "v4.17"]
+#       type: olm.semver
+catalogs: render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
+	@echo "Rendering catalogs from templates"
+	@${BINDIR}/render_catalogs.sh
+
+
+# validate-catalogs target illustrates FBC validation
+# all FBC must pass opm validation in order to be able to be used in a catalog
+.PHONY: validate-catalogs
+validate-catalogs: ${BINDIR}/opm
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
+		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
+
+.PHONY: create-catalog-dir
+create-catalog-dir:
+	@mkdir -p $(CATALOG_DIR)
+
+.PHONY: clean
+clean: create-catalog-dir
+	@echo "Cleaning up the operator catalogs from $(CATALOG_DIR)"
+	@find $(CATALOG_DIR) -type d -name ${OPERATOR_NAME} -exec rm -rf {} +
+
+
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+
+# Automatically download the binaries and scripts and place them in the bin directory
+OPM_VERSION ?= v1.46.0
+${BINDIR}/opm:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm ${BINDIR}/opm
+
+YQ_VERSION ?= v4.45.1
+${BINDIR}/yq:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(OS)_$(ARCH) && mv yq_$(OS)_$(ARCH) ${BINDIR}/yq && chmod +x ${BINDIR}/yq
+
+.PHONY: render_catalogs.sh
+render_catalogs.sh:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/render_catalogs.sh
+	mv render_catalogs.sh ${BINDIR}/render_catalogs.sh
+	chmod +x ${BINDIR}/render_catalogs.sh

--- a/operators/libredb-studio-operator/catalog-templates/basic.yaml
+++ b/operators/libredb-studio-operator/catalog-templates/basic.yaml
@@ -1,0 +1,13 @@
+---
+schema: olm.template.basic
+entries:
+- schema: olm.package
+  name: libredb-studio-operator
+  defaultChannel: alpha
+- schema: olm.channel
+  package: libredb-studio-operator
+  name: alpha
+  entries:
+  - name: libredb-studio-operator.v0.9.59
+- schema: olm.bundle
+  image: quay.io/community-operator-pipeline-prod/libredb-studio-operator:0.9.59

--- a/operators/libredb-studio-operator/ci.yaml
+++ b/operators/libredb-studio-operator/ci.yaml
@@ -1,0 +1,18 @@
+---
+reviewers:
+  - cevheri
+  - yusuf-gundogdu
+fbc:
+  enabled: true
+  catalog_mapping:
+    - template_name: basic.yaml
+      type: olm.template.basic
+      catalog_names:
+        - v4.15
+        - v4.16
+        - v4.17
+        - v4.18
+        - v4.19
+        - v4.20
+        - v4.21
+        - v4.22


### PR DESCRIPTION
New operator submission (FBC): **LibreDB Studio** — an open-source, web-based SQL IDE (PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB, Redis) packaged as a codeless Helm-based operator (operator-sdk helm plugin).

- **Controller image:** public multi-arch `ghcr.io/libredb/libredb-studio-operator:0.9.59` (linux/amd64 + linux/arm64), anonymously pullable.
- **FBC:** `ci.yaml` uses `fbc.enabled: true` with a `basic.yaml` template mapped to catalogs **v4.15–v4.22**. The `catalogs/<version>/libredb-studio-operator/catalog.yaml` fragments are rendered and committed; all pass `opm validate`.
- **minKubeVersion:** 1.26.0 (compatible with every targeted OpenShift version).
- **OpenShift compatibility:** the embedded Helm chart adapts its pod security context for the restricted-v2 SCC (drops fixed runAsUser/runAsGroup/fsGroup, keeps runAsNonRoot + seccomp) and supports arbitrary UIDs.

Validated locally with the operatorframework suite plus `operatorhubv2`, `community`, `capabilities`, `categories`, `multiarch`, and `opm validate` on every rendered catalog — all pass. Also submitted to k8s-operatorhub/community-operators (operatorhub.io) as PR #8794.
