### PR TITLE
operator file-integrity-console-plugin (0.1.0)

### DIFF
--- a/operators/file-integrity-console-plugin/0.1.0/manifests/file-integrity-console-plugin.v0.1.0.clusterserviceversion.yaml
+++ b/operators/file-integrity-console-plugin/0.1.0/manifests/file-integrity-console-plugin.v0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,203 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/os.linux: supported
+  annotations:
+    capabilities: Basic Install
+    categories: Security,Monitoring
+    repository: https://github.com/amedeos/file-integrity-console-plugin
+    support: https://github.com/amedeos/file-integrity-console-plugin/issues
+    description: >-
+      Node-by-node view of Red Hat File Integrity Operator (AIDE) scan results in the OpenShift
+      console.
+    console.openshift.io/plugins: '["file-integrity-console-plugin"]'
+    operatorframework.io/suggested-namespace: openshift-file-integrity
+    containerImage: quay.io/asalvati/file-integrity-console-plugin:0.1.0
+    createdAt: '2026-07-27T15:29:09Z'
+    alm-examples: '[]'
+  name: file-integrity-console-plugin.v0.1.0
+spec:
+  displayName: File Integrity Console Plugin
+  description: |
+    A console plugin for the [File Integrity Operator][fio]: a node-by-node view
+    of AIDE scan results, with the failing files parsed out of the operator's
+    result ConfigMaps instead of read as raw log text.
+
+    It adds a **Compute → File Integrity** entry to the administrator
+    perspective, visible only on clusters where the `FileIntegrity` CRD exists.
+
+    ## What it shows
+
+    * **Overview** — every `FileIntegrityNodeStatus` in the cluster, its phase,
+      and the count of files added, changed and removed.
+    * **Node report** — the AIDE report for one node, parsed into a filterable
+      table, with the attribute differences for each changed file. Both the AIDE
+      0.16 (`CONTENTEX`) and 0.18 (`CONTENT_EX`) report grammars are read, and a
+      report the operator truncated is labelled as truncated rather than shown
+      as though it were complete.
+    * **Re-initialise** — per node or cluster-wide, behind a confirmation that
+      spells out that the current baseline is discarded.
+
+    ## How it talks to the cluster
+
+    The plugin's own ServiceAccount has **no Role and no ClusterRole**.
+    Everything the backend does against the API server it does with the calling
+    user's token, resolving the caller with `SelfSubjectReview` and checking
+    rights with `SelfSubjectAccessReview`. A request arriving without a bearer
+    token is rejected; it is never served with the plugin's own credentials.
+
+    ## Reading files from nodes
+
+    One feature reads the current contents of a file from a node, so a reported
+    change can be looked at. It reads as though it grants something, and it does
+    not: the read runs as the browsing user, is refused unless they hold
+    `pods/exec` in the scan namespace, and is recorded against their name in the
+    API server's audit log. A deny list — refusing keys, certificates, shadow
+    files and the static pod resources — is checked before the caller is even
+    authenticated, so probing it costs nothing and is attributed to no session.
+
+    It can be switched off, and then the endpoint answers `501` and the backend
+    builds no Kubernetes client at all. Set `PLUGIN_ENABLE_FILE_RETRIEVE` to
+    `false` through the Subscription to do that.
+
+    [fio]: https://github.com/openshift/file-integrity-operator
+  keywords:
+    - file integrity
+    - aide
+    - security
+    - compliance
+    - console plugin
+  maturity: alpha
+  provider:
+    name: Amedeo Salvati
+    url: https://github.com/amedeos/file-integrity-console-plugin
+  maintainers:
+    - name: Amedeo Salvati
+      email: cops.capable425@passmail.net
+  links:
+    - name: Source
+      url: https://github.com/amedeos/file-integrity-console-plugin
+    - name: File Integrity Operator
+      url: https://github.com/openshift/file-integrity-operator
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: false
+  customresourcedefinitions: {}
+  version: 0.1.0
+  minKubeVersion: 1.35.0
+  icon:
+    - base64data: >-
+        PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4IiByb2xlPSJpbWciCiAgICAgYXJpYS1sYWJlbD0iRmlsZSBJbnRlZ3JpdHkgQ29uc29sZSBQbHVnaW4iPgogIDx0aXRsZT5GaWxlIEludGVncml0eSBDb25zb2xlIFBsdWdpbjwvdGl0bGU+CiAgPCEtLQogICAgQSBmaWxlIHdob3NlIGNvcm5lciBpcyBmb2xkZWQsIHdpdGggYSBjaGVjayBpbnNpZGUgYSBzaGllbGQ6IHRoZSBvcGVyYXRvcgogICAgcmVwb3J0cywgZmlsZSBieSBmaWxlLCB3aGV0aGVyIHdoYXQgaXMgb24gYSBub2RlIHN0aWxsIG1hdGNoZXMgdGhlIGJhc2VsaW5lLgogICAgRGVsaWJlcmF0ZWx5IG5vdCBSZWQgSGF0J3MgcGFsZXR0ZSBvciBtYXJrcyDigJQgdGhpcyBpcyBhIHRoaXJkLXBhcnR5IHBsdWdpbgogICAgZm9yIHRoZWlyIG9wZXJhdG9yLCBub3Qgc29tZXRoaW5nIHB1Ymxpc2hlZCBieSB0aGVtLgogIC0tPgogIDxyZWN0IHdpZHRoPSIxMjgiIGhlaWdodD0iMTI4IiByeD0iMjAiIGZpbGw9IiMxYjI3MzMiLz4KICA8cGF0aCBkPSJNMzYgMjZoMzVsMjEgMjF2NTVhNSA1IDAgMCAxLTUgNUgzNmE1IDUgMCAwIDEtNS01VjMxYTUgNSAwIDAgMSA1LTV6IgogICAgICAgIGZpbGw9IiNlOGVkZjIiLz4KICA8cGF0aCBkPSJNNzEgMjZsMjEgMjFINzZhNSA1IDAgMCAxLTUtNXoiIGZpbGw9IiNhN2I2YzQiLz4KICA8cGF0aCBkPSJNNjQgNTVsMTkgN3YxNmMwIDExLTggMjAtMTkgMjQtMTEtNC0xOS0xMy0xOS0yNFY2MnoiIGZpbGw9IiMyYjlhZjMiLz4KICA8cGF0aCBkPSJNNTUgNzlsNyA3IDE1LTE1IiBmaWxsPSJub25lIiBzdHJva2U9IiNmZmZmZmYiIHN0cm9rZS13aWR0aD0iNyIKICAgICAgICBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+Cg==
+      mediatype: image/svg+xml
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: file-integrity-console-plugin
+          rules: []
+      deployments:
+        - name: file-integrity-console-plugin
+          label:
+            app: file-integrity-console-plugin
+            app.kubernetes.io/name: file-integrity-console-plugin
+            app.kubernetes.io/instance: file-integrity-console-plugin
+            app.kubernetes.io/part-of: file-integrity-console-plugin
+            app.kubernetes.io/version: 0.1.0
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                app: file-integrity-console-plugin
+                app.kubernetes.io/name: file-integrity-console-plugin
+                app.kubernetes.io/instance: file-integrity-console-plugin
+                app.kubernetes.io/part-of: file-integrity-console-plugin
+            template:
+              metadata:
+                labels:
+                  helm.sh/chart: file-integrity-console-plugin-0.1.0
+                  app: file-integrity-console-plugin
+                  app.kubernetes.io/name: file-integrity-console-plugin
+                  app.kubernetes.io/instance: file-integrity-console-plugin
+                  app.kubernetes.io/part-of: file-integrity-console-plugin
+                  app.kubernetes.io/version: 0.1.0
+                  app.kubernetes.io/managed-by: Helm
+                annotations:
+                  checksum/policy: 42ba610a86d150941363115a6aad91c30c4d108039d4f16ca498999e39039a06
+              spec:
+                serviceAccountName: file-integrity-console-plugin
+                containers:
+                  - name: file-integrity-console-plugin
+                    image: quay.io/asalvati/file-integrity-console-plugin:0.1.0
+                    args:
+                      - '--listen=:9443'
+                      - '--tls-cert-file=/var/cert/tls.crt'
+                      - '--tls-key-file=/var/cert/tls.key'
+                      - '--static-dir=/opt/app-root/web'
+                    env:
+                      - name: PLUGIN_FIO_NAMESPACE
+                        value: openshift-file-integrity
+                      - name: PLUGIN_MAX_FILE_BYTES
+                        value: '1048576'
+                      - name: PLUGIN_ENABLE_FILE_RETRIEVE
+                        value: 'true'
+                    ports:
+                      - containerPort: 9443
+                        protocol: TCP
+                    imagePullPolicy: IfNotPresent
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    resources:
+                      limits:
+                        memory: 256Mi
+                      requests:
+                        cpu: 10m
+                        memory: 50Mi
+                    readinessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 9443
+                        scheme: HTTPS
+                      initialDelaySeconds: 2
+                      periodSeconds: 10
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 9443
+                        scheme: HTTPS
+                      initialDelaySeconds: 10
+                      periodSeconds: 30
+                    volumeMounts:
+                      - name: plugin-cert
+                        readOnly: true
+                        mountPath: /var/cert
+                volumes:
+                  - name: plugin-cert
+                    secret:
+                      secretName: file-integrity-console-plugin-cert
+                      defaultMode: 420
+                restartPolicy: Always
+                dnsPolicy: ClusterFirst
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+            strategy:
+              type: RollingUpdate
+              rollingUpdate:
+                maxUnavailable: 25%
+                maxSurge: 25%
+  relatedImages:
+    - name: plugin
+      image: quay.io/asalvati/file-integrity-console-plugin:0.1.0

--- a/operators/file-integrity-console-plugin/0.1.0/manifests/file-integrity-console-plugin_console.openshift.io_v1_consoleplugin.yaml
+++ b/operators/file-integrity-console-plugin/0.1.0/manifests/file-integrity-console-plugin_console.openshift.io_v1_consoleplugin.yaml
@@ -1,0 +1,30 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: file-integrity-console-plugin
+  labels:
+    app: file-integrity-console-plugin
+    app.kubernetes.io/name: file-integrity-console-plugin
+    app.kubernetes.io/instance: file-integrity-console-plugin
+    app.kubernetes.io/part-of: file-integrity-console-plugin
+    app.kubernetes.io/version: 0.1.0
+spec:
+  displayName: File Integrity
+  i18n:
+    loadType: Preload
+  backend:
+    type: Service
+    service:
+      name: file-integrity-console-plugin
+      namespace: openshift-file-integrity
+      port: 9443
+      basePath: /
+  proxy:
+    - alias: fio-backend
+      authorization: UserToken
+      endpoint:
+        type: Service
+        service:
+          name: file-integrity-console-plugin
+          namespace: openshift-file-integrity
+          port: 9443

--- a/operators/file-integrity-console-plugin/0.1.0/manifests/file-integrity-console-plugin_core_v1_service.yaml
+++ b/operators/file-integrity-console-plugin/0.1.0/manifests/file-integrity-console-plugin_core_v1_service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: file-integrity-console-plugin-cert
+  name: file-integrity-console-plugin
+  labels:
+    app: file-integrity-console-plugin
+    app.kubernetes.io/name: file-integrity-console-plugin
+    app.kubernetes.io/instance: file-integrity-console-plugin
+    app.kubernetes.io/part-of: file-integrity-console-plugin
+    app.kubernetes.io/version: 0.1.0
+spec:
+  ports:
+    - name: 9443-tcp
+      protocol: TCP
+      port: 9443
+      targetPort: 9443
+  selector:
+    app: file-integrity-console-plugin
+    app.kubernetes.io/name: file-integrity-console-plugin
+    app.kubernetes.io/instance: file-integrity-console-plugin
+    app.kubernetes.io/part-of: file-integrity-console-plugin
+  type: ClusterIP
+  sessionAffinity: None

--- a/operators/file-integrity-console-plugin/0.1.0/metadata/annotations.yaml
+++ b/operators/file-integrity-console-plugin/0.1.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: file-integrity-console-plugin
+  operators.operatorframework.io.bundle.channels.v1: stable-4.22
+  operators.operatorframework.io.bundle.channel.default.v1: stable-4.22
+  com.redhat.openshift.versions: v4.22

--- a/operators/file-integrity-console-plugin/ci.yaml
+++ b/operators/file-integrity-console-plugin/ci.yaml
@@ -1,0 +1,12 @@
+---
+# Reviewers whose approval lets a change to this operator merge automatically.
+reviewers:
+  - amedeos
+
+# Upgrade edges come from the CSV's `replaces`/`skips` fields and from nothing
+# else. Deliberately not semver-mode: this package ships one bundle per console
+# generation, and in semver `0.1.0-ocp4.16` is a *prerelease* of `0.1.0`, so a
+# version-ordered graph would describe an upgrade from the 4.16 build to the
+# 4.22 one. They are different builds for different consoles, not successive
+# releases.
+updateGraph: replaces-mode


### PR DESCRIPTION
### New Submissions

* [x] Are you familiar with our contribution guidelines?
* [x] Are you familiar with our operator pipeline?
* [x] Have you tested your Operator with all Custom Resource Definitions packaging? — n/a, this operator owns no CRDs
* [x] Have you tested your Operator in all supported installation modes?
* [x] Have you considered whether you want to use semantic versioning order?
* [x] Is your submission signed?
* [x] Is operator icon set?

### Your submission should not

* [x] Add more than one operator bundle per PR
* [x] Modify any operator
* [x] Rename an operator
* [x] Modify any files outside the above-mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description of the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human-readable name and 1-liner description about your Operator
* [x] Valid category name
* [x] One of the pre-defined capability levels
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used — n/a, no CRDs
* [x] A quadratic logo

---

**Notes for reviewers**

This operator installs an OpenShift **console plugin** and no API: it owns no
CRDs, runs no controller, and the CSV carries only a Deployment. The two CRD
items above are therefore not applicable.

`installModes` declares **`OwnNamespace` only**, deliberately. The
`ConsolePlugin` names its backend Service's namespace literally — OLM templates
nothing inside a cluster-scoped manifest — so an install anywhere but
`openshift-file-integrity` produces a plugin the console cannot reach. That
namespace is also where the File Integrity Operator, whose results this plugin
displays, already runs.

`updateGraph: replaces-mode`, also deliberately. The package ships one bundle
per OpenShift console generation, kept apart by `com.redhat.openshift.versions`
and by a channel each. In semver `0.1.0-ocp4.16` is a *prerelease* of `0.1.0`,
so a version-ordered graph would describe an upgrade from the 4.16 build to the
4.22 one — different builds for different consoles, not successive releases.
Only the 4.22 bundle is submitted here.

The `permissions` entry has an **empty rule list** and there are no
`clusterPermissions`. That is intentional and is the operator's central
property: the backend has no authority of its own and makes every API-server
call with the browsing user's token, via `SelfSubjectReview` and
`SelfSubjectAccessReview`. The entry exists only so OLM creates the
ServiceAccount the Deployment runs as.