### PR TITLE
operator kairos-operator (2.1.1)

### DIFF
--- a/operators/kairos-operator/2.1.1/manifests/kairos-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+    control-plane: controller-manager
+  name: kairos-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: kairos
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/kairos-operator/2.1.1/manifests/kairos-kairosagent-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-kairosagent-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-kairosagent-admin-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosagents
+  verbs:
+  - '*'
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosagents/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-kairosagent-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-kairosagent-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-kairosagent-editor-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosagents
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosagents/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-kairosagent-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-kairosagent-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-kairosagent-viewer-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosagents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosagents/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-kairosconsole-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-kairosconsole-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-kairosconsole-admin-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosconsoles
+  verbs:
+  - '*'
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosconsoles/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-kairosconsole-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-kairosconsole-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-kairosconsole-editor-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosconsoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosconsoles/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-kairosconsole-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-kairosconsole-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-kairosconsole-viewer-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosconsoles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - kairosconsoles/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kairos-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-operator.clusterserviceversion.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-operator.clusterserviceversion.yaml
@@ -1,0 +1,761 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kairos.maximilianopizarro.github.io/v1alpha1",
+          "kind": "KairosAgent",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kairos-operator"
+            },
+            "name": "agent-dev-environments",
+            "namespace": "kairos-system"
+          },
+          "spec": {
+            "aiModel": {
+              "apiKeySecret": {
+                "key": "token",
+                "name": "kairos-ai-credentials"
+              },
+              "apiURL": "https://isvc-granite-31-8b-fp8-predictor.sandbox-shared-models.svc.cluster.local:8443/v1/chat/completions",
+              "model": "granite-31-8b",
+              "timeoutSeconds": 30
+            },
+            "correctionPolicy": {
+              "dryRun": false,
+              "maxActionsPerHour": 50,
+              "rollbackOnFailure": true
+            },
+            "mode": "autopilot",
+            "paused": false,
+            "reporting": {
+              "interval": "60s"
+            },
+            "watch": {
+              "namespaceSuffix": "-dev",
+              "namespaces": [],
+              "resourceTypes": [
+                "Deployment"
+              ]
+            }
+          }
+        },
+        {
+          "apiVersion": "kairos.maximilianopizarro.github.io/v1alpha1",
+          "kind": "KairosAgent",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kairos-operator"
+            },
+            "name": "agent-production",
+            "namespace": "kairos-system"
+          },
+          "spec": {
+            "aiModel": {
+              "apiKeySecret": {
+                "key": "token",
+                "name": "kairos-ai-credentials"
+              },
+              "apiURL": "https://isvc-granite-31-8b-fp8-predictor.sandbox-shared-models.svc.cluster.local:8443/v1/chat/completions",
+              "model": "granite-31-8b",
+              "temperature": "0.3",
+              "timeoutSeconds": 60
+            },
+            "correctionPolicy": {
+              "dryRun": false,
+              "maxActionsPerHour": 10,
+              "requireApprovalAbove": "50%",
+              "rollbackOnFailure": true
+            },
+            "mode": "supervised",
+            "paused": false,
+            "reporting": {
+              "interval": "30s",
+              "otelExport": true
+            },
+            "watch": {
+              "labelSelector": "kairos.io/managed=true",
+              "namespaceSuffix": "-prod",
+              "namespaces": [
+                "industrial-edge-tst",
+                "factory-kafka"
+              ],
+              "resourceTypes": [
+                "Deployment",
+                "StatefulSet"
+              ]
+            }
+          }
+        },
+        {
+          "apiVersion": "kairos.maximilianopizarro.github.io/v1alpha1",
+          "kind": "KairosAgent",
+          "metadata": {
+            "name": "agent-qa-environments",
+            "namespace": "kairos-system"
+          },
+          "spec": {
+            "aiModel": {
+              "apiKeySecret": {
+                "key": "token",
+                "name": "kairos-ai-credentials"
+              },
+              "apiURL": "https://isvc-granite-31-8b-fp8-predictor.sandbox-shared-models.svc.cluster.local:8443/v1/chat/completions",
+              "model": "granite-31-8b"
+            },
+            "correctionPolicy": {
+              "maxActionsPerHour": 20,
+              "requireApprovalAbove": "30%",
+              "rollbackOnFailure": true
+            },
+            "mode": "supervised",
+            "reporting": {
+              "interval": "45s"
+            },
+            "watch": {
+              "namespaceSuffix": "-qa",
+              "namespaces": [],
+              "resourceTypes": [
+                "Deployment",
+                "StatefulSet"
+              ]
+            }
+          }
+        },
+        {
+          "apiVersion": "kairos.maximilianopizarro.github.io/v1alpha1",
+          "kind": "KairosConsole",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kairos-operator"
+            },
+            "name": "kairos",
+            "namespace": "kairos-system"
+          },
+          "spec": {
+            "auth": {
+              "type": "none"
+            },
+            "clusters": [
+              {
+                "apiURL": "https://api.hub-cluster:6443",
+                "name": "hub",
+                "region": "central"
+              }
+            ],
+            "image": "quay.io/maximilianopizarro/kairos-console:v1.0.0",
+            "replicas": 1,
+            "route": {
+              "enabled": true,
+              "host": "kairos-console.apps.your-cluster.example.com",
+              "tlsEnabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "kairos.maximilianopizarro.github.io/v1alpha1",
+          "kind": "KairosEvent",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kairos-operator"
+            },
+            "name": "example-event",
+            "namespace": "kairos-system"
+          },
+          "spec": {
+            "action": "scale_up",
+            "agentName": "my-agent",
+            "cluster": "hub",
+            "dryRun": false,
+            "namespace": "default",
+            "reason": "CPU utilization exceeded 80% threshold",
+            "resource": "my-app"
+          }
+        },
+        {
+          "apiVersion": "kairos.maximilianopizarro.github.io/v1alpha1",
+          "kind": "SmartScalingPolicy",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kairos-operator"
+            },
+            "name": "industrial-edge-policy",
+            "namespace": "kairos-system"
+          },
+          "spec": {
+            "ai": {
+              "enabled": false
+            },
+            "otelEndpoint": "otel-collector.observability.svc.cluster.local:4317",
+            "paused": false,
+            "prometheusEndpoint": "prometheus-k8s.openshift-monitoring.svc.cluster.local:9090",
+            "rules": [
+              {
+                "action": {
+                  "cooldown": "5m",
+                  "increaseCPUPercent": 25,
+                  "increaseMemoryPercent": 20,
+                  "maxCPU": "2",
+                  "maxMemory": "2Gi",
+                  "type": "IncreaseResources"
+                },
+                "name": "high-cpu-vertical",
+                "when": {
+                  "for": "3m",
+                  "metric": "container_cpu_usage_seconds_total",
+                  "operator": "GreaterThan",
+                  "threshold": "80"
+                }
+              },
+              {
+                "action": {
+                  "cooldown": "5m",
+                  "increaseMemoryPercent": 30,
+                  "maxMemory": "4Gi",
+                  "type": "IncreaseResources"
+                },
+                "name": "memory-pressure-vertical",
+                "when": {
+                  "for": "2m",
+                  "metric": "container_memory_working_set_bytes",
+                  "operator": "GreaterThan",
+                  "threshold": "85"
+                }
+              },
+              {
+                "action": {
+                  "cooldown": "10m",
+                  "maxReplicas": 6,
+                  "replicas": 1,
+                  "type": "AddReplicas"
+                },
+                "name": "request-rate-horizontal",
+                "when": {
+                  "for": "1m",
+                  "metric": "http_server_requests_per_second",
+                  "operator": "GreaterThan",
+                  "threshold": "1000"
+                }
+              },
+              {
+                "action": {
+                  "cooldown": "30m",
+                  "increaseCPUPercent": 20,
+                  "minCPU": "100m",
+                  "type": "DecreaseResources"
+                },
+                "name": "low-utilization-downscale",
+                "when": {
+                  "for": "15m",
+                  "metric": "container_cpu_usage_seconds_total",
+                  "operator": "LessThan",
+                  "threshold": "20"
+                }
+              }
+            ],
+            "schedule": [
+              {
+                "action": {
+                  "minReplicas": 3,
+                  "type": "SetMinReplicas"
+                },
+                "cron": "0 8 * * 1-5",
+                "name": "business-hours-preemptive"
+              },
+              {
+                "action": {
+                  "minReplicas": 1,
+                  "type": "SetMinReplicas"
+                },
+                "cron": "0 20 * * 1-5",
+                "name": "off-hours-scale-down"
+              }
+            ],
+            "target": {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "name": "line-dashboard",
+              "namespace": "industrial-edge-tst"
+            }
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: AI/Machine Learning, Monitoring
+    containerImage: quay.io/maximilianopizarro/kairos-operator:v2.1.1
+    createdAt: "2026-07-28T22:21:23Z"
+    description: AI-powered Kubernetes resource optimizer with SSA, ArgoCD-safe, multi-cluster
+      governance
+    operatorframework.io/suggested-namespace: kairos-system
+    operators.operatorframework.io/builder: operator-sdk-v1.40.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/maximilianoPizarro/kairos
+    support: maximilianopizarro
+  name: kairos-operator.v2.1.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: AI-powered resource management agent that monitors and optimizes
+        workloads
+      displayName: Kairos Agent
+      kind: KairosAgent
+      name: kairosagents.kairos.maximilianopizarro.github.io
+      specDescriptors:
+      - description: Operating mode (autopilot, supervised, or gitops)
+        displayName: Mode
+        path: mode
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:autopilot
+        - urn:alm:descriptor:com.tectonic.ui:select:supervised
+        - urn:alm:descriptor:com.tectonic.ui:select:gitops
+      - description: OpenAI-compatible API endpoint URL
+        displayName: AI API URL
+        path: aiModel.apiURL
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      - description: Enable dry-run mode (no actual changes applied)
+        displayName: Dry Run
+        path: correctionPolicy.dryRun
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: Pause the agent
+        displayName: Paused
+        path: paused
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Current phase of the agent
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1alpha1
+    - description: Multi-cluster governance dashboard with approval workflows and
+        historical charts
+      displayName: Kairos Console
+      kind: KairosConsole
+      name: kairosconsoles.kairos.maximilianopizarro.github.io
+      specDescriptors:
+      - description: Number of console replicas
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: Create an OpenShift Route automatically
+        displayName: Route Enabled
+        path: route.enabled
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Console URL
+        displayName: URL
+        path: url
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      version: v1alpha1
+    - description: Audit trail for scaling decisions
+      displayName: Kairos Event
+      kind: KairosEvent
+      name: kairosevents.kairos.maximilianopizarro.github.io
+      version: v1alpha1
+    - description: Metric-based scaling policy with AI integration, policy inheritance,
+        and predictive scaling
+      displayName: Smart Scaling Policy
+      kind: SmartScalingPolicy
+      name: smartscalingpolicies.kairos.maximilianopizarro.github.io
+      specDescriptors:
+      - description: Target workload kind
+        displayName: Target Kind
+        path: target.kind
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:Deployment
+        - urn:alm:descriptor:com.tectonic.ui:select:StatefulSet
+        - urn:alm:descriptor:com.tectonic.ui:select:DaemonSet
+      - description: Pause all scaling actions
+        displayName: Paused
+        path: paused
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Current conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      version: v1alpha1
+  description: |
+    ## Kairos Operator — Intelligent Resource Management
+
+    Kairos is a Kubernetes operator that uses AI models to continuously analyze workload
+    metrics and automatically right-size container resources using **Server-Side Apply (SSA)**,
+    ensuring **zero conflicts with ArgoCD** and other GitOps controllers.
+
+    ### Why Kairos?
+
+    | Feature | Kairos | VPA | HPA |
+    |---------|--------|-----|-----|
+    | ArgoCD-safe (SSA) | Yes | No | N/A |
+    | AI-powered decisions | Yes | No | No |
+    | Multi-cluster governance | Yes | No | No |
+    | Dry-run mode | Yes | Yes | No |
+    | Approval workflows | Yes | No | No |
+    | GitOps PR generation | Yes | No | No |
+
+    ### Key Features
+
+    * **AI-Powered Recommendations** — Connects to any OpenAI-compatible API (OpenAI, Ollama, vLLM, etc.)
+    * **Server-Side Apply** — Zero-conflict resource management, fully compatible with ArgoCD
+    * **Multi-Cluster Hub-Spoke** — Central console for governance across all clusters
+    * **4 Operating Modes** — Autopilot, Supervised, GitOps, or Dry-Run
+    * **HPA/KEDA/VPA Coexistence** — Automatic detection and deferral to avoid conflicts
+    * **PinnedResources** — SRE can lock workload resources for a set duration
+    * **KairosEvent Audit Trail** — Full history of every scaling decision
+    * **Approval Workflows** — Supervised mode with approve/reject in console UI
+    * **Policy Inheritance** — Global > Cluster > Namespace scope with priority-based resolution
+    * **Cost Estimation** — Integrate with AWS/GCP/Azure pricing APIs
+    * **Notification Webhooks** — Slack, Teams, or generic webhook alerts on corrections
+    * **Predictive Scaling** — Time-series forecasting for proactive resource adjustment
+    * **GitOps Native** — Generate PRs to your infrastructure repo instead of direct patches
+    * **Grafana Dashboard** — Pre-built dashboard for operator observability
+    * **ValidatingWebhook** — Pre-apply validation prevents misconfigurations
+
+    ### Architecture
+
+    ```
+    ┌─────────────────────────────────────────────────────────┐
+    │                     Hub Cluster                          │
+    │  ┌──────────────┐  ┌─────────────┐  ┌──────────────┐   │
+    │  │   Kairos     │  │   Kairos    │  │  SmartScaling │   │
+    │  │  Operator    │──│   Console   │  │   Policies    │   │
+    │  └──────────────┘  └─────────────┘  └──────────────┘   │
+    └───────────┬─────────────────────────────────────────────┘
+                │  Agent Reports (mTLS)
+    ┌───────────┼──────────────────────────────────────────┐
+    │    ┌──────▼──────┐         ┌──────────────┐          │
+    │    │ KairosAgent │ ──────► │  Workloads   │          │
+    │    │  (east)     │  SSA    │  (annotated) │          │
+    │    └─────────────┘         └──────────────┘          │
+    │                    Spoke Cluster                       │
+    └──────────────────────────────────────────────────────┘
+    ```
+
+    ### Prerequisites
+
+    * OpenShift 4.12+ or Kubernetes 1.25+
+    * (Optional) AI model endpoint — OpenAI, Ollama, vLLM, or any compatible API
+    * (Optional) Prometheus/Thanos for metrics collection
+
+    ### Quick Start
+
+    1. Install the operator from OperatorHub
+    2. A default `KairosConsole` is created automatically with a Route
+    3. Create a `KairosAgent` to start monitoring workloads
+    4. Annotate target workloads with `kairos.io/managed: "true"`
+    5. View recommendations in the Kairos Console
+  displayName: Kairos Operator
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0OCA0OCI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJnMSIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzAwYmNkNCIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzFhMjM3ZSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxjaXJjbGUgY3g9IjI0IiBjeT0iMjQiIHI9IjIzIiBmaWxsPSIjMGQxMTE3Ii8+PGNpcmNsZSBjeD0iMjQiIGN5PSIyNCIgcj0iMjIiIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzAwZTVmZiIgc3Ryb2tlLXdpZHRoPSIwLjgiIG9wYWNpdHk9IjAuNiIvPjxwYXRoIGQ9Ik0xNyAxMCBMMzEgMTAgTDI1LjUgMjIuNSBMMjQgMjQgTDIyLjUgMjIuNSBMMTcgMTAgWiIgZmlsbD0idXJsKCNnMSkiIG9wYWNpdHk9IjAuOSIvPjxwYXRoIGQ9Ik0xNyAzOCBMMzEgMzggTDI1LjUgMjUuNSBMMjQgMjQgTDIyLjUgMjUuNSBMMTcgMzggWiIgZmlsbD0idXJsKCNnMSkiIG9wYWNpdHk9IjAuOSIvPjxwYXRoIGQ9Ik0xNiA5IEwzMiA5IiBzdHJva2U9IiMwMGU1ZmYiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMTYgMzkgTDMyIDM5IiBzdHJva2U9IiMwMGU1ZmYiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNMTIgMjAgQzkgMTggNSAxNyAzIDE4IEM1IDIwIDggMjIgMTIgMjMiIGZpbGw9IiMwMGJjZDQiIG9wYWNpdHk9IjAuNyIvPjxwYXRoIGQ9Ik0zNiAyMCBDMzkgMTggNDMgMTcgNDUgMTggQzQzIDIwIDQwIDIyIDM2IDIzIiBmaWxsPSIjMDBiY2Q0IiBvcGFjaXR5PSIwLjciLz48Y2lyY2xlIGN4PSIyNCIgY3k9IjI0IiByPSIyLjUiIGZpbGw9IiMwMGU1ZmYiLz48Y2lyY2xlIGN4PSIyNCIgY3k9IjI0IiByPSIxLjIiIGZpbGw9IiMwZDExMTciLz48Y2lyY2xlIGN4PSIyNCIgY3k9IjE1IiByPSIwLjYiIGZpbGw9IiNmZmFiNDAiIG9wYWNpdHk9IjAuOCIvPjxjaXJjbGUgY3g9IjI0IiBjeT0iMzIiIHI9IjAuNSIgZmlsbD0iI2ZmYWI0MCIgb3BhY2l0eT0iMC42Ii8+PC9zdmc+
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - kairos.maximilianopizarro.github.io
+          resources:
+          - kairosagents
+          - kairosconsoles
+          - kairosevents
+          - smartscalingpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kairos.maximilianopizarro.github.io
+          resources:
+          - kairosagents/finalizers
+          - kairosconsoles/finalizers
+          - smartscalingpolicies/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kairos.maximilianopizarro.github.io
+          resources:
+          - kairosagents/status
+          - kairosconsoles/status
+          - smartscalingpolicies/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: kairos-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: kairos
+          control-plane: controller-manager
+        name: kairos-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: kairos
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: kairos
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: quay.io/maximilianopizarro/kairos-operator:v2.1.1
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: kairos-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: kairos-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kubernetes
+  - autoscaling
+  - ai
+  - resource-management
+  - openshift
+  - machine-learning
+  - cost-optimization
+  - gitops
+  - ssa
+  - argocd
+  links:
+  - name: GitHub
+    url: https://github.com/maximilianoPizarro/kairos
+  - name: Documentation
+    url: https://maximilianopizarro.github.io/kairos/
+  maintainers:
+  - email: maximilianopizarro5@gmail.com
+    name: Maximiliano Pizarro
+  maturity: beta
+  minKubeVersion: 1.25.0
+  nativeAPIs:
+  - group: apps
+    kind: Deployment
+    version: v1
+  - group: apps
+    kind: StatefulSet
+    version: v1
+  - group: apps
+    kind: DaemonSet
+    version: v1
+  - group: batch
+    kind: CronJob
+    version: v1
+  - group: autoscaling
+    kind: HorizontalPodAutoscaler
+    version: v2
+  provider:
+    name: maximilianopizarro
+    url: https://github.com/maximilianoPizarro
+  version: 2.1.1

--- a/operators/kairos-operator/2.1.1/manifests/kairos-smartscalingpolicy-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-smartscalingpolicy-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-smartscalingpolicy-admin-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - smartscalingpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - smartscalingpolicies/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-smartscalingpolicy-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-smartscalingpolicy-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-smartscalingpolicy-editor-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - smartscalingpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - smartscalingpolicies/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos-smartscalingpolicy-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos-smartscalingpolicy-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: kairos
+  name: kairos-smartscalingpolicy-viewer-role
+rules:
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - smartscalingpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kairos.maximilianopizarro.github.io
+  resources:
+  - smartscalingpolicies/status
+  verbs:
+  - get

--- a/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_kairosagents.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_kairosagents.yaml
@@ -1,0 +1,533 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  name: kairosagents.kairos.maximilianopizarro.github.io
+spec:
+  group: kairos.maximilianopizarro.github.io
+  names:
+    kind: KairosAgent
+    listKind: KairosAgentList
+    plural: kairosagents
+    singular: kairosagent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.mode
+      name: Mode
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.correctionPolicy.dryRun
+      name: DryRun
+      type: boolean
+    - jsonPath: .status.totalCorrections
+      name: Corrections
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KairosAgent is the Schema for the kairosagents API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KairosAgentSpec defines the desired state of KairosAgent.
+            properties:
+              aiModel:
+                description: AI model configuration
+                properties:
+                  apiKeySecret:
+                    description: Secret reference for API key
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  apiURL:
+                    description: OpenAI-compatible API endpoint
+                    type: string
+                  model:
+                    description: Model identifier
+                    type: string
+                  temperature:
+                    description: Temperature for model responses (0.0 - 1.0)
+                    type: string
+                  timeoutSeconds:
+                    description: Request timeout
+                    format: int32
+                    type: integer
+                  tls:
+                    description: TLS settings for AI API connection
+                    properties:
+                      caSecretRef:
+                        description: Custom CA certificate secret reference
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      certSecretRef:
+                        description: Client certificate secret reference (mTLS)
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      insecureSkipVerify:
+                        description: Skip TLS certificate verification (for disconnected/air-gapped
+                          environments)
+                        type: boolean
+                    type: object
+                required:
+                - apiURL
+                - model
+                type: object
+              correctionPolicy:
+                description: Correction guardrails
+                properties:
+                  dryRun:
+                    description: 'Dry-run mode: log decisions without applying them'
+                    type: boolean
+                  maxActionsPerHour:
+                    description: Maximum corrections per hour
+                    format: int32
+                    type: integer
+                  requireApprovalAbove:
+                    description: Changes above this percentage require human approval
+                    type: string
+                  rollbackOnFailure:
+                    description: Automatically rollback if a correction causes degradation
+                    type: boolean
+                required:
+                - maxActionsPerHour
+                type: object
+              gitops:
+                description: 'GitOps configuration: generate PRs instead of direct
+                  SSA patches'
+                properties:
+                  branch:
+                    description: 'Branch to create PRs against (default: main)'
+                    type: string
+                  credentialsSecretRef:
+                    description: Secret reference with git credentials (token or SSH
+                      key)
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  path:
+                    description: Path within the repository where manifests reside
+                    type: string
+                  prTitlePrefix:
+                    description: PR title prefix
+                    type: string
+                  repository:
+                    description: Git repository URL (e.g. https://github.com/org/infra-config.git)
+                    type: string
+                required:
+                - repository
+                type: object
+              hubReporting:
+                description: 'Hub reporting: push agent status to the hub console'
+                properties:
+                  clusterName:
+                    description: Cluster name as displayed in the hub console (e.g.
+                      "east", "west", "factory-floor")
+                    type: string
+                  enabled:
+                    description: Enable reporting agent status to hub console
+                    type: boolean
+                  endpoint:
+                    description: Hub console API endpoint (e.g. https://kairos-console.apps.hub-cluster.example.com)
+                    type: string
+                  insecureSkipVerify:
+                    description: Skip TLS verification for hub connection (air-gapped
+                      / self-signed certs)
+                    type: boolean
+                  tls:
+                    description: TLS settings for hub communication
+                    properties:
+                      caSecretRef:
+                        description: Custom CA certificate secret reference
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      certSecretRef:
+                        description: Client certificate secret reference (mTLS)
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      insecureSkipVerify:
+                        description: Skip TLS certificate verification (for disconnected/air-gapped
+                          environments)
+                        type: boolean
+                    type: object
+                  tokenSecretRef:
+                    description: Bearer token secret for authenticating to the hub
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                required:
+                - enabled
+                - endpoint
+                type: object
+              mode:
+                description: 'Operating mode: autopilot or supervised'
+                enum:
+                - autopilot
+                - supervised
+                - gitops
+                type: string
+              notifications:
+                description: Notification webhook configuration (Slack/Teams/generic)
+                properties:
+                  channel:
+                    description: Channel override (Slack only)
+                    type: string
+                  events:
+                    description: Events to notify on
+                    items:
+                      type: string
+                    type: array
+                  webhookSecretRef:
+                    description: Secret reference for webhook URL (alternative to
+                      inline)
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  webhookURL:
+                    description: Webhook URL (Slack incoming webhook, Teams connector,
+                      or generic)
+                    type: string
+                required:
+                - webhookURL
+                type: object
+              paused:
+                description: Pause the agent
+                type: boolean
+              pinnedResources:
+                description: 'PinnedResources overrides: SRE can pin workload resources
+                  for a duration'
+                items:
+                  description: 'PinnedResource overrides: SRE can pin workload resources
+                    for a duration.'
+                  properties:
+                    cpu:
+                      type: string
+                    memory:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    until:
+                      format: date-time
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  - until
+                  type: object
+                type: array
+              reporting:
+                description: Reporting configuration
+                properties:
+                  interval:
+                    description: How often the agent reports status
+                    type: string
+                  otelExport:
+                    description: Send events to OTel collector
+                    type: boolean
+                required:
+                - interval
+                type: object
+              slaClass:
+                description: 'SLA class reference: priority class for SLA-aware scheduling'
+                type: string
+              watch:
+                description: What resources to watch
+                properties:
+                  labelSelector:
+                    description: Label selector for filtering resources
+                    type: string
+                  namespaceSuffix:
+                    description: |-
+                      NamespaceSuffix filters namespaces by suffix (e.g. "-dev", "-test", "-qa", "-prod").
+                      When set, the agent watches ALL namespaces ending with this suffix.
+                      Can be combined with explicit Namespaces list.
+                    type: string
+                  namespaces:
+                    description: Namespaces to watch
+                    items:
+                      type: string
+                    type: array
+                  resourceTypes:
+                    description: Resource types to monitor (Deployment, StatefulSet,
+                      DaemonSet, CronJob)
+                    items:
+                      type: string
+                    type: array
+                required:
+                - namespaces
+                - resourceTypes
+                type: object
+            required:
+            - aiModel
+            - correctionPolicy
+            - mode
+            - watch
+            type: object
+          status:
+            description: KairosAgentStatus defines the observed state of KairosAgent.
+            properties:
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              correctionsLastHour:
+                description: Corrections in the last hour
+                format: int32
+                type: integer
+              dryRunRecommendations:
+                description: 'Dry-run recommendations (last 20, only when dryRun:
+                  true)'
+                items:
+                  description: DryRunRecommendation records a resource change that
+                    would be applied if dry-run were disabled.
+                  properties:
+                    aiResponse:
+                      type: string
+                    currentCPU:
+                      type: string
+                    currentMemory:
+                      type: string
+                    namespace:
+                      type: string
+                    proposedCPU:
+                      type: string
+                    proposedMemory:
+                      type: string
+                    reason:
+                      type: string
+                    resource:
+                      type: string
+                    timestamp:
+                      format: date-time
+                      type: string
+                  required:
+                  - namespace
+                  - reason
+                  - resource
+                  - timestamp
+                  type: object
+                type: array
+              lastCheckTime:
+                description: Last time the agent checked resources
+                format: date-time
+                type: string
+              pendingApprovals:
+                description: Pending approvals (supervised mode)
+                items:
+                  description: PendingApproval represents a correction waiting for
+                    human approval.
+                  properties:
+                    action:
+                      type: string
+                    aiResponse:
+                      type: string
+                    id:
+                      type: string
+                    namespace:
+                      type: string
+                    reason:
+                      type: string
+                    resource:
+                      type: string
+                    timestamp:
+                      format: date-time
+                      type: string
+                  required:
+                  - action
+                  - id
+                  - namespace
+                  - reason
+                  - resource
+                  - timestamp
+                  type: object
+                type: array
+              phase:
+                description: Current phase of the agent
+                enum:
+                - Active
+                - Idle
+                - Correcting
+                - WaitingApproval
+                - Error
+                - Paused
+                type: string
+              recentCorrections:
+                description: Recent corrections (last 20)
+                items:
+                  description: CorrectionRecord records a correction the agent made
+                    or proposed.
+                  properties:
+                    action:
+                      type: string
+                    aiResponse:
+                      type: string
+                    applied:
+                      type: boolean
+                    namespace:
+                      type: string
+                    reason:
+                      type: string
+                    resource:
+                      type: string
+                    timestamp:
+                      format: date-time
+                      type: string
+                  required:
+                  - action
+                  - applied
+                  - namespace
+                  - reason
+                  - resource
+                  - timestamp
+                  type: object
+                type: array
+              totalCorrections:
+                description: Total corrections applied
+                format: int32
+                type: integer
+              watchedResources:
+                description: Watched resource count
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_kairosconsoles.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_kairosconsoles.yaml
@@ -1,0 +1,260 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  name: kairosconsoles.kairos.maximilianopizarro.github.io
+spec:
+  group: kairos.maximilianopizarro.github.io
+  names:
+    kind: KairosConsole
+    listKind: KairosConsoleList
+    plural: kairosconsoles
+    singular: kairosconsole
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KairosConsole is the Schema for the kairosconsoles API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KairosConsoleSpec defines the desired state of KairosConsole.
+            properties:
+              auth:
+                description: Authentication configuration
+                properties:
+                  oauth:
+                    description: OpenShift OAuth proxy configuration (only used when
+                      type=openshift-oauth)
+                    properties:
+                      cookieSecret:
+                        description: Cookie secret name for OAuth session encryption
+                        type: string
+                      httpsPort:
+                        default: 8443
+                        description: 'Custom HTTPS port for the OAuth proxy (default:
+                          8443)'
+                        format: int32
+                        type: integer
+                      image:
+                        default: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+                        description: The OpenShift OAuth proxy image to use
+                        type: string
+                      requiredRole:
+                        default: cluster-admin
+                        description: 'ClusterRole required to access the console (default:
+                          cluster-admin)'
+                        type: string
+                    type: object
+                  tokenSecret:
+                    description: SecretKeyRef references a key in a Secret.
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  type:
+                    description: AuthType defines authentication method for the console.
+                    enum:
+                    - openshift-oauth
+                    - none
+                    - token
+                    type: string
+                required:
+                - type
+                type: object
+              clusters:
+                description: Clusters to display in the console
+                items:
+                  description: ClusterRef references a managed cluster for the console
+                    dashboard.
+                  properties:
+                    apiURL:
+                      type: string
+                    name:
+                      type: string
+                    region:
+                      type: string
+                    tls:
+                      description: TLS settings for this cluster connection
+                      properties:
+                        caSecretRef:
+                          description: Custom CA certificate secret reference
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        certSecretRef:
+                          description: Client certificate secret reference (mTLS)
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        insecureSkipVerify:
+                          description: Skip TLS certificate verification (for disconnected/air-gapped
+                            environments)
+                          type: boolean
+                      type: object
+                    tokenSecretRef:
+                      description: Bearer token secret for authenticating to this
+                        cluster's API
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              image:
+                description: Console container image override
+                type: string
+              replicas:
+                default: 1
+                description: Number of console replicas
+                format: int32
+                type: integer
+              route:
+                description: Route configuration
+                properties:
+                  enabled:
+                    type: boolean
+                  host:
+                    type: string
+                  tlsEnabled:
+                    type: boolean
+                required:
+                - enabled
+                type: object
+            required:
+            - route
+            type: object
+          status:
+            description: KairosConsoleStatus defines the observed state of KairosConsole.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              readyReplicas:
+                description: Ready replicas
+                format: int32
+                type: integer
+              url:
+                description: Console URL once deployed
+                type: string
+              version:
+                description: Console version deployed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_kairosevents.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_kairosevents.yaml
@@ -1,0 +1,122 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  name: kairosevents.kairos.maximilianopizarro.github.io
+spec:
+  group: kairos.maximilianopizarro.github.io
+  names:
+    kind: KairosEvent
+    listKind: KairosEventList
+    plural: kairosevents
+    singular: kairosevent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.agentName
+      name: Agent
+      type: string
+    - jsonPath: .spec.action
+      name: Action
+      type: string
+    - jsonPath: .spec.resource
+      name: Resource
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KairosEvent is the Schema for the kairosevents API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KairosEventSpec defines the desired state of KairosEvent.
+            properties:
+              action:
+                description: Action taken (e.g. scale_up, scale_down, restart, patch)
+                type: string
+              after:
+                description: Resource state after the action
+                properties:
+                  cpu:
+                    type: string
+                  memory:
+                    type: string
+                  replicas:
+                    type: string
+                type: object
+              agentName:
+                description: Name of the KairosAgent that generated this event
+                type: string
+              aiResponse:
+                description: Raw AI model response
+                type: string
+              before:
+                description: Resource state before the action
+                properties:
+                  cpu:
+                    type: string
+                  memory:
+                    type: string
+                  replicas:
+                    type: string
+                type: object
+              cluster:
+                description: Cluster where the event originated
+                type: string
+              dryRun:
+                description: Whether this was a dry-run (no actual changes applied)
+                type: boolean
+              namespace:
+                description: Target resource namespace
+                type: string
+              policyName:
+                description: Name of the SmartScalingPolicy that generated this event
+                  (if applicable)
+                type: string
+              reason:
+                description: Human-readable reason for the action
+                type: string
+              resource:
+                description: Target resource name
+                type: string
+              status:
+                description: EventStatus indicates the lifecycle state of a KairosEvent.
+                type: string
+            required:
+            - action
+            - agentName
+            - cluster
+            - namespace
+            - resource
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_smartscalingpolicies.yaml
+++ b/operators/kairos-operator/2.1.1/manifests/kairos.maximilianopizarro.github.io_smartscalingpolicies.yaml
@@ -1,0 +1,830 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  creationTimestamp: null
+  name: smartscalingpolicies.kairos.maximilianopizarro.github.io
+spec:
+  group: kairos.maximilianopizarro.github.io
+  names:
+    kind: SmartScalingPolicy
+    listKind: SmartScalingPolicyList
+    plural: smartscalingpolicies
+    singular: smartscalingpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.target.name
+      name: Target
+      type: string
+    - jsonPath: .spec.rules
+      name: Rules
+      type: integer
+    - jsonPath: .spec.paused
+      name: Paused
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SmartScalingPolicy is the Schema for the smartscalingpolicies
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SmartScalingPolicySpec defines the desired state of SmartScalingPolicy.
+            properties:
+              ai:
+                description: AI-assisted decisions configuration
+                properties:
+                  agentRef:
+                    type: string
+                  enabled:
+                    type: boolean
+                required:
+                - enabled
+                type: object
+              costEstimation:
+                description: Cost estimation integration (cloud provider pricing APIs)
+                properties:
+                  credentialsSecretRef:
+                    description: Secret with cloud credentials for pricing API
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  endpoint:
+                    description: Pricing API endpoint (for custom provider)
+                    type: string
+                  monthlyBudgetUSD:
+                    description: Monthly budget limit (USD) — alerts when approaching
+                    format: int64
+                    type: integer
+                  provider:
+                    description: Cloud provider (aws, gcp, azure, custom)
+                    enum:
+                    - aws
+                    - gcp
+                    - azure
+                    - custom
+                    type: string
+                  region:
+                    description: Region for pricing lookups
+                    type: string
+                required:
+                - provider
+                - region
+                type: object
+              metricsAdapters:
+                description: Custom metrics adapters (Datadog, New Relic, Splunk)
+                items:
+                  description: MetricsAdapter configures an external metrics provider.
+                  properties:
+                    credentialsSecretRef:
+                      description: Secret with API key/credentials
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    endpoint:
+                      description: API endpoint for the metrics provider
+                      type: string
+                    metricMappings:
+                      additionalProperties:
+                        type: string
+                      description: Metric name mapping (provider-specific metric name
+                        -> standard name)
+                      type: object
+                    type:
+                      description: 'Adapter type: datadog, newrelic, splunk, custom'
+                      enum:
+                      - datadog
+                      - newrelic
+                      - splunk
+                      - custom
+                      type: string
+                  required:
+                  - endpoint
+                  - type
+                  type: object
+                type: array
+              metricsTLS:
+                description: TLS settings for metrics endpoints (Prometheus/Thanos/OTel)
+                properties:
+                  caSecretRef:
+                    description: Custom CA certificate secret reference
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  certSecretRef:
+                    description: Client certificate secret reference (mTLS)
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  insecureSkipVerify:
+                    description: Skip TLS certificate verification (for disconnected/air-gapped
+                      environments)
+                    type: boolean
+                type: object
+              ocmSync:
+                description: 'Open Cluster Management sync: replicate policy across
+                  managed clusters'
+                properties:
+                  clusterSelector:
+                    additionalProperties:
+                      type: string
+                    description: Cluster selector labels
+                    type: object
+                  enabled:
+                    description: Enable OCM policy sync
+                    type: boolean
+                  placementRef:
+                    description: Placement rule name for target clusters
+                    type: string
+                required:
+                - enabled
+                type: object
+              otelEndpoint:
+                description: OTel collector endpoint (gRPC)
+                type: string
+              paused:
+                description: Pause all scaling actions
+                type: boolean
+              predictiveScaling:
+                description: Predictive scaling configuration (time-series forecasting)
+                properties:
+                  algorithm:
+                    description: 'Algorithm to use: linear, arima, prophet'
+                    enum:
+                    - linear
+                    - arima
+                    - prophet
+                    type: string
+                  confidenceThreshold:
+                    description: Confidence threshold (0.0-1.0) for applying predictions
+                    type: string
+                  enabled:
+                    description: Enable predictive scaling
+                    type: boolean
+                  forecastWindow:
+                    description: Forecast horizon (e.g. "1h", "6h", "24h")
+                    type: string
+                  lookbackPeriod:
+                    description: Historical data lookback period (e.g. "7d", "30d")
+                    type: string
+                required:
+                - enabled
+                - forecastWindow
+                type: object
+              priority:
+                description: Priority for conflict resolution (higher wins)
+                format: int32
+                type: integer
+              prometheusEndpoint:
+                description: Prometheus endpoint (fallback)
+                type: string
+              rules:
+                description: Metric-based scaling rules
+                items:
+                  description: ScalingRule defines a single metric-based rule.
+                  properties:
+                    action:
+                      description: ScalingAction defines what to do when a rule triggers.
+                      properties:
+                        cooldown:
+                          description: Cooldown period between consecutive actions
+                          type: string
+                        increaseCPUPercent:
+                          format: int32
+                          type: integer
+                        increaseMemoryPercent:
+                          format: int32
+                          type: integer
+                        maxCPU:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxMemory:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxReplicas:
+                          format: int32
+                          type: integer
+                        minCPU:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        minMemory:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        minReplicas:
+                          format: int32
+                          type: integer
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        type:
+                          description: ActionType defines what scaling action to take.
+                          enum:
+                          - IncreaseResources
+                          - DecreaseResources
+                          - AddReplicas
+                          - RemoveReplicas
+                          - SetMinReplicas
+                          - SetResources
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    enabled:
+                      type: boolean
+                    name:
+                      type: string
+                    when:
+                      description: MetricCondition defines when a rule triggers.
+                      properties:
+                        for:
+                          description: Duration the condition must hold before triggering
+                          type: string
+                        metric:
+                          description: OTel or Prometheus metric name
+                          type: string
+                        operator:
+                          description: Comparison operator
+                          enum:
+                          - GreaterThan
+                          - LessThan
+                          - Equal
+                          type: string
+                        threshold:
+                          description: Threshold value (e.g. "200ms", "500", "80%")
+                          type: string
+                      required:
+                      - metric
+                      - operator
+                      - threshold
+                      type: object
+                  required:
+                  - action
+                  - name
+                  - when
+                  type: object
+                type: array
+              scalingSchedule:
+                description: Scheduled scaling windows (cron-based resource profiles)
+                items:
+                  description: ScalingSchedule defines a cron-based resource profile
+                    window.
+                  properties:
+                    cron:
+                      type: string
+                    duration:
+                      type: string
+                    name:
+                      type: string
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This is an alpha field and requires enabling the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                  required:
+                  - cron
+                  - duration
+                  - name
+                  - resources
+                  type: object
+                type: array
+              schedule:
+                description: Time-based scheduling rules
+                items:
+                  description: ScheduleAction defines a time-based scaling action.
+                  properties:
+                    action:
+                      description: ScalingAction defines what to do when a rule triggers.
+                      properties:
+                        cooldown:
+                          description: Cooldown period between consecutive actions
+                          type: string
+                        increaseCPUPercent:
+                          format: int32
+                          type: integer
+                        increaseMemoryPercent:
+                          format: int32
+                          type: integer
+                        maxCPU:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxMemory:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxReplicas:
+                          format: int32
+                          type: integer
+                        minCPU:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        minMemory:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        minReplicas:
+                          format: int32
+                          type: integer
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute
+                            resource requirements.
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        type:
+                          description: ActionType defines what scaling action to take.
+                          enum:
+                          - IncreaseResources
+                          - DecreaseResources
+                          - AddReplicas
+                          - RemoveReplicas
+                          - SetMinReplicas
+                          - SetResources
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    cron:
+                      type: string
+                    enabled:
+                      type: boolean
+                    name:
+                      type: string
+                  required:
+                  - action
+                  - cron
+                  - name
+                  type: object
+                type: array
+              scope:
+                description: Policy scope for inheritance (global > cluster > namespace)
+                enum:
+                - global
+                - cluster
+                - namespace
+                type: string
+              target:
+                description: Target workload to scale
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            required:
+            - target
+            type: object
+          status:
+            description: SmartScalingPolicyStatus defines the observed state of SmartScalingPolicy.
+            properties:
+              activeRules:
+                description: Active rules currently triggering
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: Current conditions
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentReplicas:
+                description: Current replica count
+                format: int32
+                type: integer
+              currentResources:
+                description: Current resource allocation
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              lastEvaluationTime:
+                description: Last time the policy was evaluated
+                format: date-time
+                type: string
+              lastScalingEvent:
+                description: Last scaling event
+                properties:
+                  action:
+                    description: ActionType defines what scaling action to take.
+                    enum:
+                    - IncreaseResources
+                    - DecreaseResources
+                    - AddReplicas
+                    - RemoveReplicas
+                    - SetMinReplicas
+                    - SetResources
+                    type: string
+                  detail:
+                    type: string
+                  rule:
+                    type: string
+                  success:
+                    type: boolean
+                  timestamp:
+                    format: date-time
+                    type: string
+                required:
+                - action
+                - detail
+                - rule
+                - success
+                - timestamp
+                type: object
+              recentEvents:
+                description: Recent scaling events (last 10)
+                items:
+                  description: ScalingEvent records a scaling action that was taken.
+                  properties:
+                    action:
+                      description: ActionType defines what scaling action to take.
+                      enum:
+                      - IncreaseResources
+                      - DecreaseResources
+                      - AddReplicas
+                      - RemoveReplicas
+                      - SetMinReplicas
+                      - SetResources
+                      type: string
+                    detail:
+                      type: string
+                    rule:
+                      type: string
+                    success:
+                      type: boolean
+                    timestamp:
+                      format: date-time
+                      type: string
+                  required:
+                  - action
+                  - detail
+                  - rule
+                  - success
+                  - timestamp
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/kairos-operator/2.1.1/metadata/annotations.yaml
+++ b/operators/kairos-operator/2.1.1/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kairos-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.40.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # OpenShift version compatibility.
+  com.redhat.openshift.versions: "v4.12"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/kairos-operator/2.1.1/release-config.yaml
+++ b/operators/kairos-operator/2.1.1/release-config.yaml
@@ -1,0 +1,5 @@
+---
+catalog_templates:
+  - template_name: semver.yaml
+    channels:
+      - Candidate

--- a/operators/kairos-operator/2.1.1/tests/scorecard/config.yaml
+++ b/operators/kairos-operator/2.1.1/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.40.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.40.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.40.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.40.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.40.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.40.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/operators/kairos-operator/catalog-templates/semver.yaml
+++ b/operators/kairos-operator/catalog-templates/semver.yaml
@@ -6,3 +6,4 @@ Candidate:
   Bundles:
   - Image: quay.io/community-operator-pipeline-prod/kairos-operator:2.0.1
   - Image: quay.io/community-operator-pipeline-prod/kairos-operator:2.1.0
+  - Image: quay.io/community-operator-pipeline-prod/kairos-operator:2.1.1


### PR DESCRIPTION
## operator kairos-operator (2.1.1)

### Changes

Patch release fixing two high-priority bugs:

- **#4**: SmartScalingPolicy actions fail with `spec.selector=null` — replaced SSA `client.Apply` with strategic merge patch
- **#3**: Console SA lacks RBAC — operator now auto-creates ClusterRole/ClusterRoleBinding; backend returns structured JSON on Forbidden; frontend guards `.json()` calls

### Verification

- Tested on OpenShift 4.x (CI cluster) via `operator-sdk run bundle`
- CSV phase: `Succeeded`
- Console RBAC: `oc auth can-i list smartscalingpolicies --as=system:serviceaccount:kairos-system:kairos-console` = yes
- SSA patch: `SetResources` applied without selector corruption

### FBC

- Uses `olm.semver` template with `Candidate` channel
- `release-config.yaml` present for automerge
- `ci.yaml` includes `reviewers: [maximilianoPizarro]`

Made with [Cursor](https://cursor.com)