### PR TITLE
operator datadog-operator (1.29.0)

### DIFF
--- a/operators/datadog-operator/1.29.0/manifests/datadog-operator-webhook-service_v1_service.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadog-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: datadog-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/datadog-operator/1.29.0/manifests/datadog-operator.clusterserviceversion.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadog-operator.clusterserviceversion.yaml
@@ -1,0 +1,1103 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogAgentProfile",
+          "metadata": {
+            "name": "datadogagentprofile-sample"
+          },
+          "spec": {
+            "config": {
+              "override": {
+                "nodeAgent": {
+                  "containers": {
+                    "agent": {
+                      "resources": {
+                        "requests": {
+                          "cpu": "256m"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "profileAffinity": {
+              "profileNodeAffinity": [
+                {
+                  "key": "kubernetes.io/os",
+                  "operator": "In",
+                  "values": [
+                    "linux"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogDashboard",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/created-by": "datadog-operator",
+              "app.kubernetes.io/instance": "datadogdashboard-sample",
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "datadogdashboard",
+              "app.kubernetes.io/part-of": "datadog-operator"
+            },
+            "name": "datadogdashboard-sample"
+          },
+          "spec": null
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogGenericResource",
+          "metadata": {
+            "name": "datadoggenericresource-notebook-sample"
+          },
+          "spec": {
+            "jsonSpec": "{\n  \"data\": {\n    \"attributes\": {\n      \"cells\": [\n        {\n          \"attributes\": {\n            \"definition\": {\n              \"text\": \"## Some test markdown\\n\\n```js\\nvar x, y;\\nx = 5;\\ny = 6;\\n```\",\n              \"type\": \"markdown\"\n            }\n          },\n          \"type\": \"notebook_cells\"\n        },\n        {\n          \"attributes\": {\n            \"definition\": {\n              \"requests\": [\n                {\n                  \"display_type\": \"line\",\n                  \"q\": \"avg:system.load.1{*}\",\n                  \"style\": {\n                    \"line_type\": \"solid\",\n                    \"line_width\": \"normal\",\n                    \"palette\": \"dog_classic\"\n                  }\n                }\n              ],\n              \"show_legend\": true,\n              \"type\": \"timeseries\",\n              \"yaxis\": {\n                \"scale\": \"linear\"\n              }\n            },\n            \"graph_size\": \"m\",\n            \"split_by\": {\n              \"keys\": [],\n              \"tags\": []\n            },\n            \"time\": null\n          },\n          \"type\": \"notebook_cells\"\n        }\n      ],\n      \"name\": \"Example-Notebook\",\n      \"status\": \"published\",\n      \"time\": {\n        \"live_span\": \"1h\"\n      }\n    },\n    \"type\": \"notebooks\"\n  }\n}",
+            "type": "notebook"
+          }
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogInstrumentation",
+          "metadata": {
+            "name": "sample-instrumentation"
+          },
+          "spec": {
+            "config": {
+              "checks": [
+                {
+                  "containerName": "sample-app",
+                  "initConfig": {},
+                  "instances": [
+                    {
+                      "metrics": [
+                        "sample_requests_total"
+                      ],
+                      "namespace": "sample",
+                      "openmetrics_endpoint": "http://%%host%%:8080/metrics",
+                      "tags": [
+                        "service:sample-app",
+                        "env:dev"
+                      ]
+                    }
+                  ],
+                  "integration": "openmetrics"
+                }
+              ],
+              "logs": [
+                {
+                  "containerName": "sample-app",
+                  "path": "/var/log/sample-app/*.log",
+                  "service": "sample-app",
+                  "source": "sample-app",
+                  "tags": [
+                    "service:sample-app",
+                    "env:dev"
+                  ],
+                  "type": "file"
+                }
+              ]
+            },
+            "targetRef": {
+              "apiVersion": "apps/v1",
+              "kind": "Deployment",
+              "name": "sample-workload"
+            }
+          }
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogMetric",
+          "metadata": {
+            "name": "datadogmetric-sample"
+          },
+          "spec": {
+            "query": "avg:kubernetes.cpu.usage.total{app:foo}.rollup(avg,30)/(avg:kubernetes.cpu.limits{app:foo}.rollup(avg,30)*10000000)"
+          }
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogMonitor",
+          "metadata": {
+            "name": "datadogmonitor-sample"
+          },
+          "spec": {
+            "message": "Something is wrong and we need to fix it.",
+            "query": "avg(last_15m):avg:foo{env:staging,service:bar} \u003e 1",
+            "tags": [
+              "env:staging",
+              "service:bar"
+            ],
+            "title": "Latency is increasing on staging",
+            "type": "metric alert"
+          }
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogPodAutoscaler",
+          "metadata": {
+            "name": "datadogpodautoscaler-sample"
+          },
+          "spec": null
+        },
+        {
+          "apiVersion": "datadoghq.com/v1alpha1",
+          "kind": "DatadogSLO",
+          "metadata": {
+            "name": "datadogslo-sample"
+          },
+          "spec": {
+            "description": "This is an example metric SLO from datadog-operator",
+            "name": "datadogslo-sample",
+            "query": {
+              "denominator": "sum:requests.total{service:example,env:prod}.as_count()",
+              "numerator": "sum:requests.success{service:example,env:prod}.as_count()"
+            },
+            "tags": [
+              "service:example",
+              "env:prod"
+            ],
+            "targetThreshold": "99.9",
+            "timeframe": "7d",
+            "type": "metric"
+          }
+        },
+        {
+          "apiVersion": "datadoghq.com/v2alpha1",
+          "kind": "DatadogAgent",
+          "metadata": {
+            "name": "datadogagent-sample"
+          },
+          "spec": {
+            "features": {
+              "admissionController": {
+                "enabled": false
+              },
+              "apm": {
+                "enabled": false
+              },
+              "clusterChecks": {
+                "enabled": true,
+                "useClusterChecksRunners": true
+              },
+              "liveProcessCollection": {
+                "enabled": false
+              },
+              "logCollection": {
+                "containerCollectAll": true,
+                "enabled": true
+              }
+            },
+            "global": {
+              "clusterAgentToken": "\u003cDATADOG_CLUSTER_AGENT_TOKEN\u003e",
+              "clusterName": "\u003cCLUSTER_NAME\u003e",
+              "credentials": {
+                "apiKey": "\u003cDATADOG_API_KEY\u003e",
+                "appKey": "\u003cDATADOG_APP_KEY\u003e"
+              },
+              "criSocketPath": "/var/run/crio/crio.sock",
+              "kubelet": {
+                "tlsVerify": false
+              }
+            },
+            "override": {
+              "clusterAgent": {
+                "containers": {
+                  "cluster-agent": {
+                    "securityContext": {
+                      "readOnlyRootFilesystem": false
+                    }
+                  }
+                },
+                "replicas": 2,
+                "serviceAccountName": "datadog-agent-scc"
+              },
+              "clusterChecksRunner": {
+                "replicas": 2
+              },
+              "nodeAgent": {
+                "hostNetwork": true,
+                "securityContext": {
+                  "runAsUser": 0,
+                  "seLinuxOptions": {
+                    "level": "s0",
+                    "role": "system_r",
+                    "type": "spc_t",
+                    "user": "system_u"
+                  }
+                },
+                "serviceAccountName": "datadog-agent-scc"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Monitoring, Logging & Tracing
+    createdAt: "2026-08-04 20:33:01"
+    description: |-
+      Datadog provides a modern monitoring and analytics platform. Gather metrics, logs and traces for full observability of your Kubernetes cluster with Datadog Operator.
+
+      **WARNING**: Starting from version `1.21.0`, the Datadog Operator DatadogAgent controller only watches by default the namespace where it is installed. This means your `DatadogAgent` custom resource must be created in the same namespace as the Operator. This can be changed by removing the `DD_AGENT_WATCH_NAMESPACE` environment variable from the Datadog Operator deployment inside the ClusterServiceVersion YAML.
+    operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/DataDog/datadog-operator
+    containerImage: gcr.io/datadoghq/operator:1.29.0
+    support: Datadog, Inc.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    olm.skipRange: '>=1.7.0 <1.29.0'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+  name: datadog-operator.v1.29.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: DatadogAgentInternal is the Schema for the datadogagentinternals API
+        displayName: Datadog Agent Internal
+        kind: DatadogAgentInternal
+        name: datadogagentinternals.datadoghq.com
+        version: v1alpha1
+      - description: DatadogAgentProfile is the Schema for the datadogagentprofiles API
+        displayName: Datadog Agent Profile
+        kind: DatadogAgentProfile
+        name: datadogagentprofiles.datadoghq.com
+        version: v1alpha1
+      - description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+        displayName: Datadog Agent
+        kind: DatadogAgent
+        name: datadogagents.datadoghq.com
+        version: v2alpha1
+      - kind: DatadogCSIDriver
+        name: datadogcsidrivers.datadoghq.com
+        version: v1alpha1
+      - description: DatadogDashboard is the Schema for the datadogdashboards API
+        displayName: Datadog Dashboard
+        kind: DatadogDashboard
+        name: datadogdashboards.datadoghq.com
+        version: v1alpha1
+      - kind: DatadogGenericResource
+        name: datadoggenericresources.datadoghq.com
+        version: v1alpha1
+      - description: DatadogInstrumentation is the Schema for the datadoginstrumentations API.
+        displayName: Datadog Instrumentation
+        kind: DatadogInstrumentation
+        name: datadoginstrumentations.datadoghq.com
+        version: v1alpha1
+      - description: DatadogMetric allows autoscaling on arbitrary Datadog query
+        displayName: Datadog Metric
+        kind: DatadogMetric
+        name: datadogmetrics.datadoghq.com
+        version: v1alpha1
+      - description: DatadogMonitor allows to define and manage Monitors from your Kubernetes Cluster
+        displayName: Datadog Monitor
+        kind: DatadogMonitor
+        name: datadogmonitors.datadoghq.com
+        version: v1alpha1
+      - kind: DatadogPodAutoscalerClusterProfile
+        name: datadogpodautoscalerclusterprofiles.datadoghq.com
+        version: v1alpha2
+      - description: DatadogPodAutoscaler is the Schema for the datadogpodautoscalers API
+        displayName: Datadog Pod Autoscaler
+        kind: DatadogPodAutoscaler
+        name: datadogpodautoscalers.datadoghq.com
+        version: v1alpha1
+      - description: DatadogPodAutoscaler is the Schema for the datadogpodautoscalers API
+        displayName: Datadog Pod Autoscaler
+        kind: DatadogPodAutoscaler
+        name: datadogpodautoscalers.datadoghq.com
+        version: v1alpha2
+      - description: DatadogSLO allows a user to define and manage datadog SLOs from Kubernetes cluster.
+        displayName: Datadog SLO
+        kind: DatadogSLO
+        name: datadogslos.datadoghq.com
+        version: v1alpha1
+  description: |-
+    Datadog provides a modern monitoring and analytics platform. Gather metrics, logs and traces for full observability of your Kubernetes cluster with Datadog Operator.
+
+    **WARNING**: Starting from version `1.21.0`, the Datadog Operator DatadogAgent controller only watches by default the namespace where it is installed. This means your `DatadogAgent` custom resource must be created in the same namespace as the Operator. This can be changed by removing the `DD_AGENT_WATCH_NAMESPACE` environment variable from the Datadog Operator deployment inside the ClusterServiceVersion YAML.
+  displayName: Datadog Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuNCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA4MDAuNTUgODU2Ljg1IiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA4MDAuNTUgODU2Ljg1OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGwtcnVsZTpldmVub2RkO2NsaXAtcnVsZTpldmVub2RkO2ZpbGw6IzYzMkNBNjt9Cjwvc3R5bGU+CjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik02NzAuMzgsNjA4LjI3bC03MS4yNC00Ni45OWwtNTkuNDMsOTkuMjdsLTY5LjEyLTIwLjIxbC02MC44Niw5Mi44OWwzLjEyLDI5LjI0bDMzMC45LTYwLjk3bC0xOS4yMi0yMDYuNzUKCUw2NzAuMzgsNjA4LjI3eiBNMzYxLjc5LDUxOS4xM2w1My4wOS03LjNjOC41OSwzLjg2LDE0LjU3LDUuMzMsMjQuODcsNy45NWMxNi4wNCw0LjE4LDM0LjYxLDguMTksNjIuMTEtNS42NwoJYzYuNC0zLjE3LDE5LjczLTE1LjM2LDI1LjEyLTIyLjMxbDIxNy41Mi0zOS40NmwyMi4xOSwyNjguNTZsLTM3Mi42NSw2Ny4xNkwzNjEuNzksNTE5LjEzeiBNNzY1Ljg1LDQyMi4zNmwtMjEuNDcsNC4wOUw3MDMuMTMsMC4yNwoJTDAuMjcsODEuNzdsODYuNTksNzAyLjY4bDgyLjI3LTExLjk0Yy02LjU3LTkuMzgtMTYuOC0yMC43My0zNC4yNy0zNS4yNmMtMjQuMjMtMjAuMTMtMTUuNjYtNTQuMzItMS4zNy03NS45MQoJYzE4LjkxLTM2LjQ4LDExNi4zNC04Mi44NCwxMTAuODItMTQxLjE1Yy0xLjk4LTIxLjItNS4zNS00OC44LTI1LjAzLTY3LjcxYy0wLjc0LDcuODUsMC41OSwxNS40MSwwLjU5LDE1LjQxCglzLTguMDgtMTAuMzEtMTIuMTEtMjQuMzdjLTQtNS4zOS03LjE0LTcuMTEtMTEuMzktMTQuMzFjLTMuMDMsOC4zMy0yLjYzLDE3Ljk5LTIuNjMsMTcuOTlzLTYuNjEtMTUuNjItNy42OC0yOC44CgljLTMuOTIsNS45LTQuOTEsMTcuMTEtNC45MSwxNy4xMXMtOC41OS0yNC42Mi02LjYzLTM3Ljg4Yy0zLjkyLTExLjU0LTE1LjU0LTM0LjQ0LTEyLjI1LTg2LjQ5YzIxLjQ1LDE1LjAzLDY4LjY3LDExLjQ2LDg3LjA3LTE1LjY2CgljNi4xMS04Ljk4LDEwLjI5LTMzLjUtMy4wNS04MS44MWMtOC41Ny0zMC45OC0yOS43OS03Ny4xMS0zOC4wNi05NC42MWwtMC45OSwwLjcxYzQuMzYsMTQuMSwxMy4zNSw0My42NiwxNi44LDU3Ljk5CgljMTAuNDQsNDMuNDcsMTMuMjQsNTguNiw4LjM0LDc4LjY0Yy00LjE3LDE3LjQyLTE0LjE3LDI4LjgyLTM5LjUyLDQxLjU2Yy0yNS4zNSwxMi43OC01OC45OS0xOC4zMi02MS4xMi0yMC4wNAoJYy0yNC42My0xOS42Mi00My42OC01MS42My00NS44MS02Ny4xOGMtMi4yMS0xNy4wMiw5LjgxLTI3LjI0LDE1Ljg3LTQxLjE2Yy04LjY3LDIuNDgtMTguMzQsNi44OC0xOC4zNCw2Ljg4CglzMTEuNTQtMTEuOTQsMjUuNzctMjIuMjdjNS44OS0zLjksOS4zNS02LjM4LDE1LjU2LTExLjU0Yy04Ljk5LTAuMTUtMTYuMjksMC4xMS0xNi4yOSwwLjExczE0Ljk5LTguMSwzMC41My0xNAoJYy0xMS4zNy0wLjUtMjIuMjUtMC4wOC0yMi4yNS0wLjA4czMzLjQ1LTE0Ljk2LDU5Ljg3LTI1Ljk0YzE4LjE3LTcuNDUsMzUuOTItNS4yNSw0NS44OSw5LjE3YzEzLjA5LDE4Ljg5LDI2Ljg0LDI5LjE1LDU1Ljk4LDM1LjUxCgljMTcuODktNy45MywyMy4zMy0xMi4wMSw0NS44MS0xOC4xM2MxOS43OS0yMS43NiwzNS4zMy0yNC41OCwzNS4zMy0yNC41OHMtNy43MSw3LjA3LTkuNzcsMTguMTgKCWMxMS4yMi04Ljg0LDIzLjUyLTE2LjIyLDIzLjUyLTE2LjIycy00Ljc2LDUuODgtOS4yLDE1LjIybDEuMDMsMS41M2MxMy4wOS03Ljg1LDI4LjQ4LTE0LjA0LDI4LjQ4LTE0LjA0cy00LjQsNS41Ni05LjU2LDEyLjc2CgljOS44Ny0wLjA4LDI5Ljg5LDAuNDIsMzcuNjYsMS4zYzQ1Ljg3LDEuMDEsNTUuMzktNDguOTksNzIuOTktNTUuMjZjMjIuMDQtNy44NywzMS44OS0xMi42Myw2OS40NSwyNC4yNgoJYzMyLjIzLDMxLjY3LDU3LjQxLDg4LjM2LDQ0LjkxLDEwMS4wNmMtMTAuNDgsMTAuNTQtMzEuMTYtNC4xMS01NC4wOC0zMi42OGMtMTIuMTEtMTUuMTMtMjEuMjctMzMuMDEtMjUuNTYtNTUuNzQKCWMtMy42Mi0xOS4xOC0xNy43MS0zMC4zMS0xNy43MS0zMC4zMVM1MjAsOTIuOTUsNTIwLDEwOS4wMWMwLDguNzcsMS4xLDQxLjU2LDE1LjE2LDU5Ljk2Yy0xLjM5LDIuNjktMi4wNCwxMy4zMS0zLjU4LDE1LjM0CgljLTE2LjM2LTE5Ljc3LTUxLjQ5LTMzLjkyLTU3LjIyLTM4LjA5YzE5LjM5LDE1Ljg5LDYzLjk2LDUyLjM5LDgxLjA4LDg3LjM3YzE2LjE5LDMzLjA4LDYuNjUsNjMuNCwxNC44NCw3MS4yNQoJYzIuMzMsMi4yNSwzNC44Miw0Mi43Myw0MS4wNyw2My4wN2MxMC45LDM1LjQ1LDAuNjUsNzIuNy0xMy42Miw5NS44MWwtMzkuODUsNi4yMWMtNS44My0xLjYyLTkuNzYtMi40My0xNC45OS01LjQ2CgljMi44OC01LjEsOC42MS0xNy44Miw4LjY3LTIwLjQ0bC0yLjI1LTMuOTVjLTEyLjQsMTcuNTctMzMuMTgsMzQuNjMtNTAuNDQsNDQuNDNjLTIyLjU5LDEyLjgtNDguNjMsMTAuODMtNjUuNTgsNS41OAoJYy00OC4xMS0xNC44NC05My42LTQ3LjM1LTEwNC41Ny01NS44OWMwLDAtMC4zNCw2LjgyLDEuNzMsOC4zNWMxMi4xMywxMy42OCwzOS45MiwzOC40Myw2Ni43OCw1NS42OGwtNTcuMjYsNi4zbDI3LjA3LDIxMC43OAoJYy0xMiwxLjcyLTEzLjg3LDIuNTYtMjcuMDEsNC40M2MtMTEuNTgtNDAuOTEtMzMuNzMtNjcuNjItNTcuOTQtODMuMThjLTIxLjM1LTEzLjcyLTUwLjgtMTYuODEtNzguOTktMTEuMjNsLTEuODEsMi4xCgljMTkuNi0yLjA0LDQyLjc0LDAuOCw2Ni41MSwxNS44NWMyMy4zMywxNC43NSw0Mi4xMyw1Mi44NSw0OS4wNSw3NS43OWM4Ljg2LDI5LjMyLDE0Ljk5LDYwLjY4LTguODYsOTMuOTIKCWMtMTYuOTcsMjMuNjMtNjYuNTEsMzYuNjktMTA2LjUzLDguNDRjMTAuNjksMTcuMTksMjUuMTQsMzEuMjUsNDQuNTksMzMuOWMyOC44OCwzLjkyLDU2LjI5LTEuMDksNzUuMTYtMjAuNDYKCWMxNi4xMS0xNi41NiwyNC42NS01MS4xOSwyMi40LTg3LjY2bDI1LjQ5LTMuN2w5LjIsNjUuNDZsNDIxLjk4LTUwLjgxTDc2NS44NSw0MjIuMzZ6IE01MDkuMTIsMjQ0LjU5CgljLTEuMTgsMi42OS0zLjAzLDQuNDUtMC4yNSwxMy4ybDAuMTcsMC41bDAuNDQsMS4xM2wxLjE2LDIuNjJjNS4wMSwxMC4yNCwxMC41MSwxOS45LDE5LjcsMjQuODNjMi4zOC0wLjQsNC44NC0wLjY3LDcuMzktMC44CgljOC42My0wLjM4LDE0LjA4LDAuOTksMTcuNTQsMi44NWMwLjMxLTEuNzIsMC4zOC00LjI0LDAuMTktNy45NWMtMC42Ny0xMi45NywyLjU3LTM1LjAzLTIyLjM2LTQ2LjY0CgljLTkuNDEtNC4zNy0yMi42MS0zLjAyLTI3LjAxLDIuNDNjMC44LDAuMSwxLjUyLDAuMjcsMi4wOCwwLjQ2QzUxNC44MiwyMzkuNTUsNTEwLjMxLDI0MS44NCw1MDkuMTIsMjQ0LjU5IE01NzguOTksMzY1LjYxCgljLTMuMjctMS44LTE4LjU1LTEuMDktMjkuMjksMC4xOWMtMjAuNDYsMi40MS00Mi41NSw5LjUxLTQ3LjM5LDEzLjI5Yy04LjgsNi44LTQuOCwxOC42NiwxLjcsMjMuNTMKCWMxOC4yMywxMy42MiwzNC4yMSwyMi43NSw1MS4wOCwyMC41M2MxMC4zNi0xLjM2LDE5LjQ5LTE3Ljc2LDI1Ljk2LTMyLjY0QzU4NS40OCwzODAuMjYsNTg1LjQ4LDM2OS4yLDU3OC45OSwzNjUuNjEgTTM5Ny44NSwyNjAuNjUKCWM1Ljc3LTUuNDgtMjguNzQtMTIuNjgtNTUuNTIsNS41OGMtMTkuNzUsMTMuNDctMjAuMzgsNDIuMzUtMS40Nyw1OC43MmMxLjg5LDEuNjIsMy40NSwyLjc3LDQuOTEsMy43MQoJYzUuNTItMi42LDExLjgxLTUuMjMsMTkuMDUtNy41OGMxMi4yMy0zLjk3LDIyLjQtNi4wMiwzMC43Ni03LjExYzQtNC40Nyw4LjY1LTEyLjM0LDcuNDktMjYuNTkKCUM0MDEuNDksMjY4LjA1LDM4Ni44NCwyNzEuMTIsMzk3Ljg1LDI2MC42NSIvPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - nonResourceURLs:
+                - /metrics
+                - /metrics/slis
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - componentstatuses
+                - deployments
+                - limitranges
+                - namespaces
+                - persistentvolumeclaims
+                - persistentvolumes
+                - replicationcontrollers
+                - resourcequotas
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - endpoints
+                - events
+                - pods
+                - secrets
+                - serviceaccounts
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes/configz
+                - nodes/healthz
+                - nodes/logs
+                - nodes/metrics
+                - nodes/pods
+                - nodes/proxy
+                - nodes/spec
+                - nodes/stats
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - pods/eviction
+                - pods/exec
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - pods/resize
+              verbs:
+                - patch
+            - apiGroups:
+                - '*'
+              resources:
+                - '*/scale'
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - '*'
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apiregistration.k8s.io
+              resources:
+                - apiservices
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - controllerrevisions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments/status
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - replicasets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - argoproj.io
+              resources:
+                - applications
+                - applicationsets
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - argoproj.io
+              resources:
+                - rollouts
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - auto.gke.io
+              resources:
+                - allowlistsynchronizers
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - autoscaling.k8s.io
+              resources:
+                - verticalpodautoscalers
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - cronjobs
+                - jobs
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - certificates.k8s.io
+              resources:
+                - certificatesigningrequests
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - cilium.io
+              resources:
+                - ciliumnetworkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - configuration.konghq.com
+                - consul.hashicorp.com
+                - core.haproxy.org
+                - datadoghq.com
+                - gateway.envoyproxy.io
+                - ingress.v1.haproxy.org
+                - karpenter.azure.com
+                - kuma.io
+                - mesh.consul.hashicorp.com
+                - policy.linkerd.io
+                - traefik.containo.us
+              resources:
+                - '*'
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadogagentinternals
+                - datadogagentinternals/finalizers
+                - datadogagentprofiles
+                - datadogagentprofiles/finalizers
+                - datadogagents
+                - datadogagents/finalizers
+                - datadogcsidrivers
+                - datadogcsidrivers/finalizers
+                - datadogdashboards
+                - datadoggenericresources
+                - datadoggenericresources/finalizers
+                - datadogmonitors
+                - datadogmonitors/finalizers
+                - datadogslos
+                - datadogslos/finalizers
+                - extendeddaemonsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadogagentinternals/status
+                - datadogagentprofiles/status
+                - datadogagents/status
+                - datadogcsidrivers/status
+                - datadogdashboards/status
+                - datadoggenericresources/status
+                - datadogmonitors/status
+                - datadogslos/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadogdashboards/finalizers
+                - datadogmetrics/status
+              verbs:
+                - update
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadoginstrumentations
+                - extendeddaemonsetreplicasets
+                - watermarkpodautoscalers
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadoginstrumentations/status
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadogmetrics
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - datadoghq.com
+              resources:
+                - datadogpodautoscalerclusterprofiles
+                - datadogpodautoscalerclusterprofiles/status
+                - datadogpodautoscalers
+                - datadogpodautoscalers/status
+              verbs:
+                - '*'
+            - apiGroups:
+                - discovery.k8s.io
+              resources:
+                - endpointslices
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - eks.amazonaws.com
+                - external.metrics.k8s.io
+                - karpenter.k8s.aws
+              resources:
+                - '*'
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - gateway.envoyproxy.io
+              resources:
+                - backends
+                - envoyextensionpolicies
+                - envoypatchpolicies
+              verbs:
+                - create
+                - delete
+                - get
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gatewayclasses
+                - gateways
+                - httproutes
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - grpcroutes
+                - listenersets
+                - tlsroutes
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - referencegrants
+              verbs:
+                - create
+                - delete
+                - get
+                - patch
+            - apiGroups:
+                - k8s.nginx.org
+              resources:
+                - virtualserverroutes
+                - virtualservers
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - karpenter.sh
+              resources:
+                - '*'
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - kustomize.toolkit.fluxcd.io
+              resources:
+                - kustomizations
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - metrics.eks.amazonaws.com
+              resources:
+                - kcm/metrics
+                - ksh/metrics
+              verbs:
+                - get
+            - apiGroups:
+                - networking.istio.io
+              resources:
+                - destinationrules
+                - serviceentries
+                - sidecars
+                - virtualservices
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - networking.istio.io
+              resources:
+                - envoyfilters
+              verbs:
+                - create
+                - delete
+                - get
+            - apiGroups:
+                - networking.istio.io
+              resources:
+                - gateways
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingressclasses
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - quota.openshift.io
+              resources:
+                - clusterresourcequotas
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+              verbs:
+                - create
+                - delete
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - restricted
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - source.toolkit.fluxcd.io
+              resources:
+                - buckets
+                - externalartifacts
+                - gitrepositories
+                - helmcharts
+                - helmrepositories
+                - ocirepositories
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - list
+                - watch
+            - apiGroups:
+                - storage.k8s.io
+              resourceNames:
+                - k8s.csi.datadoghq.com
+              resources:
+                - csidrivers
+              verbs:
+                - delete
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+                - volumeattachments
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - traefik.io
+              resources:
+                - ingressroutes
+              verbs:
+                - list
+                - watch
+          serviceAccountName: datadog-operator-controller-manager
+        - rules:
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - hostaccess
+                - privileged
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+          serviceAccountName: datadog-agent-scc
+      deployments:
+        - label:
+            app.kubernetes.io/name: datadog-operator
+            control-plane: controller-manager
+          name: datadog-operator-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: datadog-operator
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  ad.datadoghq.com/manager.check_names: '["openmetrics"]'
+                  ad.datadoghq.com/manager.init_configs: '[{}]'
+                  ad.datadoghq.com/manager.instances: |
+                    [{
+                      "prometheus_url": "http://%%host%%:8080/metrics",
+                      "namespace": "datadog.operator",
+                      "metrics": ["*"]
+                    }]
+                labels:
+                  app.kubernetes.io/name: datadog-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --enable-leader-election
+                      - --pprof
+                    command:
+                      - /manager
+                    env:
+                      - name: DD_HOSTNAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: spec.nodeName
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: DD_AGENT_WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: DD_TOOL_VERSION
+                        value: redhat-community-operators
+                    image: gcr.io/datadoghq/operator:1.29.0
+                    imagePullPolicy: IfNotPresent
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz/
+                        port: 8081
+                      periodSeconds: 10
+                    name: manager
+                    ports:
+                      - containerPort: 8080
+                        name: metrics
+                        protocol: TCP
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 250Mi
+                      requests:
+                        cpu: 100m
+                        memory: 250Mi
+                serviceAccountName: datadog-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases/status
+              verbs:
+                - get
+                - update
+                - patch
+          serviceAccountName: datadog-operator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - Datadog
+    - Monitoring
+    - Logs
+    - Tracing
+  links:
+    - name: Documentation
+      url: https://docs.datadoghq.com/agent/kubernetes/
+    - name: Kubernetes Monitoring Info
+      url: https://www.datadoghq.com/blog/tag/kubernetes/
+  maintainers:
+    - email: support@datadoghq.com
+      name: Datadog Inc.
+  maturity: alpha
+  minKubeVersion: 1.16.0
+  provider:
+    name: Datadog
+  version: 1.29.0
+  replaces: datadog-operator.v1.28.0

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogagentinternals.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogagentinternals.yaml
@@ -1,0 +1,12008 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogagentinternals.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgentInternal
+    listKind: DatadogAgentInternalList
+    plural: datadogagentinternals
+    shortNames:
+    - ddai
+    singular: datadogagentinternal
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.agent.status
+      name: agent
+      type: string
+    - jsonPath: .status.clusterAgent.status
+      name: cluster-agent
+      type: string
+    - jsonPath: .status.clusterChecksRunner.status
+      name: cluster-checks-runner
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogAgentInternal is the Schema for the datadogagentinternals
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogAgentSpec defines the desired state of DatadogAgent
+            properties:
+              features:
+                description: Features running on the Agent and Cluster Agent
+                properties:
+                  admissionController:
+                    description: AdmissionController configuration.
+                    properties:
+                      agentCommunicationMode:
+                        description: |-
+                          AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent.
+                          It can be "hostip", "service", or "socket".
+                        type: string
+                      agentSidecarInjection:
+                        description: AgentSidecarInjection contains Agent sidecar
+                          injection configurations.
+                        properties:
+                          clusterAgentCommunicationEnabled:
+                            description: |-
+                              ClusterAgentCommunicationEnabled enables communication between Agent sidecars and the Cluster Agent.
+                              Default : true
+                            type: boolean
+                          clusterAgentTlsVerification:
+                            description: ClusterAgentTLSVerification configures TLS
+                              verification for Agent sidecar to Cluster Agent communication.
+                            properties:
+                              copyCaConfigMap:
+                                description: |-
+                                  CopyCaConfigMap enables automatic creation of a ConfigMap containing the Cluster Agent's CA certificate
+                                  in namespaces where sidecar injection occurs.
+                                  Default: false
+                                type: boolean
+                              enabled:
+                                description: |-
+                                  Enabled enables TLS verification for agent sidecars communicating with the Cluster Agent.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Sidecar injections.
+                              Default: false
+                            type: boolean
+                          image:
+                            description: Image overrides the default Agent image name
+                              and tag for the Agent sidecar.
+                            properties:
+                              jmxEnabled:
+                                description: |-
+                                  Define whether the Agent image should support JMX.
+                                  To be used if the `Name` field does not correspond to a full image string.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Defines the Agent image name for the pod. You can provide this as:
+                                  * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                  for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                  * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                  and `[key].image.jmxEnabled` are ignored.
+                                  * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                    like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                                type: string
+                              pullPolicy:
+                                description: |-
+                                  The Kubernetes pull policy:
+                                  Use `Always`, `Never`, or `IfNotPresent`.
+                                type: string
+                              pullSecrets:
+                                description: |-
+                                  It is possible to specify Docker registry credentials.
+                                  See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                                items:
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                              tag:
+                                description: |-
+                                  Define the image tag to use.
+                                  To be used if the `Name` field does not correspond to a full image string.
+                                type: string
+                            type: object
+                          profiles:
+                            description: Profiles define the sidecar configuration
+                              override. Only one profile is supported.
+                            items:
+                              description: Profile defines a sidecar configuration
+                                override.
+                              properties:
+                                env:
+                                  description: EnvVars specifies the environment variables
+                                    for the profile.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                resources:
+                                  description: ResourceRequirements specifies the
+                                    resource requirements for the profile.
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This field depends on the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                securityContext:
+                                  description: SecurityContext specifies the security
+                                    context for the profile.
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label
+                                            that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label
+                                            that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          provider:
+                            description: |-
+                              Provider is used to add infrastructure provider-specific configurations to the Agent sidecar.
+                              Currently only "fargate" is supported.
+                              To use the feature in other environments (including local testing) omit the config.
+                              See also: https://docs.datadoghq.com/integrations/eks_fargate
+                            type: string
+                          registry:
+                            description: Registry overrides the default registry for
+                              the sidecar Agent.
+                            type: string
+                          selectors:
+                            description: Selectors define the pod selector for sidecar
+                              injection. Only one rule is supported.
+                            items:
+                              description: Selectors define a pod selector for sidecar
+                                injection.
+                              properties:
+                                namespaceSelector:
+                                  description: NamespaceSelector specifies the label
+                                    selector for namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                objectSelector:
+                                  description: ObjectSelector specifies the label
+                                    selector for objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      cwsInstrumentation:
+                        description: CWSInstrumentation holds the CWS Instrumentation
+                          endpoint configuration
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable the CWS Instrumentation admission controller endpoint.
+                              Default: false
+                            type: boolean
+                          mode:
+                            description: |-
+                              Mode defines the behavior of the CWS Instrumentation endpoint, and can be either "init_container" or "remote_copy".
+                              Default: "remote_copy"
+                            type: string
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the Admission Controller.
+                          Default: true
+                        type: boolean
+                      failurePolicy:
+                        description: FailurePolicy determines how unrecognized and
+                          timeout errors are handled.
+                        type: string
+                      kubernetesAdmissionEvents:
+                        description: KubernetesAdmissionEvents holds the Kubernetes
+                          Admission Events configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable the Kubernetes Admission Events feature.
+                              Default: false
+                            type: boolean
+                        type: object
+                      mutateUnlabelled:
+                        description: |-
+                          MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'.
+                          Default: false
+                        type: boolean
+                      mutation:
+                        description: Mutation contains Admission Controller mutation
+                          configurations.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller mutation webhook.
+                              Default: true
+                            type: boolean
+                        type: object
+                      probe:
+                        description: Probe holds the admission controller connectivity
+                          probe configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the admission controller connectivity probe.
+                              The probe periodically sends dry-run ConfigMap creation requests to verify the
+                              webhook is reachable from the API server. Requires Cluster Agent 7.78.0+.
+                              Default: true
+                            type: boolean
+                          gracePeriod:
+                            description: |-
+                              GracePeriod is the number of seconds to wait at startup before the first probe.
+                              Default: 60
+                            format: int32
+                            type: integer
+                          interval:
+                            description: |-
+                              Interval is the number of seconds between probe executions.
+                              Default: 60
+                            format: int32
+                            type: integer
+                        type: object
+                      registry:
+                        description: Registry defines an image registry for the admission
+                          controller.
+                        type: string
+                      serviceName:
+                        description: ServiceName corresponds to the webhook service
+                          name.
+                        type: string
+                      validation:
+                        description: Validation contains Admission Controller validation
+                          configurations.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller validation webhook.
+                              Default: true
+                            type: boolean
+                        type: object
+                      webhookName:
+                        description: |-
+                          WebhookName is a custom name for the MutatingWebhookConfiguration.
+                          Default: "datadog-webhook"
+                        type: string
+                    type: object
+                  apm:
+                    description: APM (Application Performance Monitoring) configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables Application Performance Monitoring.
+                          Default: true
+                        type: boolean
+                      errorTrackingStandalone:
+                        description: |-
+                          ErrorTrackingStandalone contains the configuration for the Error Tracking standalone feature.
+                          Feature is in preview.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables Error Tracking for backend services.
+                              Default: false
+                            type: boolean
+                        type: object
+                      hostPortConfig:
+                        description: |-
+                          HostPortConfig contains host port configuration.
+                          Enabled Default: false
+                          Port Default: 8126
+                        properties:
+                          enabled:
+                            description: Enabled enables host port configuration
+                            type: boolean
+                          hostPort:
+                            description: |-
+                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                              If HostNetwork is enabled, this value must match the ContainerPort.
+                            format: int32
+                            type: integer
+                        type: object
+                      instrumentation:
+                        description: |-
+                          SingleStepInstrumentation allows the agent to inject the Datadog APM libraries into all pods in the cluster.
+                          Feature is in beta.
+                          See also: https://docs.datadoghq.com/tracing/trace_collection/single-step-apm
+                          Enabled Default: false
+                        properties:
+                          disabledNamespaces:
+                            description: DisabledNamespaces disables injecting the
+                              Datadog APM libraries into pods in specific namespaces.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          enabled:
+                            description: |-
+                              Enabled enables injecting the Datadog APM libraries into all pods in the cluster.
+                              Default: false
+                            type: boolean
+                          enabledNamespaces:
+                            description: EnabledNamespaces enables injecting the Datadog
+                              APM libraries into pods in specific namespaces.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          injectionMode:
+                            description: |-
+                              InjectionMode is the injection mode to use for libraries injection.
+                              Valid values are: "auto", "init_container", "csi" (experimental, requires Cluster Agent 7.76.0+ and Datadog CSI Driver 1.2.0+), "image_volume" (experimental, requires Cluster Agent 7.77.0+).
+                              Empty by default so the Cluster Agent can apply its own defaults.
+                            enum:
+                            - auto
+                            - init_container
+                            - csi
+                            - image_volume
+                            type: string
+                          injector:
+                            description: Injector configures the APM Injector.
+                            properties:
+                              imageTag:
+                                description: |-
+                                  Set the image tag to use for the APM Injector.
+                                  (Requires Cluster Agent 7.57.0+)
+                                type: string
+                            type: object
+                          languageDetection:
+                            description: |-
+                              LanguageDetection detects languages and adds them as annotations on Deployments, but does not use these languages for injecting libraries to workload pods.
+                              (Requires Agent 7.52.0+ and Cluster Agent 7.52.0+)
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Language Detection to automatically detect languages of user workloads (beta).
+                                  Requires SingleStepInstrumentation.Enabled to be true.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          libVersions:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.
+                              <Library>: <Version>
+                              ex: "java": "v1.18.0"
+                            type: object
+                          targets:
+                            description: |-
+                              Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
+                              used. If no target matches, the auto instrumentation will not be applied.
+                              (Requires Cluster Agent 7.64.0+)
+                            items:
+                              description: SSITarget is a rule to apply the auto instrumentation
+                                to a specific workload using the pod and namespace
+                                selectors.
+                              properties:
+                                ddTraceConfigs:
+                                  description: |-
+                                    TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+                                    as environment variables in addition to the injected tracer.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                ddTraceVersions:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
+                                    name and the value is the version to inject.
+                                  type: object
+                                name:
+                                  description: Name is the name of the target. It
+                                    will be appended to the pod annotations to identify
+                                    the target that was used.
+                                  type: string
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
+                                    be used in conjunction with the Selector to match the pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: |-
+                                        MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
+                                        expressions are ANDed. This cannot be used with MatchNames.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
+                                        ANDed. This cannot be used with MatchNames.
+                                      type: object
+                                    matchNames:
+                                      description: MatchNames is a list of namespace
+                                        names to match. If empty, all namespaces are
+                                        matched.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                podSelector:
+                                  description: |-
+                                    PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
+                                    conjunction with the NamespaceSelector to match the pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                        type: object
+                      unixDomainSocketConfig:
+                        description: |-
+                          UnixDomainSocketConfig contains socket configuration.
+                          See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                          Enabled Default: true
+                          Path Default: `/var/run/datadog/apm.socket`
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Unix Domain Socket.
+                              Default: true
+                            type: boolean
+                          path:
+                            description: Path defines the socket path used when enabled.
+                            type: string
+                        type: object
+                    type: object
+                  asm:
+                    description: ASM (Application Security Management) configuration.
+                    properties:
+                      iast:
+                        description: |-
+                          IAST configures Interactive Application Security Testing.
+                          Enabled Default: false
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Interactive Application Security Testing (IAST).
+                              Default: false
+                            type: boolean
+                        type: object
+                      sca:
+                        description: |-
+                          SCA configures Software Composition Analysis.
+                          Enabled Default: false
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Software Composition Analysis (SCA).
+                              Default: false
+                            type: boolean
+                        type: object
+                      threats:
+                        description: |-
+                          Threats configures ASM App & API Protection.
+                          Enabled Default: false
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables ASM App & API Protection.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                  autoscaling:
+                    description: Autoscaling configuration.
+                    properties:
+                      cluster:
+                        description: Cluster contains the configuration for the cluster
+                          autoscaling product.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the cluster autoscaling product.
+                              (Requires Cluster Agent 7.74.0+)
+                              Default: false
+                            type: boolean
+                          spot:
+                            description: |-
+                              Spot contains the configuration for the spot instance scheduling sub-feature.
+                              Requires cluster autoscaling to be enabled.
+                              (Requires Cluster Agent 7.79.0+)
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the cluster spot scheduling product.
+                                  (Requires Cluster Agent 7.79.0+)
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      workload:
+                        description: Workload contains the configuration for the workload
+                          autoscaling product.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the workload autoscaling product.
+                              Default: false
+                            type: boolean
+                          inPlaceVerticalScaling:
+                            description: |-
+                              InPlaceVerticalScaling contains the configuration for the in-place vertical scaling sub-feature.
+                              Requires workload autoscaling to be enabled.
+                              (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables in-place vertical scaling for workload autoscaling.
+                                  (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                    type: object
+                  clusterChecks:
+                    description: ClusterChecks configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables Cluster Checks scheduling in the Cluster Agent.
+                          Default: true
+                        type: boolean
+                      useClusterChecksRunners:
+                        description: |-
+                          Enabled enables Cluster Checks Runners to run all Cluster Checks.
+                          Default: false
+                        type: boolean
+                    type: object
+                  controlPlaneMonitoring:
+                    description: ControlPlaneMonitoring configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables control plane monitoring checks in the cluster agent.
+                          Default: true
+                        type: boolean
+                    type: object
+                  cspm:
+                    description: CSPM (Cloud Security Posture Management) configuration.
+                    properties:
+                      checkInterval:
+                        description: CheckInterval defines the check interval.
+                        type: string
+                      customBenchmarks:
+                        description: |-
+                          CustomBenchmarks contains CSPM benchmarks.
+                          The content of the ConfigMap will be merged with the benchmarks bundled with the agent.
+                          Any benchmarks with the same name as those existing in the agent will take precedence.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables Cloud Security Posture Management, including Docker and Kubernetes benchmarks.
+                          Default: false
+                        type: boolean
+                      hostBenchmarks:
+                        description: HostBenchmarks contains configuration for host
+                          benchmarks.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Linux host benchmarks. Requires `features.cspm.enabled` to be set to `true`.
+                              Default: true
+                            type: boolean
+                        type: object
+                      runInSystemProbe:
+                        description: |-
+                          RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                          This is an experimental feature. Contact support before using.
+                          Default: false
+                        type: boolean
+                    type: object
+                  cws:
+                    description: CWS (Cloud Workload Security) configuration.
+                    properties:
+                      customPolicies:
+                        description: |-
+                          CustomPolicies contains security policies.
+                          The content of the ConfigMap will be merged with the policies bundled with the agent.
+                          Any policies with the same name as those existing in the agent will take precedence.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      directSendFromSystemProbe:
+                        description: |-
+                          DirectSendFromSystemProbe configures CWS to send payloads directly from the system-probe, without using the security-agent.
+                          This is an experimental feature. Contact support before using.
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enabled enables Cloud Workload Security.
+                          Default: false
+                        type: boolean
+                      enforcement:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Enforcement for Cloud Workload Security.
+                              Default: true
+                            type: boolean
+                        type: object
+                      network:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Workload Security Network detections.
+                              Default: true
+                            type: boolean
+                        type: object
+                      remoteConfiguration:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Remote Configuration for Cloud Workload Security.
+                              Default: true
+                            type: boolean
+                        type: object
+                      securityProfiles:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Security Profiles collection for Cloud Workload Security.
+                              Default: true
+                            type: boolean
+                        type: object
+                      syscallMonitorEnabled:
+                        description: |-
+                          SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only).
+                          Default: false
+                        type: boolean
+                    type: object
+                  dataPlane:
+                    description: |-
+                      DataPlane configuration for the Agent Data Plane.
+                      Agent Data Plane is a high-performance sidecar that handles data ingestion.
+                    properties:
+                      dogstatsd:
+                        description: Dogstatsd configures DogStatsD handling by the
+                          Data Plane.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled configures the Data Plane to handle DogStatsD traffic.
+                              When set to false, DogStatsD is handled by the Core Agent instead.
+                              Default: true
+                            type: boolean
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the Data Plane.
+                          Default: false
+                        type: boolean
+                    type: object
+                  dogstatsd:
+                    description: Dogstatsd configuration.
+                    properties:
+                      hostPortConfig:
+                        description: |-
+                          HostPortConfig contains host port configuration.
+                          Enabled Default: false
+                          Port Default: 8125
+                        properties:
+                          enabled:
+                            description: Enabled enables host port configuration
+                            type: boolean
+                          hostPort:
+                            description: |-
+                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                              If HostNetwork is enabled, this value must match the ContainerPort.
+                            format: int32
+                            type: integer
+                        type: object
+                      mapperProfiles:
+                        description: |-
+                          Configure the Dogstasd Mapper Profiles.
+                          Can be passed as raw data or via a json encoded string in a config map.
+                          See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      nonLocalTraffic:
+                        description: |-
+                          NonLocalTraffic enables non-local traffic for Dogstatsd.
+                          Default: true
+                        type: boolean
+                      originDetectionEnabled:
+                        description: |-
+                          OriginDetectionEnabled enables origin detection for container tagging.
+                          See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+                        type: boolean
+                      tagCardinality:
+                        description: |-
+                          TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                          This setting only applies when OriginDetectionEnabled is true.
+                          See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
+                          Cardinality default: low
+                        type: string
+                      unixDomainSocketConfig:
+                        description: |-
+                          UnixDomainSocketConfig contains socket configuration.
+                          See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                          Enabled Default: true
+                          Path Default: `/var/run/datadog/dsd.socket`
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Unix Domain Socket.
+                              Default: true
+                            type: boolean
+                          path:
+                            description: Path defines the socket path used when enabled.
+                            type: string
+                        type: object
+                    type: object
+                  dynamicInstrumentation:
+                    description: DynamicInstrumentation configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the Dynamic Instrumentation system probe module.
+                          Default: false
+                        type: boolean
+                    type: object
+                  ebpfCheck:
+                    description: EBPFCheck configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the eBPF check.
+                          Default: false
+                        type: boolean
+                    type: object
+                  eventCollection:
+                    description: EventCollection configuration.
+                    properties:
+                      collectKubernetesEvents:
+                        description: |-
+                          CollectKubernetesEvents enables Kubernetes event collection.
+                          Default: true
+                        type: boolean
+                      collectedEventTypes:
+                        description: |-
+                          CollectedEventTypes defines the list of events to collect when UnbundleEvents is enabled.
+                          Default:
+                          [
+                          {"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},
+                          {"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},
+                          {"kind":"CronJob","reasons":["SawCompletedJob"]}
+                          ]
+                        items:
+                          description: EventTypes defines the kind and reasons of
+                            events to collect.
+                          properties:
+                            kind:
+                              description: 'Kind is the kind of event to collect.
+                                (ex: Pod, Node, CronJob)'
+                              type: string
+                            reasons:
+                              description: 'Reasons is a list of event reasons to
+                                collect. (ex: Failed, BackOff, Unhealthy)'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - kind
+                          - reasons
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      unbundleEvents:
+                        description: |-
+                          UnbundleEvents enables collection of Kubernetes events as individual events.
+                          Default: false
+                        type: boolean
+                    type: object
+                  externalMetricsServer:
+                    description: ExternalMetricsServer configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the External Metrics Server.
+                          Default: false
+                        type: boolean
+                      endpoint:
+                        description: |-
+                          Override the API endpoint for the External Metrics Server.
+                          URL Default: "https://app.datadoghq.com".
+                        properties:
+                          credentials:
+                            description: Credentials defines the Datadog credentials
+                              used to submit data to/query data from Datadog.
+                            properties:
+                              apiKey:
+                                description: |-
+                                  APIKey configures your Datadog API key.
+                                  See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                                type: string
+                              apiSecret:
+                                description: |-
+                                  APISecret references an existing Secret which stores the API key instead of creating a new one.
+                                  If set, this parameter takes precedence over "APIKey".
+                                properties:
+                                  keyName:
+                                    description: KeyName is the key of the secret
+                                      to use.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of the secret.
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                              appKey:
+                                description: |-
+                                  AppKey configures your Datadog application key.
+                                  If you are using features.externalMetricsServer.enabled = true, you must set
+                                  a Datadog application key for read access to your metrics.
+                                type: string
+                              appSecret:
+                                description: |-
+                                  AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                                  If set, this parameter takes precedence over "AppKey".
+                                properties:
+                                  keyName:
+                                    description: KeyName is the key of the secret
+                                      to use.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of the secret.
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                            type: object
+                          url:
+                            description: URL defines the endpoint URL.
+                            type: string
+                        type: object
+                      port:
+                        description: |-
+                          Port specifies the metricsProvider External Metrics Server service port.
+                          Default: 8443
+                        format: int32
+                        type: integer
+                      registerAPIService:
+                        description: |-
+                          RegisterAPIService registers the External Metrics endpoint as an APIService
+                          Default: true
+                        type: boolean
+                      useDatadogMetrics:
+                        description: |-
+                          UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries).
+                          Default: true
+                        type: boolean
+                      wpaController:
+                        description: |-
+                          WPAController enables the informer and controller of the Watermark Pod Autoscaler.
+                          NOTE: The Watermark Pod Autoscaler controller needs to be installed.
+                          See also: https://github.com/DataDog/watermarkpodautoscaler.
+                          Default: false
+                        type: boolean
+                    type: object
+                  gpu:
+                    description: GPU monitoring
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables GPU monitoring core check.
+                          Default: false
+                        type: boolean
+                      patchCgroupPermissions:
+                        description: |-
+                          PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case
+                          the container runtime is not properly configured and the Agent containers lose access to GPU devices.
+                          Default: false
+                        type: boolean
+                      privilegedMode:
+                        description: |-
+                          PrivilegedMode enables GPU Probe module in System Probe.
+                          Default: false
+                        type: boolean
+                      requiredRuntimeClassName:
+                        description: |-
+                          PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature.
+                          If the value is an empty string, the runtime class is not set.
+                          Default: nvidia
+                        type: string
+                    type: object
+                  helmCheck:
+                    description: HelmCheck configuration.
+                    properties:
+                      collectEvents:
+                        description: |-
+                          CollectEvents set to `true` enables event collection in the Helm check
+                          (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+)
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enabled enables the Helm check.
+                          Default: false
+                        type: boolean
+                      valuesAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ValuesAsTags collects Helm values from a release and uses them as tags
+                          (Requires Agent and Cluster Agent 7.40.0+).
+                          Default: {}
+                        type: object
+                    type: object
+                  kubeStateMetricsCore:
+                    description: KubeStateMetricsCore check configuration.
+                    properties:
+                      collectCrMetrics:
+                        description: |-
+                          `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                          The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                          The exact structure and existing fields of each item in this list can be found in:
+                          https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                        items:
+                          description: Resource configures a custom resource for metric
+                            generation.
+                          properties:
+                            commonLabels:
+                              additionalProperties:
+                                type: string
+                              description: CommonLabels are added to all metrics.
+                              type: object
+                            groupVersionKind:
+                              description: GroupVersionKind of the custom resource
+                                to be monitored.
+                              properties:
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                version:
+                                  type: string
+                              type: object
+                            labelsFromPath:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: LabelsFromPath adds additional labels where
+                                the value is taken from a field in the resource.
+                              type: object
+                            metricNamePrefix:
+                              description: |-
+                                MetricNamePrefix defines a prefix for all metrics of the resource.
+                                If set to "", no prefix will be added.
+                                Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                              type: string
+                            metrics:
+                              description: Metrics are the custom resource fields
+                                to be collected.
+                              items:
+                                description: Generator describes a unique metric name.
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are added to all metrics.
+                                    type: object
+                                  each:
+                                    description: Each targets a value or values from
+                                      the resource.
+                                    properties:
+                                      gauge:
+                                        description: Gauge defines a gauge metric.
+                                        properties:
+                                          labelFromKey:
+                                            description: LabelFromKey adds a label
+                                              with the given name if Path is an object.
+                                              The label value will be the object key.
+                                            type: string
+                                          labelsFromPath:
+                                            additionalProperties:
+                                              items:
+                                                type: string
+                                              type: array
+                                            description: LabelsFromPath adds additional
+                                              labels where the value of the label
+                                              is taken from a field under Path.
+                                            type: object
+                                          nilIsZero:
+                                            description: NilIsZero indicates that
+                                              if a value is nil it will be treated
+                                              as zero value.
+                                            type: boolean
+                                          path:
+                                            description: Path is the path to to generate
+                                              metric(s) for.
+                                            items:
+                                              type: string
+                                            type: array
+                                          valueFrom:
+                                            description: ValueFrom is the path to
+                                              a numeric field under Path that will
+                                              be the metric value.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - path
+                                        type: object
+                                      info:
+                                        description: Info defines an info metric.
+                                        properties:
+                                          labelFromKey:
+                                            description: LabelFromKey adds a label
+                                              with the given name if Path is an object.
+                                              The label value will be the object key.
+                                            type: string
+                                          labelsFromPath:
+                                            additionalProperties:
+                                              items:
+                                                type: string
+                                              type: array
+                                            description: LabelsFromPath adds additional
+                                              labels where the value of the label
+                                              is taken from a field under Path.
+                                            type: object
+                                          path:
+                                            description: Path is the path to to generate
+                                              metric(s) for.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - path
+                                        type: object
+                                      stateSet:
+                                        description: StateSet defines a state set
+                                          metric.
+                                        properties:
+                                          labelName:
+                                            description: LabelName is the key of the
+                                              label which is used for each entry in
+                                              List to expose the value.
+                                            type: string
+                                          labelsFromPath:
+                                            additionalProperties:
+                                              items:
+                                                type: string
+                                              type: array
+                                            description: LabelsFromPath adds additional
+                                              labels where the value of the label
+                                              is taken from a field under Path.
+                                            type: object
+                                          list:
+                                            description: List is the list of values
+                                              to expose a value for.
+                                            items:
+                                              type: string
+                                            type: array
+                                          path:
+                                            description: Path is the path to to generate
+                                              metric(s) for.
+                                            items:
+                                              type: string
+                                            type: array
+                                          valueFrom:
+                                            description: ValueFrom is the subpath
+                                              to compare the list to.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - path
+                                        type: object
+                                      type:
+                                        description: Type defines the type of the
+                                          metric.
+                                        type: string
+                                    type: object
+                                  help:
+                                    description: Help text for the metric.
+                                    type: string
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: LabelsFromPath adds additional labels
+                                      where the value is taken from a field in the
+                                      resource.
+                                    type: object
+                                  name:
+                                    description: Name of the metric. Subject to prefixing
+                                      based on the configuration of the Resource.
+                                    type: string
+                                type: object
+                              type: array
+                            resourcePlural:
+                              description: ResourcePlural sets the plural name of
+                                the resource. Defaults to the plural version of the
+                                Kind according to flect.Pluralize.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                          This must point to a ConfigMap containing a valid cluster check configuration.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables Kube State Metrics Core.
+                          Default: true
+                        type: boolean
+                    type: object
+                  kubernetesActions:
+                    description: KubernetesActions configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the Kubernetes Actions feature on the Cluster Agent.
+                          Default: false
+                        type: boolean
+                    type: object
+                  liveContainerCollection:
+                    description: LiveContainerCollection configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables container collection for the Live Container View.
+                          Default: true
+                        type: boolean
+                    type: object
+                  liveProcessCollection:
+                    description: LiveProcessCollection configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables Process monitoring.
+                          Default: false
+                        type: boolean
+                      scrubProcessArguments:
+                        description: |-
+                          ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ).
+                          Default: true
+                        type: boolean
+                      stripProcessArguments:
+                        description: |-
+                          StripProcessArguments enables stripping of all process arguments.
+                          Default: false
+                        type: boolean
+                    type: object
+                  logCollection:
+                    description: LogCollection configuration.
+                    properties:
+                      autoMultiLineDetection:
+                        description: |-
+                          AutoMultiLineDetection allows the Agent to detect and aggregate common multi-line logs automatically.
+                          See also: https://docs.datadoghq.com/agent/logs/auto_multiline_detection/
+                        type: boolean
+                      containerCollectAll:
+                        description: |-
+                          ContainerCollectAll enables Log collection from all containers.
+                          Default: false
+                        type: boolean
+                      containerCollectUsingFiles:
+                        description: |-
+                          ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API.
+                          Collecting logs from files is usually the most efficient way of collecting logs.
+                          See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                          Default: true
+                        type: boolean
+                      containerLogsPath:
+                        description: |-
+                          ContainerLogsPath allows log collection from the container log path.
+                          Set to a different path if you are not using the Docker runtime.
+                          See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
+                          Default: `/var/lib/docker/containers`
+                        type: string
+                      containerSymlinksPath:
+                        description: |-
+                          ContainerSymlinksPath allows log collection to use symbolic links in this directory to validate container ID -> pod.
+                          Default: `/var/log/containers`
+                        type: string
+                      enabled:
+                        description: |-
+                          Enabled enables Log collection.
+                          Default: false
+                        type: boolean
+                      openFilesLimit:
+                        description: |-
+                          OpenFilesLimit sets the maximum number of log files that the Datadog Agent tails.
+                          Increasing this limit can increase resource consumption of the Agent.
+                          See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                          Default: 100
+                        format: int32
+                        type: integer
+                      podLogsPath:
+                        description: |-
+                          PodLogsPath allows log collection from a pod log path.
+                          Default: `/var/log/pods`
+                        type: string
+                      tempStoragePath:
+                        description: |-
+                          TempStoragePath (always mounted from the host) is used by the Agent to store information about processed log files.
+                          If the Agent is restarted, it starts tailing the log files immediately.
+                          Default: `/var/lib/datadog-agent/logs`
+                        type: string
+                    type: object
+                  npm:
+                    description: NPM (Network Performance Monitoring) configuration.
+                    properties:
+                      collectDNSStats:
+                        description: |-
+                          CollectDNSStats enables DNS stat collection.
+                          Default: false
+                        type: boolean
+                      enableConntrack:
+                        description: |-
+                          EnableConntrack enables the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data.
+                          See also: http://conntrack-tools.netfilter.org/
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enabled enables Network Performance Monitoring.
+                          Default: false
+                        type: boolean
+                    type: object
+                  oomKill:
+                    description: OOMKill configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the OOMKill eBPF-based check.
+                          Default: false
+                        type: boolean
+                    type: object
+                  orchestratorExplorer:
+                    description: OrchestratorExplorer check configuration.
+                    properties:
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default Orchestrator Explorer check.
+                          This must point to a ConfigMap containing a valid cluster check configuration.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      customResources:
+                        description: |-
+                          `CustomResources` defines custom resources for the orchestrator explorer to collect.
+                          Each item should follow the convention `group/version/kind`. For example, `datadoghq.com/v1alpha1/datadogmetrics`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      ddUrl:
+                        description: |-
+                          Override the API endpoint for the Orchestrator Explorer.
+                          URL Default: "https://orchestrator.datadoghq.com".
+                        type: string
+                      enabled:
+                        description: |-
+                          Enabled enables the Orchestrator Explorer.
+                          Default: true
+                        type: boolean
+                      extraTags:
+                        description: |-
+                          Additional tags to associate with the collected data in the form of `a b c`.
+                          This is a Cluster Agent option distinct from DD_TAGS that is used in the Orchestrator Explorer.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      scrubContainers:
+                        description: |-
+                          ScrubContainers enables scrubbing of sensitive container data (passwords, tokens, etc. ).
+                          Default: true
+                        type: boolean
+                    type: object
+                  otelAgentGateway:
+                    description: OtelAgentGateway configuration.
+                    properties:
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default OTel Agent Gateway.
+                          This must point to a ConfigMap containing a valid OTel collector configuration.
+                          When passing a configmap, file name *must* be otel-gateway-config.yaml.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the OTel Agent Gateway.
+                          Default: false
+                        type: boolean
+                      featureGates:
+                        description: |-
+                          FeatureGates are the feature gates to pass to the OTel collector as a comma-separated list.
+                          Example: "component.UseLocalHostAsDefaultHost,connector.datadogconnector.NativeIngest"
+                        type: string
+                      ports:
+                        description: |-
+                          Ports contains the ports that the OTel Collector is listening on.
+                          Defaults: otel-grpc:4317 / otel-http:4318.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  otelCollector:
+                    description: OtelCollector configuration.
+                    properties:
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                          This must point to a ConfigMap containing a valid cluster check configuration.
+                          When passing a configmap, file name *must* be otel-config.yaml.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      coreConfig:
+                        description: OTelCollector Config Relevant to the Core agent
+                        properties:
+                          enabled:
+                            description: Enabled marks otelcollector as enabled in
+                              core agent.
+                            type: boolean
+                          extensionTimeout:
+                            description: |-
+                              Extension URL provides the timout of the ddflareextension to
+                              the core agent.
+                            type: integer
+                          extensionURL:
+                            description: |-
+                              Extension URL provides the URL of the ddflareextension to
+                              the core agent.
+                            type: string
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the OTel Agent.
+                          Default: false
+                        type: boolean
+                      ports:
+                        description: |-
+                          Ports contains the ports for the otel-agent.
+                          Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317
+                          or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http).
+                          If not, this will lead to a port conflict.
+                          This limitation will be lifted once annotations support is removed.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  otlp:
+                    description: OTLP ingest configuration
+                    properties:
+                      receiver:
+                        description: Receiver contains configuration for the OTLP
+                          ingest receiver.
+                        properties:
+                          protocols:
+                            description: Protocols contains configuration for the
+                              OTLP ingest receiver protocols.
+                            properties:
+                              grpc:
+                                description: GRPC contains configuration for the OTLP
+                                  ingest OTLP/gRPC receiver.
+                                properties:
+                                  enabled:
+                                    description: Enable the OTLP/gRPC endpoint. Host
+                                      port is enabled by default and can be disabled.
+                                    type: boolean
+                                  endpoint:
+                                    description: |-
+                                      Endpoint for OTLP/gRPC.
+                                      gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+                                      The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`).
+                                      Default: `0.0.0.0:4317`.
+                                    type: string
+                                  hostPortConfig:
+                                    description: |-
+                                      Enable hostPort for OTLP/gRPC
+                                      Default: true
+                                    properties:
+                                      enabled:
+                                        description: Enabled enables host port configuration
+                                        type: boolean
+                                      hostPort:
+                                        description: |-
+                                          Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                          If HostNetwork is enabled, this value must match the ContainerPort.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              http:
+                                description: HTTP contains configuration for the OTLP
+                                  ingest OTLP/HTTP receiver.
+                                properties:
+                                  enabled:
+                                    description: Enable the OTLP/HTTP endpoint. Host
+                                      port is enabled by default and can be disabled.
+                                    type: boolean
+                                  endpoint:
+                                    description: |-
+                                      Endpoint for OTLP/HTTP.
+                                      Default: '0.0.0.0:4318'.
+                                    type: string
+                                  hostPortConfig:
+                                    description: |-
+                                      Enable hostPorts for OTLP/HTTP
+                                      Default: true
+                                    properties:
+                                      enabled:
+                                        description: Enabled enables host port configuration
+                                        type: boolean
+                                      hostPort:
+                                        description: |-
+                                          Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                          If HostNetwork is enabled, this value must match the ContainerPort.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  processDiscovery:
+                    description: ProcessDiscovery configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the Process Discovery check in the Agent.
+                          Default: true
+                        type: boolean
+                    type: object
+                  prometheusScrape:
+                    description: PrometheusScrape configuration.
+                    properties:
+                      additionalConfigs:
+                        description: AdditionalConfigs allows adding advanced Prometheus
+                          check configurations with custom discovery rules.
+                        type: string
+                      enableServiceEndpoints:
+                        description: |-
+                          EnableServiceEndpoints enables generating dedicated checks for service endpoints.
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enable autodiscovery of pods and services exposing Prometheus metrics.
+                          Default: false
+                        type: boolean
+                      version:
+                        description: |-
+                          Version specifies the version of the OpenMetrics check.
+                          Default: 2
+                        type: integer
+                    type: object
+                  remoteConfiguration:
+                    description: Remote Configuration configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enable this option to activate Remote Configuration.
+                          Default: true
+                        type: boolean
+                    type: object
+                  sbom:
+                    description: SBOM collection configuration.
+                    properties:
+                      containerImage:
+                        description: SBOMTypeConfig contains configuration for a SBOM
+                          collection type.
+                        properties:
+                          analyzers:
+                            description: Analyzers to use for SBOM collection.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                          overlayFSDirectScan:
+                            description: |-
+                              Enable this option to enable experimental overlayFS direct scan.
+                              Default: false
+                            type: boolean
+                          uncompressedLayersSupport:
+                            description: |-
+                              Enable this option to enable support for uncompressed layers.
+                              Default: false
+                            type: boolean
+                        type: object
+                      enabled:
+                        description: |-
+                          Enable this option to activate SBOM collection.
+                          Default: false
+                        type: boolean
+                      enrichment:
+                        description: SBOMEnrichmentConfig contains SBOM enrichment
+                          configuration.
+                        properties:
+                          usage:
+                            description: Usage contains configuration for the "package
+                              in use" enrichment.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM enrichment with runtime "package in use" detection.
+                                  Requires system-probe for eBPF-based file access tracking.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      host:
+                        description: SBOMTypeConfig contains configuration for a SBOM
+                          collection type.
+                        properties:
+                          analyzers:
+                            description: Analyzers to use for SBOM collection.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                  serviceDiscovery:
+                    description: ServiceDiscovery
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the service discovery check.
+                          Default: true when omitted and the node Agent image is >= 7.78.0. Otherwise false.
+                          If the image version cannot be determined, it is treated as latest.
+                        type: boolean
+                    type: object
+                  tcpQueueLength:
+                    description: TCPQueueLength configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the TCP queue length eBPF-based check.
+                          Default: false
+                        type: boolean
+                    type: object
+                  usm:
+                    description: USM (Universal Service Monitoring) configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables Universal Service Monitoring.
+                          Default: false
+                        type: boolean
+                    type: object
+                type: object
+              global:
+                description: Global settings to configure the agents
+                properties:
+                  checksTagCardinality:
+                    description: |-
+                      ChecksTagCardinality configures tag cardinality for the metrics collected by integrations (`low`, `orchestrator` or `high`).
+                      See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#tags-cardinality.
+                      Not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low.
+                      Ref: https://github.com/DataDog/datadog-agent/blob/856cf4a66142ce91fd4f8a278149436eb971184a/pkg/config/setup/config.go#L625.
+                    type: string
+                  clusterAgentToken:
+                    description: ClusterAgentToken is the token for communication
+                      between the NodeAgent and ClusterAgent.
+                    type: string
+                  clusterAgentTokenSecret:
+                    description: ClusterAgentTokenSecret is the secret containing
+                      the Cluster Agent token.
+                    properties:
+                      keyName:
+                        description: KeyName is the key of the secret to use.
+                        type: string
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                    - secretName
+                    type: object
+                  clusterName:
+                    description: ClusterName sets a unique cluster name for the deployment
+                      to easily scope monitoring data in the Datadog app.
+                    type: string
+                  commonLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      CommonLabels specified labels to be added to all operator-managed Kubernetes resources
+                      (DaemonSets, Deployments, ConfigMaps, Services, ServiceAccounts, etc.).
+                      This is useful when external policy tools such as Kyverno enforce the presence of
+                      specific labels on all cluster resources.
+                      Labels defined here are merged with the operator's own default labels; operator labels
+                      take precedence on any key conflict.
+                    type: object
+                    x-kubernetes-map-type: granular
+                  containerStrategy:
+                    description: |-
+                      ContainerStrategy determines whether agents run in a single or multiple containers.
+                      Default: 'optimized'
+                    type: string
+                  credentials:
+                    description: Credentials defines the Datadog credentials used
+                      to submit data to/query data from Datadog.
+                    properties:
+                      apiKey:
+                        description: |-
+                          APIKey configures your Datadog API key.
+                          See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                        type: string
+                      apiSecret:
+                        description: |-
+                          APISecret references an existing Secret which stores the API key instead of creating a new one.
+                          If set, this parameter takes precedence over "APIKey".
+                        properties:
+                          keyName:
+                            description: KeyName is the key of the secret to use.
+                            type: string
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      appKey:
+                        description: |-
+                          AppKey configures your Datadog application key.
+                          If you are using features.externalMetricsServer.enabled = true, you must set
+                          a Datadog application key for read access to your metrics.
+                        type: string
+                      appSecret:
+                        description: |-
+                          AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                          If set, this parameter takes precedence over "AppKey".
+                        properties:
+                          keyName:
+                            description: KeyName is the key of the secret to use.
+                            type: string
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                    type: object
+                  criSocketPath:
+                    description: Path to the container runtime socket (if different
+                      from Docker).
+                    type: string
+                  csi:
+                    description: CSI contains configuration for Datadog CSI Driver
+                    properties:
+                      autoManage:
+                        description: |-
+                          AutoManage controls whether the operator automatically manages the DatadogCSIDriver
+                          custom resource on behalf of this DatadogAgent. Set to false to hand ownership over to a
+                          DatadogCSIDriver CR that you maintain yourself (useful for migrations where you need
+                          customizations not exposed on the DatadogAgent spec). When toggled from true to false,
+                          the operator cleans up the DDA-owned DatadogCSIDriver CR; you are then responsible for
+                          providing a replacement so CSI continues to work.
+                          Default: true
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enables the usage of CSI driver in Datadog Agent. When the operator is started with
+                          `--datadogCSIDriverEnabled=true`, it will also install the driver by creating a
+                          DatadogCSIDriver custom resource, unless a cluster-scoped `k8s.csi.datadoghq.com`
+                          CSIDriver is already present, in which case it defers to the existing installation
+                          (e.g. from the Datadog CSI driver Helm chart).
+                          Default: false
+                        type: boolean
+                      nodeAffinity:
+                        description: NodeAffinity specifies node affinity scheduling
+                          rules for CSI driver DaemonSet pods.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector is a map of key-value pairs for
+                          CSI driver DaemonSet pod node selection.
+                        type: object
+                      tolerations:
+                        description: Tolerations configure the CSI driver DaemonSet
+                          pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  disableNonResourceRules:
+                    description: |-
+                      Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.
+                      Required 'true' for Google Cloud Marketplace.
+                    type: boolean
+                  dockerSocketPath:
+                    description: Path to the docker runtime socket.
+                    type: string
+                  endpoint:
+                    description: |-
+                      Endpoint is the Datadog intake URL the Agent data are sent to.
+                      Only set this option if you need the Agent to send data to a custom URL.
+                      Overrides the site setting defined in `Site`.
+                    properties:
+                      credentials:
+                        description: Credentials defines the Datadog credentials used
+                          to submit data to/query data from Datadog.
+                        properties:
+                          apiKey:
+                            description: |-
+                              APIKey configures your Datadog API key.
+                              See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                            type: string
+                          apiSecret:
+                            description: |-
+                              APISecret references an existing Secret which stores the API key instead of creating a new one.
+                              If set, this parameter takes precedence over "APIKey".
+                            properties:
+                              keyName:
+                                description: KeyName is the key of the secret to use.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            required:
+                            - secretName
+                            type: object
+                          appKey:
+                            description: |-
+                              AppKey configures your Datadog application key.
+                              If you are using features.externalMetricsServer.enabled = true, you must set
+                              a Datadog application key for read access to your metrics.
+                            type: string
+                          appSecret:
+                            description: |-
+                              AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                              If set, this parameter takes precedence over "AppKey".
+                            properties:
+                              keyName:
+                                description: KeyName is the key of the secret to use.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            required:
+                            - secretName
+                            type: object
+                        type: object
+                      url:
+                        description: URL defines the endpoint URL.
+                        type: string
+                    type: object
+                  env:
+                    description: Env contains a list of environment variables that
+                      are set for all Agents.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  fips:
+                    description: FIPS contains configuration used to customize the
+                      FIPS proxy sidecar.
+                    properties:
+                      customFIPSConfig:
+                        description: |-
+                          CustomFIPSConfig configures a custom configMap to provide the FIPS configuration.
+                          Specify custom contents for the FIPS proxy sidecar container config
+                          (/etc/datadog-fips-proxy/datadog-fips-proxy.cfg). If empty, the default FIPS
+                          proxy sidecar container config is used.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: Enable FIPS sidecar.
+                        type: boolean
+                      image:
+                        description: The container image of the FIPS sidecar.
+                        properties:
+                          jmxEnabled:
+                            description: |-
+                              Define whether the Agent image should support JMX.
+                              To be used if the `Name` field does not correspond to a full image string.
+                            type: boolean
+                          name:
+                            description: |-
+                              Defines the Agent image name for the pod. You can provide this as:
+                              * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                              for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                              * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                              and `[key].image.jmxEnabled` are ignored.
+                              * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                            type: string
+                          pullPolicy:
+                            description: |-
+                              The Kubernetes pull policy:
+                              Use `Always`, `Never`, or `IfNotPresent`.
+                            type: string
+                          pullSecrets:
+                            description: |-
+                              It is possible to specify Docker registry credentials.
+                              See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            description: |-
+                              Define the image tag to use.
+                              To be used if the `Name` field does not correspond to a full image string.
+                            type: string
+                        type: object
+                      localAddress:
+                        description: |-
+                          Set the local IP address.
+                          Default: `127.0.0.1`
+                        type: string
+                      port:
+                        description: |-
+                          Port specifies which port is used by the containers to communicate to the FIPS sidecar.
+                          Default: 9803
+                        format: int32
+                        type: integer
+                      portRange:
+                        description: |-
+                          PortRange specifies the number of ports used.
+                          Default: 15
+                        format: int32
+                        type: integer
+                      resources:
+                        description: Resources is the requests and limits for the
+                          FIPS sidecar container.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      useHTTPS:
+                        description: |-
+                          UseHTTPS enables HTTPS.
+                          Default: false
+                        type: boolean
+                    type: object
+                  kubelet:
+                    description: Kubelet contains the kubelet configuration parameters.
+                    properties:
+                      agentCAPath:
+                        description: |-
+                          AgentCAPath is the container path where the kubelet CA certificate is stored.
+                          Default: '/var/run/host-kubelet-ca.crt' if hostCAPath is set, else '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+                        type: string
+                      host:
+                        description: Host overrides the host used to contact kubelet
+                          API (default to status.hostIP).
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing
+                                  the env file.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            - volumeName
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      hostCAPath:
+                        description: HostCAPath is the host path where the kubelet
+                          CA certificate is stored.
+                        type: string
+                      podResourcesSocketPath:
+                        description: |-
+                          PodResourcesSocketPath is the host path where the pod resources socket is stored.
+                          Default: `/var/lib/kubelet/pod-resources/`
+                        type: string
+                      tlsVerify:
+                        description: |-
+                          TLSVerify toggles kubelet TLS verification.
+                          Default: true
+                        type: boolean
+                    type: object
+                  kubernetesResourcesAnnotationsAsTags:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: "Provide a mapping of Kubernetes Resource Groups
+                      to annotations mapping to Datadog Tags.\n<KUBERNETES_RESOURCE_GROUP>:\n\t\t<KUBERNETES_ANNOTATION>:
+                      <DATADOG_TAG_KEY>\nKUBERNETES_RESOURCE_GROUP should be in the
+                      form `{resource}.{group}` or `{resource}` (example: deployments.apps,
+                      pods)"
+                    type: object
+                  kubernetesResourcesLabelsAsTags:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: "Provide a mapping of Kubernetes Resource Groups
+                      to labels mapping to Datadog Tags.\n<KUBERNETES_RESOURCE_GROUP>:\n\t\t<KUBERNETES_LABEL>:
+                      <DATADOG_TAG_KEY>\nKUBERNETES_RESOURCE_GROUP should be in the
+                      form `{resource}.{group}` or `{resource}` (example: deployments.apps,
+                      pods)"
+                    type: object
+                  localService:
+                    description: LocalService contains configuration to customize
+                      the internal traffic policy service.
+                    properties:
+                      forceEnableLocalService:
+                        description: |-
+                          ForceEnableLocalService forces the creation of the internal traffic policy service to target the agent running on the local node.
+                          This parameter only applies to Kubernetes 1.21, where the feature is in alpha and is disabled by default.
+                          (On Kubernetes 1.22+, the feature entered beta and the internal traffic service is created by default, so this parameter is ignored.)
+                          Default: false
+                        type: boolean
+                      nameOverride:
+                        description: NameOverride defines the name of the internal
+                          traffic service to target the agent running on the local
+                          node.
+                        type: string
+                    type: object
+                  logLevel:
+                    description: |-
+                      LogLevel sets logging verbosity. This can be overridden by container.
+                      Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                      Default: 'info'
+                    type: string
+                  namespaceAnnotationsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Namespace Annotations to Datadog Tags.
+                      <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  namespaceLabelsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Namespace Labels to Datadog Tags.
+                      <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  networkPolicy:
+                    description: NetworkPolicy contains the network configuration.
+                    properties:
+                      create:
+                        description: Create defines whether to create a NetworkPolicy
+                          for the current deployment.
+                        type: boolean
+                      dnsSelectorEndpoints:
+                        description: DNSSelectorEndpoints defines the cilium selector
+                          of the DNS server entity.
+                        items:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      flavor:
+                        description: Flavor defines Which network policy to use.
+                        type: string
+                    type: object
+                  nodeLabelsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Node Labels to Datadog Tags.
+                      <KUBERNETES_NODE_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  originDetectionUnified:
+                    description: OriginDetectionUnified defines the origin detection
+                      unified mechanism behavior.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables unified mechanism for origin detection.
+                          Default: false
+                        type: boolean
+                    type: object
+                  podAnnotationsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Annotations to Datadog Tags.
+                      <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY>
+                    type: object
+                  podLabelsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Labels to Datadog Tags.
+                      <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  registry:
+                    description: |-
+                      Registry is the image registry to use for all Agent images.
+                      Use 'public.ecr.aws/datadog' for AWS ECR.
+                      Use 'datadoghq.azurecr.io' for Azure Container Registry.
+                      Use 'gcr.io/datadoghq' for Google Container Registry.
+                      Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
+                      Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
+                      Use 'docker.io/datadog' for DockerHub.
+                      Default: 'registry.datadoghq.com'
+                    type: string
+                  secretBackend:
+                    description: |-
+                      Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management
+                      See also: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md
+                    properties:
+                      args:
+                        description: List of arguments to pass to the command (space-separated
+                          strings).
+                        type: string
+                      command:
+                        description: |-
+                          The secret backend command to use. Datadog provides a pre-defined binary `/readsecret_multiple_providers.sh`.
+                          Read more about `/readsecret_multiple_providers.sh` at https://docs.datadoghq.com/agent/configuration/secrets-management/?tab=linux#script-for-reading-from-multiple-secret-providers.
+                        type: string
+                      config:
+                        additionalProperties:
+                          x-kubernetes-preserve-unknown-fields: true
+                        description: Additional configuration for the secret backend
+                          type.
+                        type: object
+                      enableGlobalPermissions:
+                        description: |-
+                          Whether to create a global permission allowing Datadog agents to read all Kubernetes secrets.
+                          Default: `false`.
+                        type: boolean
+                      refreshInterval:
+                        description: |-
+                          The refresh interval for secrets (0 disables refreshing).
+                          Default: `0`.
+                        format: int32
+                        type: integer
+                      roles:
+                        description: |-
+                          Roles for Datadog to read the specified secrets, replacing `enableGlobalPermissions`.
+                          They are defined as a list of namespace/secrets.
+                          Each defined namespace needs to be present in the DatadogAgent controller using `WATCH_NAMESPACE` or `DD_AGENT_WATCH_NAMESPACE`.
+                          See also: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md#how-to-deploy-the-agent-components-using-the-secret-backend-feature-with-datadogagent.
+                        items:
+                          description: SecretBackendRolesConfig provides configuration
+                            of the secrets Datadog agents can read for the SecretBackend
+                            feature
+                          properties:
+                            namespace:
+                              description: Namespace defines the namespace in which
+                                the secrets reside.
+                              type: string
+                            secrets:
+                              description: Secrets defines the list of secrets for
+                                which a role should be created.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                          - namespace
+                          - secrets
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      timeout:
+                        description: |-
+                          The command timeout in seconds.
+                          Default: `30`.
+                        format: int32
+                        type: integer
+                      type:
+                        description: |-
+                          The built-in secret backend type to use (e.g., `k8s.secrets`, `docker.secrets`, `aws.secrets`).
+                          Alternative to Command; when Type is set, the Agent uses the built-in backend to resolve secrets.
+                          Requires Agent 7.70+.
+                        type: string
+                    type: object
+                  site:
+                    description: |-
+                      Site is the Datadog intake site Agent data are sent to.
+                      Set to 'datadoghq.com' to send data to the US1 site (default).
+                      Set to 'datadoghq.eu' to send data to the EU site.
+                      Set to 'us3.datadoghq.com' to send data to the US3 site.
+                      Set to 'us5.datadoghq.com' to send data to the US5 site.
+                      Set to 'ddog-gov.com' to send data to the US1-FED site.
+                      Set to 'ap1.datadoghq.com' to send data to the AP1 site.
+                      Default: 'datadoghq.com'
+                    type: string
+                  tags:
+                    description: |-
+                      Tags contains a list of tags to attach to every metric, event and service check collected.
+                      Learn more about tagging: https://docs.datadoghq.com/tagging/
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  useFIPSAgent:
+                    description: |-
+                      UseFIPSAgent enables the FIPS flavor of the Agent. If 'true', the FIPS proxy will always be disabled.
+                      Default: 'false'
+                    type: boolean
+                  useVSock:
+                    description: |-
+                      UseVSock allows the use of VSock communication between the Agent and containerized workloads.
+                      Default: 'false'
+                    type: boolean
+                type: object
+              override:
+                additionalProperties:
+                  description: DatadogAgentComponentOverride is the generic description
+                    equivalent to a subset of the PodTemplate for a component.
+                  properties:
+                    affinity:
+                      description: If specified, the pod's scheduling constraints.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations provide annotations that are added
+                        to the different component (Datadog Agent, Cluster Agent,
+                        Cluster Check Runner) pods.
+                      type: object
+                    celWorkloadExclude:
+                      description: |-
+                        CELWorkloadExclude enables excluding workloads from monitoring using Common Expression Language (CEL).
+                        See https://docs.datadoghq.com/containers/guide/container-discovery-management
+                        (Requires Agent 7.73+ and Cluster Agent 7.73+)
+                      items:
+                        description: |-
+                          CelWorkloadExcludeConfig configures CEL-based filtering to exclude specific workloads
+                          from Agent collection.
+                        properties:
+                          products:
+                            description: Products specifies which products these exclusion
+                              rules apply to.
+                            items:
+                              description: |-
+                                Product defines which Datadog product(s) the CEL-based workload exclusion rules apply to.
+                                Use "global" to apply rules across all products, or specify individual products for granular control.
+                              enum:
+                              - metrics
+                              - logs
+                              - sbom
+                              - global
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          rules:
+                            description: Rules defines the CEL expressions used to
+                              identify workloads to exclude.
+                            properties:
+                              containers:
+                                description: Containers exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              kube_endpoints:
+                                description: KubeEndpoints exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              kube_services:
+                                description: KubeServices exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              pods:
+                                description: Pods exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              processes:
+                                description: Processes exclude rule
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    containers:
+                      additionalProperties:
+                        description: DatadogAgentGenericContainer is the generic structure
+                          describing any container's common configuration.
+                        properties:
+                          appArmorProfileName:
+                            description: AppArmorProfileName specifies an apparmor
+                              profile.
+                            type: string
+                          args:
+                            description: Args allows the specification of extra args
+                              to the `Command` parameter
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          command:
+                            description: Command allows the specification of a custom
+                              entrypoint for container
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          env:
+                            description: |-
+                              Specify additional environment variables in the container.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          healthPort:
+                            description: |-
+                              HealthPort of the container for the internal liveness probe.
+                              Must be the same as the Liveness/Readiness probes.
+                            format: int32
+                            type: integer
+                          livenessProbe:
+                            description: Configure the Liveness Probe of the container
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          logLevel:
+                            description: |-
+                              LogLevel sets logging verbosity (overrides global setting).
+                              Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                              Default: 'info'
+                            type: string
+                          name:
+                            description: Name of the container that is overridden
+                            type: string
+                          ports:
+                            description: |-
+                              Specify additional ports to be exposed by the container. Not specifying a port here
+                              DOES NOT prevent that port from being exposed.
+                              See https://pkg.go.dev/k8s.io/api/core/v1#Container documentation for more details.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          readinessProbe:
+                            description: Configure the Readiness Probe of the container
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: |-
+                              Specify the Request and Limits of the pods
+                              To get guaranteed QoS class, specify requests and limits equal.
+                              See also: http://kubernetes.io/docs/user-guide/compute-resources/
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          seccompConfig:
+                            description: |-
+                              Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation,
+                              use SecurityContext.
+                            properties:
+                              customProfile:
+                                description: |-
+                                  CustomProfile specifies a ConfigMap containing a custom Seccomp Profile.
+                                  ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items
+                                  must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.
+                                properties:
+                                  configData:
+                                    description: ConfigData corresponds to the configuration
+                                      file content.
+                                    type: string
+                                  configMap:
+                                    description: ConfigMap references an existing
+                                      ConfigMap with the configuration file content.
+                                    properties:
+                                      items:
+                                        description: Items maps a ConfigMap data `key`
+                                          to a file `path` mount.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - key
+                                        x-kubernetes-list-type: map
+                                      name:
+                                        description: Name is the name of the ConfigMap.
+                                        type: string
+                                    type: object
+                                type: object
+                              customRootPath:
+                                description: CustomRootPath specifies a custom Seccomp
+                                  Profile root location.
+                                type: string
+                            type: object
+                          securityContext:
+                            description: Container-level SecurityContext.
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: |-
+                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                  privileges than its parent process. This bool directly controls if
+                                  the no_new_privs flag will be set on the container process.
+                                  AllowPrivilegeEscalation is true always when the container is:
+                                  1) run as Privileged
+                                  2) has CAP_SYS_ADMIN
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              appArmorProfile:
+                                description: |-
+                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                  overrides the pod's appArmorProfile.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile loaded on the node that should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must match the loaded name of the profile.
+                                      Must be set if and only if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of AppArmor profile will be applied.
+                                      Valid options are:
+                                        Localhost - a profile pre-loaded on the node.
+                                        RuntimeDefault - the container runtime's default profile.
+                                        Unconfined - no AppArmor enforcement.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              capabilities:
+                                description: |-
+                                  The capabilities to add/drop when running containers.
+                                  Defaults to the default set of capabilities granted by the container runtime.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                description: |-
+                                  Run container in privileged mode.
+                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                  Defaults to false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: |-
+                                  procMount denotes the type of proc mount to use for the containers.
+                                  The default value is Default which uses the container runtime defaults for
+                                  readonly paths and masked paths.
+                                  This requires the ProcMountType feature flag to be enabled.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: |-
+                                  Whether this container has a read-only root filesystem.
+                                  Default is false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to the container.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: |-
+                                  The seccomp options to use by this container. If seccomp options are
+                                  provided at both the pod & container level, the container options
+                                  override the pod options.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options from the PodSecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Configure the Startup Probe of the container
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          volumeMounts:
+                            description: Specify additional volume mounts in the container.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                            x-kubernetes-list-type: map
+                        type: object
+                      description: |-
+                        Configure the basic configurations for each Agent container. Valid Agent container names are:
+                        `agent`, `cluster-agent`, `init-config`, `init-volume`, `process-agent`, `seccomp-setup`,
+                        `security-agent`, `system-probe`, and `trace-agent`.
+                      type: object
+                    createPodDisruptionBudget:
+                      description: |-
+                        Set CreatePodDisruptionBudget to true to create a PodDisruptionBudget for this component.
+                        Not applicable for the Node Agent. A Cluster Agent PDB is set with 1 minimum available pod, and a Cluster Checks Runner PDB is set with 1 maximum unavailable pod.
+                      type: boolean
+                    createRbac:
+                      description: Set CreateRbac to false to prevent automatic creation
+                        of Role/ClusterRole for this component
+                      type: boolean
+                    customConfigurations:
+                      additionalProperties:
+                        description: |-
+                          CustomConfig provides a place for custom configuration of the Agent or Cluster Agent, corresponding to datadog.yaml,
+                          system-probe.yaml, security-agent.yaml or datadog-cluster.yaml.
+                          The configuration can be provided in the ConfigData field as raw data, or referenced in a ConfigMap.
+                          Note: `ConfigData` and `ConfigMap` cannot be set together.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      description: |-
+                        CustomConfigurations specifies custom contents for `datadog.yaml`, `datadog-cluster.yaml`, `security-agent.yaml`, and `system-probe.yaml`.
+                        Each provided file replaces the corresponding default file from the Agent image without merging.
+                        Agent settings provided through environment variables take precedence over these files.
+                      type: object
+                    disabled:
+                      description: Disabled force disables a component.
+                      type: boolean
+                    dnsConfig:
+                      description: |-
+                        Specifies the DNS parameters of a pod.
+                        Parameters specified here will be merged to the generated DNS
+                        configuration based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: |-
+                            A list of DNS name server IP addresses.
+                            This will be appended to the base nameservers generated from DNSPolicy.
+                            Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        options:
+                          description: |-
+                            A list of DNS resolver options.
+                            This will be merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options given in Options
+                            will override those that appear in the base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: |-
+                                  Name is this DNS resolver option's name.
+                                  Required.
+                                type: string
+                              value:
+                                description: Value is this DNS resolver option's value.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        searches:
+                          description: |-
+                            A list of DNS search domains for host-name lookup.
+                            This will be appended to the base search paths generated from DNSPolicy.
+                            Duplicated search paths will be removed.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod.
+                        Defaults to "ClusterFirst".
+                        Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                        DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                        To have DNS options set along with hostNetwork, you have to specify DNS policy
+                        explicitly to 'ClusterFirstWithHostNet'.
+                      type: string
+                    env:
+                      description: |-
+                        Specify additional environment variables for all containers in this component
+                        Priority is Container > Component.
+                        See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    envFrom:
+                      description: |-
+                        EnvFrom specifies the ConfigMaps and Secrets to expose as environment variables.
+                        Priority is env > envFrom.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    extraChecksd:
+                      description: |-
+                        Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/
+                        See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
+                      properties:
+                        configDataMap:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            ConfigDataMap corresponds to the content of the configuration files.
+                            The key should be the filename the contents get mounted to; for instance check.py or check.yaml.
+                          type: object
+                        configMap:
+                          description: ConfigMap references an existing ConfigMap
+                            with the content of the configuration files.
+                          properties:
+                            items:
+                              description: Items maps a ConfigMap data `key` to a
+                                file `path` mount.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - key
+                              x-kubernetes-list-type: map
+                            name:
+                              description: Name is the name of the ConfigMap.
+                              type: string
+                          type: object
+                      type: object
+                    extraConfd:
+                      description: |-
+                        Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/.
+                        See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
+                      properties:
+                        configDataMap:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            ConfigDataMap corresponds to the content of the configuration files.
+                            The key should be the filename the contents get mounted to; for instance check.py or check.yaml.
+                          type: object
+                        configMap:
+                          description: ConfigMap references an existing ConfigMap
+                            with the content of the configuration files.
+                          properties:
+                            items:
+                              description: Items maps a ConfigMap data `key` to a
+                                file `path` mount.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - key
+                              x-kubernetes-list-type: map
+                            name:
+                              description: Name is the name of the ConfigMap.
+                              type: string
+                          type: object
+                      type: object
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace.
+                      type: boolean
+                    hostPID:
+                      description: Use the host's PID namespace.
+                      type: boolean
+                    image:
+                      description: The container image of the different components
+                        (Datadog Agent, Cluster Agent, Cluster Check Runner).
+                      properties:
+                        jmxEnabled:
+                          description: |-
+                            Define whether the Agent image should support JMX.
+                            To be used if the `Name` field does not correspond to a full image string.
+                          type: boolean
+                        name:
+                          description: |-
+                            Defines the Agent image name for the pod. You can provide this as:
+                            * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                            for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                            * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                            and `[key].image.jmxEnabled` are ignored.
+                            * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                              like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                          type: string
+                        pullPolicy:
+                          description: |-
+                            The Kubernetes pull policy:
+                            Use `Always`, `Never`, or `IfNotPresent`.
+                          type: string
+                        pullSecrets:
+                          description: |-
+                            It is possible to specify Docker registry credentials.
+                            See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        tag:
+                          description: |-
+                            Define the image tag to use.
+                            To be used if the `Name` field does not correspond to a full image string.
+                          type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalLabels provide labels that are added
+                        to the different component (Datadog Agent, Cluster Agent,
+                        Cluster Check Runner) pods.
+                      type: object
+                      x-kubernetes-map-type: granular
+                    name:
+                      description: Name overrides the default name for the resource
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        A map of key-value pairs. For this pod to run on a specific node, the node must have these key-value pairs as labels.
+                        See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                      type: object
+                    priorityClassName:
+                      description: |-
+                        If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
+                        are two special keywords which indicate the highest priorities with the former being the highest priority.
+                        Any other name must be defined by creating a PriorityClass object with that name. If not specified,
+                        the pod priority is default, or zero if there is no default.
+                      type: string
+                    replicas:
+                      description: |-
+                        Number of the replicas.
+                        Not applicable for a DaemonSet/ExtendedDaemonSet deployment
+                      format: int32
+                      type: integer
+                    runtimeClassName:
+                      description: |-
+                        If specified, indicates the pod's RuntimeClass kubelet should use to run the pod.
+                        If the named RuntimeClass does not exist, or the CRI cannot run the corresponding handler, the pod enters the Failed terminal phase.
+                        If no runtimeClassName is specified, the default RuntimeHandler is used, which is equivalent to the behavior when the RuntimeClass feature is disabled.
+                      type: string
+                    securityContext:
+                      description: Pod-level SecurityContext.
+                      properties:
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in
+                            addition to the container's primary GID and fsGroup (if specified).  If
+                            the SupplementalGroupsPolicy feature is enabled, the
+                            supplementalGroupsPolicy field determines whether these are in addition
+                            to or instead of any group memberships defined in the container image.
+                            If unspecified, no additional groups are added, though group memberships
+                            defined in the container image may still be used, depending on the
+                            supplementalGroupsPolicy field.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          description: |-
+                            Defines how supplemental groups of the first container processes are calculated.
+                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                            and the container runtime must implement support for this feature.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccountAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: Sets the ServiceAccountAnnotations used by this
+                        component.
+                      type: object
+                    serviceAccountName:
+                      description: |-
+                        Sets the ServiceAccount used by this component.
+                        Ignored if the field CreateRbac is true.
+                      type: string
+                    tolerations:
+                      description: Configure the component tolerations.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    topologySpreadConstraints:
+                      description: |-
+                        TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                        domains. Scheduler will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    updateStrategy:
+                      description: The deployment strategy to use to replace existing
+                        pods with new ones.
+                      properties:
+                        rollingUpdate:
+                          description: Configure the rolling update strategy of the
+                            Deployment or DaemonSet.
+                          properties:
+                            maxSurge:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                                Kubernetes API documentation for additional details.
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                The maximum number of pods that can be unavailable during the update.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                Refer to the Kubernetes API documentation for additional details..
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          description: |-
+                            Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                            or "Recreate" for Deployments
+                          type: string
+                      type: object
+                    volumes:
+                      description: Specify additional volumes in the different components
+                        (Datadog Agent, Cluster Agent, Cluster Check Runner).
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: |-
+                              awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: string
+                              partition:
+                                description: |-
+                                  partition is the partition in the volume that you want to mount.
+                                  If omitted, the default is to mount by volume name.
+                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: |-
+                                  readOnly value true will force the readOnly setting in VolumeMounts.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: boolean
+                              volumeID:
+                                description: |-
+                                  volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                default: ext4
+                                description: |-
+                                  fsType is Filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                default: false
+                                description: |-
+                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
+                            properties:
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                            properties:
+                              monitors:
+                                description: |-
+                                  monitors is Required: Monitors is a collection of Ceph monitors
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: boolean
+                              secretFile:
+                                description: |-
+                                  secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: string
+                              secretRef:
+                                description: |-
+                                  secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                description: |-
+                                  user is optional: User is the rados user name, default is admin
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: |-
+                              cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is optional: points to a secret object containing parameters used to connect
+                                  to OpenStack.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeID:
+                                description: |-
+                                  volumeID used to identify the volume in cinder.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode is optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: |-
+                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                  ConfigMap will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers.
+                            properties:
+                              driver:
+                                description: |-
+                                  driver is the name of the CSI driver that handles this volume.
+                                  Consult with your admin for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: |-
+                                  fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the associated CSI driver
+                                  which will determine the default filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: |-
+                                  nodePublishSecretRef is a reference to the secret object containing
+                                  sensitive information to pass to the CSI driver to complete the CSI
+                                  NodePublishVolume and NodeUnpublishVolume calls.
+                                  This field is optional, and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all secret references are passed.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              readOnly:
+                                description: |-
+                                  readOnly specifies a read-only configuration for the volume.
+                                  Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  volumeAttributes stores driver-specific properties that are passed to the CSI
+                                  driver. Consult your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  Optional: mode bits to use on created files by default. Must be a
+                                  Optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name, namespace
+                                        and uid are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    mode:
+                                      description: |-
+                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          emptyDir:
+                            description: |-
+                              emptyDir represents a temporary directory that shares a pod's lifetime.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                            properties:
+                              medium:
+                                description: |-
+                                  medium represents what type of storage medium should back this directory.
+                                  The default is "" which means to use the node's default medium.
+                                  Must be an empty string (default) or Memory.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                  The size limit is also applicable for memory medium.
+                                  The maximum usage on memory medium EmptyDir would be the minimum value between
+                                  the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                  The default is nil which means that the limit is undefined.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver.
+                              The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                              and deleted when the pod is removed.
+
+                              Use this if:
+                              a) the volume is only needed while the pod runs,
+                              b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and
+                              d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific
+                              APIs for volumes that persist for longer than the lifecycle
+                              of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                              be used that way - see the documentation of the driver for
+                              more information.
+
+                              A pod can use both types of ephemeral volumes and
+                              persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume.
+                                  The pod in which this EphemeralVolumeSource is embedded will be the
+                                  owner of the PVC, i.e. the PVC will be deleted together with the
+                                  pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                  `<volume name>` is the name from the `PodSpec.Volumes` array
+                                  entry. Pod validation will reject the pod if the concatenated name
+                                  is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod
+                                  will *not* be used for the pod to avoid using an unrelated
+                                  volume by mistake. Starting the pod is then blocked until
+                                  the unrelated PVC is removed. If such a pre-created PVC is
+                                  meant to be used by the pod, the PVC has to updated with an
+                                  owner reference to the pod once the pod exists. Normally
+                                  this should not be necessary, but it may be useful when
+                                  manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes
+                                  to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      May contain labels and annotations that will be copied into the PVC
+                                      when creating it. No other fields are allowed and will be rejected during
+                                      validation.
+                                    type: object
+                                  spec:
+                                    description: |-
+                                      The specification for the PersistentVolumeClaim. The entire content is
+                                      copied unchanged into the PVC that gets created from this
+                                      template. The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              wwids:
+                                description: |-
+                                  wwids Optional: FC volume world wide identifiers (wwids)
+                                  Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          flexVolume:
+                            description: |-
+                              flexVolume represents a generic volume resource that is
+                              provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is Optional: secretRef is reference to the secret object containing
+                                  sensitive information to pass to the plugin scripts. This may be
+                                  empty if no secret object is specified. If the secret object
+                                  contains more than one secret, all secrets are passed to the plugin
+                                  scripts.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                            properties:
+                              datasetName:
+                                description: |-
+                                  datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                  should be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: |-
+                              gcePersistentDisk represents a GCE Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: string
+                              partition:
+                                description: |-
+                                  partition is the partition in the volume that you want to mount.
+                                  If omitted, the default is to mount by volume name.
+                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: |-
+                                  pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: |-
+                              gitRepo represents a git repository at a particular revision.
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                              into the Pod's container.
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                  git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                  the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: |-
+                              glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                            properties:
+                              endpoints:
+                                description: endpoints is the endpoint name that details
+                                  Glusterfs topology.
+                                type: string
+                              path:
+                                description: |-
+                                  path is the Glusterfs volume path.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: |-
+                              hostPath represents a pre-existing file or directory on the host
+                              machine that is directly exposed to the container. This is generally
+                              used for system agents or other privileged things that are allowed
+                              to see the host machine. Most containers will NOT need this.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                            properties:
+                              path:
+                                description: |-
+                                  path of the directory on the host.
+                                  If the path is a symlink, it will follow the link to the real path.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                type: string
+                              type:
+                                description: |-
+                                  type for HostPath Volume
+                                  Defaults to ""
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          image:
+                            description: |-
+                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                              The volume will be mounted read-only (ro) and non-executable files (noexec).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          iscsi:
+                            description: |-
+                              iscsi represents an ISCSI Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                type: string
+                              initiatorName:
+                                description: |-
+                                  initiatorName is the custom iSCSI Initiator Name.
+                                  If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                  <target portal>:<volume name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                default: default
+                                description: |-
+                                  iscsiInterface is the interface Name that uses an iSCSI transport.
+                                  Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: |-
+                                  portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              targetPortal:
+                                description: |-
+                                  targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and 3260).
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            description: |-
+                              name of the volume.
+                              Must be a DNS_LABEL and unique within the pod.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          nfs:
+                            description: |-
+                              nfs represents an NFS mount on the host that shares a pod's lifetime
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                            properties:
+                              path:
+                                description: |-
+                                  path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the NFS export to be mounted with read-only permissions.
+                                  Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: boolean
+                              server:
+                                description: |-
+                                  server is the hostname or IP address of the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            description: |-
+                              persistentVolumeClaimVolumeSource represents a reference to a
+                              PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                            properties:
+                              claimName:
+                                description: |-
+                                  claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                              is on.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fSType represents the filesystem type to mount
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode are the mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: |-
+                                  sources is the list of volume projections. Each entry in this list
+                                  handles one source.
+                                items:
+                                  description: |-
+                                    Projection that may be projected along with other supported volume types.
+                                    Exactly one of these fields must be set.
+                                  properties:
+                                    clusterTrustBundle:
+                                      description: |-
+                                        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                        of ClusterTrustBundle objects in an auto-updating file.
+
+                                        Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                        ClusterTrustBundle objects can either be selected by name, or by the
+                                        combination of signer name and a label selector.
+
+                                        Kubelet performs aggressive normalization of the PEM contents written
+                                        into the pod filesystem.  Esoteric PEM features such as inter-block
+                                        comments and block headers are stripped.  Certificates are deduplicated.
+                                        The ordering of certificates within the file is arbitrary, and Kubelet
+                                        may change the order over time.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            Select all ClusterTrustBundles that match this label selector.  Only has
+                                            effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                            interpreted as "match nothing".  If set but empty, interpreted as "match
+                                            everything".
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        name:
+                                          description: |-
+                                            Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                            with signerName and labelSelector.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                            aren't available.  If using name, then the named ClusterTrustBundle is
+                                            allowed not to exist.  If using signerName, then the combination of
+                                            signerName and labelSelector is allowed to match zero
+                                            ClusterTrustBundles.
+                                          type: boolean
+                                        path:
+                                          description: Relative path from the volume
+                                            root to write the bundle.
+                                          type: string
+                                        signerName:
+                                          description: |-
+                                            Select all ClusterTrustBundles that match this signer name.
+                                            Mutually-exclusive with name.  The contents of all selected
+                                            ClusterTrustBundles will be unified and deduplicated.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name, namespace and uid
+                                                  are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will
+                                            be addressed to this signer.
+                                          type: string
+                                        userAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            userAnnotations allow pod authors to pass additional information to
+                                            the signer implementation.  Kubernetes does not restrict or validate this
+                                            metadata in any way.
+
+                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                            the PodCertificateRequest objects that Kubelet creates.
+
+                                            Entries are subject to the same validation as object metadata annotations,
+                                            with the addition that all keys must be domain-prefixed. No restrictions
+                                            are placed on values, except an overall size limitation on the entire field.
+
+                                            Signers should document the keys and values they support. Signers should
+                                            deny requests that contain keys they do not recognize.
+                                          type: object
+                                      required:
+                                      - keyType
+                                      - signerName
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: |-
+                                            audience is the intended audience of the token. A recipient of a token
+                                            must identify itself with an identifier specified in the audience of the
+                                            token, and otherwise should reject the token. The audience defaults to the
+                                            identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: |-
+                                            expirationSeconds is the requested duration of validity of the service
+                                            account token. As the token approaches expiration, the kubelet volume
+                                            plugin will proactively rotate the service account token. The kubelet will
+                                            start trying to rotate the token if the token is older than 80 percent of
+                                            its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the path relative to the mount point of the file to project the
+                                            token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          quobyte:
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                            properties:
+                              group:
+                                description: |-
+                                  group to map volume access to
+                                  Default is no group
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: |-
+                                  registry represents a single or multiple Quobyte Registry services
+                                  specified as a string as host:port pair (multiple entries are separated with commas)
+                                  which acts as the central registry for volumes
+                                type: string
+                              tenant:
+                                description: |-
+                                  tenant owning the given Quobyte volume in the Backend
+                                  Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: |-
+                                  user to map volume access to
+                                  Defaults to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: |-
+                              rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                type: string
+                              image:
+                                description: |-
+                                  image is the rados image name.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              keyring:
+                                default: /etc/ceph/keyring
+                                description: |-
+                                  keyring is the path to key ring for RBDUser.
+                                  Default is /etc/ceph/keyring.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              monitors:
+                                description: |-
+                                  monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              pool:
+                                default: rbd
+                                description: |-
+                                  pool is the rados pool name.
+                                  Default is rbd.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is name of the authentication secret for RBDUser. If provided
+                                  overrides keyring.
+                                  Default is nil.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                default: admin
+                                description: |-
+                                  user is the rados user name.
+                                  Default is admin.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                            properties:
+                              fsType:
+                                default: xfs
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs".
+                                  Default is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef references to the secret for ScaleIO user and other
+                                  sensitive information. If this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                default: ThinProvisioned
+                                description: |-
+                                  storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: |-
+                                  volumeName is the name of a volume already created in the ScaleIO system
+                                  that is associated with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          secret:
+                            description: |-
+                              secret represents a secret that should populate this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values
+                                  for mode bits. Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: |-
+                                  items If unspecified, each key-value pair in the Data field of the referenced
+                                  Secret will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: |-
+                                  secretName is the name of the secret in the pod's namespace to use.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: string
+                            type: object
+                          storageos:
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef specifies the secret to use for obtaining the StorageOS API
+                                  credentials.  If not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeName:
+                                description: |-
+                                  volumeName is the human-readable name of the StorageOS volume.  Volume
+                                  names are only unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: |-
+                                  volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                  namespace is specified then the Pod's namespace will be used.  This allows the
+                                  Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                  Set VolumeName to any name to override the default behaviour.
+                                  Set to "default" if you are not using namespaces within StorageOS.
+                                  Namespaces that do not pre-exist within StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  type: object
+                description: Override the default configurations of the agents
+                type: object
+            type: object
+          status:
+            description: DatadogAgentInternalStatus defines the observed state of
+              DatadogAgentInternal
+            properties:
+              agent:
+                description: The actual state of the Agent as a daemonset or an extended
+                  daemonset.
+                properties:
+                  available:
+                    description: Number of available pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  current:
+                    description: Number of current pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the DaemonSet.
+                    type: string
+                  daemonsetName:
+                    description: DaemonsetName corresponds to the name of the created
+                      DaemonSet.
+                    type: string
+                  desired:
+                    description: Number of desired pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  ready:
+                    description: Number of ready pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the DaemonSet state.
+                    type: string
+                  status:
+                    description: Status corresponds to the DaemonSet computed status.
+                    type: string
+                  upToDate:
+                    description: Number of up to date pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                required:
+                - available
+                - current
+                - desired
+                - ready
+                - upToDate
+                type: object
+              clusterAgent:
+                description: The actual state of the Cluster Agent as a deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the Deployment.
+                    type: string
+                  deploymentName:
+                    description: DeploymentName corresponds to the name of the Deployment.
+                    type: string
+                  generatedToken:
+                    description: |-
+                      GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is
+                      enabled.
+                    type: string
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  readyReplicas:
+                    description: Total number of ready pods targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the Deployment state.
+                    type: string
+                  status:
+                    description: Status corresponds to the Deployment computed status.
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this Deployment. This is the total number of
+                      pods that are still required for the Deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+              clusterChecksRunner:
+                description: The actual state of the Cluster Checks Runner as a deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the Deployment.
+                    type: string
+                  deploymentName:
+                    description: DeploymentName corresponds to the name of the Deployment.
+                    type: string
+                  generatedToken:
+                    description: |-
+                      GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is
+                      enabled.
+                    type: string
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  readyReplicas:
+                    description: Total number of ready pods targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the Deployment state.
+                    type: string
+                  status:
+                    description: Status corresponds to the Deployment computed status.
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this Deployment. This is the total number of
+                      pods that are still required for the Deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+              conditions:
+                description: Conditions Represents the latest available observations
+                  of a DatadogAgent's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              otelAgentGateway:
+                description: The actual state of the OTel Agent Gateway as a deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the Deployment.
+                    type: string
+                  deploymentName:
+                    description: DeploymentName corresponds to the name of the Deployment.
+                    type: string
+                  generatedToken:
+                    description: |-
+                      GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is
+                      enabled.
+                    type: string
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  readyReplicas:
+                    description: Total number of ready pods targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the Deployment state.
+                    type: string
+                  status:
+                    description: Status corresponds to the Deployment computed status.
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this Deployment. This is the total number of
+                      pods that are still required for the Deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+              remoteConfigConfiguration:
+                description: RemoteConfigConfiguration stores the configuration received
+                  from RemoteConfig.
+                properties:
+                  features:
+                    description: DatadogFeatures are features running on the Agent
+                      and Cluster Agent.
+                    properties:
+                      admissionController:
+                        description: AdmissionController configuration.
+                        properties:
+                          agentCommunicationMode:
+                            description: |-
+                              AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent.
+                              It can be "hostip", "service", or "socket".
+                            type: string
+                          agentSidecarInjection:
+                            description: AgentSidecarInjection contains Agent sidecar
+                              injection configurations.
+                            properties:
+                              clusterAgentCommunicationEnabled:
+                                description: |-
+                                  ClusterAgentCommunicationEnabled enables communication between Agent sidecars and the Cluster Agent.
+                                  Default : true
+                                type: boolean
+                              clusterAgentTlsVerification:
+                                description: ClusterAgentTLSVerification configures
+                                  TLS verification for Agent sidecar to Cluster Agent
+                                  communication.
+                                properties:
+                                  copyCaConfigMap:
+                                    description: |-
+                                      CopyCaConfigMap enables automatic creation of a ConfigMap containing the Cluster Agent's CA certificate
+                                      in namespaces where sidecar injection occurs.
+                                      Default: false
+                                    type: boolean
+                                  enabled:
+                                    description: |-
+                                      Enabled enables TLS verification for agent sidecars communicating with the Cluster Agent.
+                                      Default: false
+                                    type: boolean
+                                type: object
+                              enabled:
+                                description: |-
+                                  Enabled enables Sidecar injections.
+                                  Default: false
+                                type: boolean
+                              image:
+                                description: Image overrides the default Agent image
+                                  name and tag for the Agent sidecar.
+                                properties:
+                                  jmxEnabled:
+                                    description: |-
+                                      Define whether the Agent image should support JMX.
+                                      To be used if the `Name` field does not correspond to a full image string.
+                                    type: boolean
+                                  name:
+                                    description: |-
+                                      Defines the Agent image name for the pod. You can provide this as:
+                                      * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                      for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                      * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                      and `[key].image.jmxEnabled` are ignored.
+                                      * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                        like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                                    type: string
+                                  pullPolicy:
+                                    description: |-
+                                      The Kubernetes pull policy:
+                                      Use `Always`, `Never`, or `IfNotPresent`.
+                                    type: string
+                                  pullSecrets:
+                                    description: |-
+                                      It is possible to specify Docker registry credentials.
+                                      See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                                    items:
+                                      description: |-
+                                        LocalObjectReference contains enough information to let you locate the
+                                        referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                  tag:
+                                    description: |-
+                                      Define the image tag to use.
+                                      To be used if the `Name` field does not correspond to a full image string.
+                                    type: string
+                                type: object
+                              profiles:
+                                description: Profiles define the sidecar configuration
+                                  override. Only one profile is supported.
+                                items:
+                                  description: Profile defines a sidecar configuration
+                                    override.
+                                  properties:
+                                    env:
+                                      description: EnvVars specifies the environment
+                                        variables for the profile.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    resources:
+                                      description: ResourceRequirements specifies
+                                        the resource requirements for the profile.
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: SecurityContext specifies the security
+                                        context for the profile.
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              provider:
+                                description: |-
+                                  Provider is used to add infrastructure provider-specific configurations to the Agent sidecar.
+                                  Currently only "fargate" is supported.
+                                  To use the feature in other environments (including local testing) omit the config.
+                                  See also: https://docs.datadoghq.com/integrations/eks_fargate
+                                type: string
+                              registry:
+                                description: Registry overrides the default registry
+                                  for the sidecar Agent.
+                                type: string
+                              selectors:
+                                description: Selectors define the pod selector for
+                                  sidecar injection. Only one rule is supported.
+                                items:
+                                  description: Selectors define a pod selector for
+                                    sidecar injection.
+                                  properties:
+                                    namespaceSelector:
+                                      description: NamespaceSelector specifies the
+                                        label selector for namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    objectSelector:
+                                      description: ObjectSelector specifies the label
+                                        selector for objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          cwsInstrumentation:
+                            description: CWSInstrumentation holds the CWS Instrumentation
+                              endpoint configuration
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable the CWS Instrumentation admission controller endpoint.
+                                  Default: false
+                                type: boolean
+                              mode:
+                                description: |-
+                                  Mode defines the behavior of the CWS Instrumentation endpoint, and can be either "init_container" or "remote_copy".
+                                  Default: "remote_copy"
+                                type: string
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller.
+                              Default: true
+                            type: boolean
+                          failurePolicy:
+                            description: FailurePolicy determines how unrecognized
+                              and timeout errors are handled.
+                            type: string
+                          kubernetesAdmissionEvents:
+                            description: KubernetesAdmissionEvents holds the Kubernetes
+                              Admission Events configuration.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable the Kubernetes Admission Events feature.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          mutateUnlabelled:
+                            description: |-
+                              MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'.
+                              Default: false
+                            type: boolean
+                          mutation:
+                            description: Mutation contains Admission Controller mutation
+                              configurations.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the Admission Controller mutation webhook.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          probe:
+                            description: Probe holds the admission controller connectivity
+                              probe configuration.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the admission controller connectivity probe.
+                                  The probe periodically sends dry-run ConfigMap creation requests to verify the
+                                  webhook is reachable from the API server. Requires Cluster Agent 7.78.0+.
+                                  Default: true
+                                type: boolean
+                              gracePeriod:
+                                description: |-
+                                  GracePeriod is the number of seconds to wait at startup before the first probe.
+                                  Default: 60
+                                format: int32
+                                type: integer
+                              interval:
+                                description: |-
+                                  Interval is the number of seconds between probe executions.
+                                  Default: 60
+                                format: int32
+                                type: integer
+                            type: object
+                          registry:
+                            description: Registry defines an image registry for the
+                              admission controller.
+                            type: string
+                          serviceName:
+                            description: ServiceName corresponds to the webhook service
+                              name.
+                            type: string
+                          validation:
+                            description: Validation contains Admission Controller
+                              validation configurations.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the Admission Controller validation webhook.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          webhookName:
+                            description: |-
+                              WebhookName is a custom name for the MutatingWebhookConfiguration.
+                              Default: "datadog-webhook"
+                            type: string
+                        type: object
+                      apm:
+                        description: APM (Application Performance Monitoring) configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Application Performance Monitoring.
+                              Default: true
+                            type: boolean
+                          errorTrackingStandalone:
+                            description: |-
+                              ErrorTrackingStandalone contains the configuration for the Error Tracking standalone feature.
+                              Feature is in preview.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enables Error Tracking for backend services.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          hostPortConfig:
+                            description: |-
+                              HostPortConfig contains host port configuration.
+                              Enabled Default: false
+                              Port Default: 8126
+                            properties:
+                              enabled:
+                                description: Enabled enables host port configuration
+                                type: boolean
+                              hostPort:
+                                description: |-
+                                  Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                  If HostNetwork is enabled, this value must match the ContainerPort.
+                                format: int32
+                                type: integer
+                            type: object
+                          instrumentation:
+                            description: |-
+                              SingleStepInstrumentation allows the agent to inject the Datadog APM libraries into all pods in the cluster.
+                              Feature is in beta.
+                              See also: https://docs.datadoghq.com/tracing/trace_collection/single-step-apm
+                              Enabled Default: false
+                            properties:
+                              disabledNamespaces:
+                                description: DisabledNamespaces disables injecting
+                                  the Datadog APM libraries into pods in specific
+                                  namespaces.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enabled enables injecting the Datadog APM libraries into all pods in the cluster.
+                                  Default: false
+                                type: boolean
+                              enabledNamespaces:
+                                description: EnabledNamespaces enables injecting the
+                                  Datadog APM libraries into pods in specific namespaces.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              injectionMode:
+                                description: |-
+                                  InjectionMode is the injection mode to use for libraries injection.
+                                  Valid values are: "auto", "init_container", "csi" (experimental, requires Cluster Agent 7.76.0+ and Datadog CSI Driver 1.2.0+), "image_volume" (experimental, requires Cluster Agent 7.77.0+).
+                                  Empty by default so the Cluster Agent can apply its own defaults.
+                                enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                                type: string
+                              injector:
+                                description: Injector configures the APM Injector.
+                                properties:
+                                  imageTag:
+                                    description: |-
+                                      Set the image tag to use for the APM Injector.
+                                      (Requires Cluster Agent 7.57.0+)
+                                    type: string
+                                type: object
+                              languageDetection:
+                                description: |-
+                                  LanguageDetection detects languages and adds them as annotations on Deployments, but does not use these languages for injecting libraries to workload pods.
+                                  (Requires Agent 7.52.0+ and Cluster Agent 7.52.0+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables Language Detection to automatically detect languages of user workloads (beta).
+                                      Requires SingleStepInstrumentation.Enabled to be true.
+                                      Default: true
+                                    type: boolean
+                                type: object
+                              libVersions:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.
+                                  <Library>: <Version>
+                                  ex: "java": "v1.18.0"
+                                type: object
+                              targets:
+                                description: |-
+                                  Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
+                                  used. If no target matches, the auto instrumentation will not be applied.
+                                  (Requires Cluster Agent 7.64.0+)
+                                items:
+                                  description: SSITarget is a rule to apply the auto
+                                    instrumentation to a specific workload using the
+                                    pod and namespace selectors.
+                                  properties:
+                                    ddTraceConfigs:
+                                      description: |-
+                                        TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+                                        as environment variables in addition to the injected tracer.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    ddTraceVersions:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
+                                        name and the value is the version to inject.
+                                      type: object
+                                    name:
+                                      description: Name is the name of the target.
+                                        It will be appended to the pod annotations
+                                        to identify the target that was used.
+                                      type: string
+                                    namespaceSelector:
+                                      description: |-
+                                        NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
+                                        be used in conjunction with the Selector to match the pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: |-
+                                            MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
+                                            expressions are ANDed. This cannot be used with MatchNames.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
+                                            ANDed. This cannot be used with MatchNames.
+                                          type: object
+                                        matchNames:
+                                          description: MatchNames is a list of namespace
+                                            names to match. If empty, all namespaces
+                                            are matched.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    podSelector:
+                                      description: |-
+                                        PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
+                                        conjunction with the NamespaceSelector to match the pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                            type: object
+                          unixDomainSocketConfig:
+                            description: |-
+                              UnixDomainSocketConfig contains socket configuration.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                              Enabled Default: true
+                              Path Default: `/var/run/datadog/apm.socket`
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Unix Domain Socket.
+                                  Default: true
+                                type: boolean
+                              path:
+                                description: Path defines the socket path used when
+                                  enabled.
+                                type: string
+                            type: object
+                        type: object
+                      asm:
+                        description: ASM (Application Security Management) configuration.
+                        properties:
+                          iast:
+                            description: |-
+                              IAST configures Interactive Application Security Testing.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Interactive Application Security Testing (IAST).
+                                  Default: false
+                                type: boolean
+                            type: object
+                          sca:
+                            description: |-
+                              SCA configures Software Composition Analysis.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Software Composition Analysis (SCA).
+                                  Default: false
+                                type: boolean
+                            type: object
+                          threats:
+                            description: |-
+                              Threats configures ASM App & API Protection.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables ASM App & API Protection.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      autoscaling:
+                        description: Autoscaling configuration.
+                        properties:
+                          cluster:
+                            description: Cluster contains the configuration for the
+                              cluster autoscaling product.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the cluster autoscaling product.
+                                  (Requires Cluster Agent 7.74.0+)
+                                  Default: false
+                                type: boolean
+                              spot:
+                                description: |-
+                                  Spot contains the configuration for the spot instance scheduling sub-feature.
+                                  Requires cluster autoscaling to be enabled.
+                                  (Requires Cluster Agent 7.79.0+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables the cluster spot scheduling product.
+                                      (Requires Cluster Agent 7.79.0+)
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                          workload:
+                            description: Workload contains the configuration for the
+                              workload autoscaling product.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the workload autoscaling product.
+                                  Default: false
+                                type: boolean
+                              inPlaceVerticalScaling:
+                                description: |-
+                                  InPlaceVerticalScaling contains the configuration for the in-place vertical scaling sub-feature.
+                                  Requires workload autoscaling to be enabled.
+                                  (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables in-place vertical scaling for workload autoscaling.
+                                      (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                      clusterChecks:
+                        description: ClusterChecks configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables Cluster Checks scheduling in the Cluster Agent.
+                              Default: true
+                            type: boolean
+                          useClusterChecksRunners:
+                            description: |-
+                              Enabled enables Cluster Checks Runners to run all Cluster Checks.
+                              Default: false
+                            type: boolean
+                        type: object
+                      controlPlaneMonitoring:
+                        description: ControlPlaneMonitoring configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables control plane monitoring checks in the cluster agent.
+                              Default: true
+                            type: boolean
+                        type: object
+                      cspm:
+                        description: CSPM (Cloud Security Posture Management) configuration.
+                        properties:
+                          checkInterval:
+                            description: CheckInterval defines the check interval.
+                            type: string
+                          customBenchmarks:
+                            description: |-
+                              CustomBenchmarks contains CSPM benchmarks.
+                              The content of the ConfigMap will be merged with the benchmarks bundled with the agent.
+                              Any benchmarks with the same name as those existing in the agent will take precedence.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Security Posture Management, including Docker and Kubernetes benchmarks.
+                              Default: false
+                            type: boolean
+                          hostBenchmarks:
+                            description: HostBenchmarks contains configuration for
+                              host benchmarks.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Linux host benchmarks. Requires `features.cspm.enabled` to be set to `true`.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          runInSystemProbe:
+                            description: |-
+                              RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                              This is an experimental feature. Contact support before using.
+                              Default: false
+                            type: boolean
+                        type: object
+                      cws:
+                        description: CWS (Cloud Workload Security) configuration.
+                        properties:
+                          customPolicies:
+                            description: |-
+                              CustomPolicies contains security policies.
+                              The content of the ConfigMap will be merged with the policies bundled with the agent.
+                              Any policies with the same name as those existing in the agent will take precedence.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          directSendFromSystemProbe:
+                            description: |-
+                              DirectSendFromSystemProbe configures CWS to send payloads directly from the system-probe, without using the security-agent.
+                              This is an experimental feature. Contact support before using.
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Workload Security.
+                              Default: false
+                            type: boolean
+                          enforcement:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Enforcement for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          network:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Cloud Workload Security Network detections.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          remoteConfiguration:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Remote Configuration for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          securityProfiles:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Security Profiles collection for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          syscallMonitorEnabled:
+                            description: |-
+                              SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only).
+                              Default: false
+                            type: boolean
+                        type: object
+                      dataPlane:
+                        description: |-
+                          DataPlane configuration for the Agent Data Plane.
+                          Agent Data Plane is a high-performance sidecar that handles data ingestion.
+                        properties:
+                          dogstatsd:
+                            description: Dogstatsd configures DogStatsD handling by
+                              the Data Plane.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled configures the Data Plane to handle DogStatsD traffic.
+                                  When set to false, DogStatsD is handled by the Core Agent instead.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the Data Plane.
+                              Default: false
+                            type: boolean
+                        type: object
+                      dogstatsd:
+                        description: Dogstatsd configuration.
+                        properties:
+                          hostPortConfig:
+                            description: |-
+                              HostPortConfig contains host port configuration.
+                              Enabled Default: false
+                              Port Default: 8125
+                            properties:
+                              enabled:
+                                description: Enabled enables host port configuration
+                                type: boolean
+                              hostPort:
+                                description: |-
+                                  Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                  If HostNetwork is enabled, this value must match the ContainerPort.
+                                format: int32
+                                type: integer
+                            type: object
+                          mapperProfiles:
+                            description: |-
+                              Configure the Dogstasd Mapper Profiles.
+                              Can be passed as raw data or via a json encoded string in a config map.
+                              See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          nonLocalTraffic:
+                            description: |-
+                              NonLocalTraffic enables non-local traffic for Dogstatsd.
+                              Default: true
+                            type: boolean
+                          originDetectionEnabled:
+                            description: |-
+                              OriginDetectionEnabled enables origin detection for container tagging.
+                              See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+                            type: boolean
+                          tagCardinality:
+                            description: |-
+                              TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                              This setting only applies when OriginDetectionEnabled is true.
+                              See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
+                              Cardinality default: low
+                            type: string
+                          unixDomainSocketConfig:
+                            description: |-
+                              UnixDomainSocketConfig contains socket configuration.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                              Enabled Default: true
+                              Path Default: `/var/run/datadog/dsd.socket`
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Unix Domain Socket.
+                                  Default: true
+                                type: boolean
+                              path:
+                                description: Path defines the socket path used when
+                                  enabled.
+                                type: string
+                            type: object
+                        type: object
+                      dynamicInstrumentation:
+                        description: DynamicInstrumentation configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Dynamic Instrumentation system probe module.
+                              Default: false
+                            type: boolean
+                        type: object
+                      ebpfCheck:
+                        description: EBPFCheck configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the eBPF check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      eventCollection:
+                        description: EventCollection configuration.
+                        properties:
+                          collectKubernetesEvents:
+                            description: |-
+                              CollectKubernetesEvents enables Kubernetes event collection.
+                              Default: true
+                            type: boolean
+                          collectedEventTypes:
+                            description: |-
+                              CollectedEventTypes defines the list of events to collect when UnbundleEvents is enabled.
+                              Default:
+                              [
+                              {"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},
+                              {"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},
+                              {"kind":"CronJob","reasons":["SawCompletedJob"]}
+                              ]
+                            items:
+                              description: EventTypes defines the kind and reasons
+                                of events to collect.
+                              properties:
+                                kind:
+                                  description: 'Kind is the kind of event to collect.
+                                    (ex: Pod, Node, CronJob)'
+                                  type: string
+                                reasons:
+                                  description: 'Reasons is a list of event reasons
+                                    to collect. (ex: Failed, BackOff, Unhealthy)'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - kind
+                              - reasons
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          unbundleEvents:
+                            description: |-
+                              UnbundleEvents enables collection of Kubernetes events as individual events.
+                              Default: false
+                            type: boolean
+                        type: object
+                      externalMetricsServer:
+                        description: ExternalMetricsServer configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the External Metrics Server.
+                              Default: false
+                            type: boolean
+                          endpoint:
+                            description: |-
+                              Override the API endpoint for the External Metrics Server.
+                              URL Default: "https://app.datadoghq.com".
+                            properties:
+                              credentials:
+                                description: Credentials defines the Datadog credentials
+                                  used to submit data to/query data from Datadog.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey configures your Datadog API key.
+                                      See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                                    type: string
+                                  apiSecret:
+                                    description: |-
+                                      APISecret references an existing Secret which stores the API key instead of creating a new one.
+                                      If set, this parameter takes precedence over "APIKey".
+                                    properties:
+                                      keyName:
+                                        description: KeyName is the key of the secret
+                                          to use.
+                                        type: string
+                                      secretName:
+                                        description: SecretName is the name of the
+                                          secret.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                  appKey:
+                                    description: |-
+                                      AppKey configures your Datadog application key.
+                                      If you are using features.externalMetricsServer.enabled = true, you must set
+                                      a Datadog application key for read access to your metrics.
+                                    type: string
+                                  appSecret:
+                                    description: |-
+                                      AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                                      If set, this parameter takes precedence over "AppKey".
+                                    properties:
+                                      keyName:
+                                        description: KeyName is the key of the secret
+                                          to use.
+                                        type: string
+                                      secretName:
+                                        description: SecretName is the name of the
+                                          secret.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                type: object
+                              url:
+                                description: URL defines the endpoint URL.
+                                type: string
+                            type: object
+                          port:
+                            description: |-
+                              Port specifies the metricsProvider External Metrics Server service port.
+                              Default: 8443
+                            format: int32
+                            type: integer
+                          registerAPIService:
+                            description: |-
+                              RegisterAPIService registers the External Metrics endpoint as an APIService
+                              Default: true
+                            type: boolean
+                          useDatadogMetrics:
+                            description: |-
+                              UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries).
+                              Default: true
+                            type: boolean
+                          wpaController:
+                            description: |-
+                              WPAController enables the informer and controller of the Watermark Pod Autoscaler.
+                              NOTE: The Watermark Pod Autoscaler controller needs to be installed.
+                              See also: https://github.com/DataDog/watermarkpodautoscaler.
+                              Default: false
+                            type: boolean
+                        type: object
+                      gpu:
+                        description: GPU monitoring
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables GPU monitoring core check.
+                              Default: false
+                            type: boolean
+                          patchCgroupPermissions:
+                            description: |-
+                              PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case
+                              the container runtime is not properly configured and the Agent containers lose access to GPU devices.
+                              Default: false
+                            type: boolean
+                          privilegedMode:
+                            description: |-
+                              PrivilegedMode enables GPU Probe module in System Probe.
+                              Default: false
+                            type: boolean
+                          requiredRuntimeClassName:
+                            description: |-
+                              PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature.
+                              If the value is an empty string, the runtime class is not set.
+                              Default: nvidia
+                            type: string
+                        type: object
+                      helmCheck:
+                        description: HelmCheck configuration.
+                        properties:
+                          collectEvents:
+                            description: |-
+                              CollectEvents set to `true` enables event collection in the Helm check
+                              (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+)
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables the Helm check.
+                              Default: false
+                            type: boolean
+                          valuesAsTags:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ValuesAsTags collects Helm values from a release and uses them as tags
+                              (Requires Agent and Cluster Agent 7.40.0+).
+                              Default: {}
+                            type: object
+                        type: object
+                      kubeStateMetricsCore:
+                        description: KubeStateMetricsCore check configuration.
+                        properties:
+                          collectCrMetrics:
+                            description: |-
+                              `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                              The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                              The exact structure and existing fields of each item in this list can be found in:
+                              https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                            items:
+                              description: Resource configures a custom resource for
+                                metric generation.
+                              properties:
+                                commonLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: CommonLabels are added to all metrics.
+                                  type: object
+                                groupVersionKind:
+                                  description: GroupVersionKind of the custom resource
+                                    to be monitored.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  type: object
+                                labelsFromPath:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: LabelsFromPath adds additional labels
+                                    where the value is taken from a field in the resource.
+                                  type: object
+                                metricNamePrefix:
+                                  description: |-
+                                    MetricNamePrefix defines a prefix for all metrics of the resource.
+                                    If set to "", no prefix will be added.
+                                    Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                  type: string
+                                metrics:
+                                  description: Metrics are the custom resource fields
+                                    to be collected.
+                                  items:
+                                    description: Generator describes a unique metric
+                                      name.
+                                    properties:
+                                      commonLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonLabels are added to all
+                                          metrics.
+                                        type: object
+                                      each:
+                                        description: Each targets a value or values
+                                          from the resource.
+                                        properties:
+                                          gauge:
+                                            description: Gauge defines a gauge metric.
+                                            properties:
+                                              labelFromKey:
+                                                description: LabelFromKey adds a label
+                                                  with the given name if Path is an
+                                                  object. The label value will be
+                                                  the object key.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              nilIsZero:
+                                                description: NilIsZero indicates that
+                                                  if a value is nil it will be treated
+                                                  as zero value.
+                                                type: boolean
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              valueFrom:
+                                                description: ValueFrom is the path
+                                                  to a numeric field under Path that
+                                                  will be the metric value.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          info:
+                                            description: Info defines an info metric.
+                                            properties:
+                                              labelFromKey:
+                                                description: LabelFromKey adds a label
+                                                  with the given name if Path is an
+                                                  object. The label value will be
+                                                  the object key.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          stateSet:
+                                            description: StateSet defines a state
+                                              set metric.
+                                            properties:
+                                              labelName:
+                                                description: LabelName is the key
+                                                  of the label which is used for each
+                                                  entry in List to expose the value.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              list:
+                                                description: List is the list of values
+                                                  to expose a value for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              valueFrom:
+                                                description: ValueFrom is the subpath
+                                                  to compare the list to.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          type:
+                                            description: Type defines the type of
+                                              the metric.
+                                            type: string
+                                        type: object
+                                      help:
+                                        description: Help text for the metric.
+                                        type: string
+                                      labelsFromPath:
+                                        additionalProperties:
+                                          items:
+                                            type: string
+                                          type: array
+                                        description: LabelsFromPath adds additional
+                                          labels where the value is taken from a field
+                                          in the resource.
+                                        type: object
+                                      name:
+                                        description: Name of the metric. Subject to
+                                          prefixing based on the configuration of
+                                          the Resource.
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourcePlural:
+                                  description: ResourcePlural sets the plural name
+                                    of the resource. Defaults to the plural version
+                                    of the Kind according to flect.Pluralize.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Kube State Metrics Core.
+                              Default: true
+                            type: boolean
+                        type: object
+                      kubernetesActions:
+                        description: KubernetesActions configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Kubernetes Actions feature on the Cluster Agent.
+                              Default: false
+                            type: boolean
+                        type: object
+                      liveContainerCollection:
+                        description: LiveContainerCollection configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables container collection for the Live Container View.
+                              Default: true
+                            type: boolean
+                        type: object
+                      liveProcessCollection:
+                        description: LiveProcessCollection configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Process monitoring.
+                              Default: false
+                            type: boolean
+                          scrubProcessArguments:
+                            description: |-
+                              ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ).
+                              Default: true
+                            type: boolean
+                          stripProcessArguments:
+                            description: |-
+                              StripProcessArguments enables stripping of all process arguments.
+                              Default: false
+                            type: boolean
+                        type: object
+                      logCollection:
+                        description: LogCollection configuration.
+                        properties:
+                          autoMultiLineDetection:
+                            description: |-
+                              AutoMultiLineDetection allows the Agent to detect and aggregate common multi-line logs automatically.
+                              See also: https://docs.datadoghq.com/agent/logs/auto_multiline_detection/
+                            type: boolean
+                          containerCollectAll:
+                            description: |-
+                              ContainerCollectAll enables Log collection from all containers.
+                              Default: false
+                            type: boolean
+                          containerCollectUsingFiles:
+                            description: |-
+                              ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API.
+                              Collecting logs from files is usually the most efficient way of collecting logs.
+                              See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                              Default: true
+                            type: boolean
+                          containerLogsPath:
+                            description: |-
+                              ContainerLogsPath allows log collection from the container log path.
+                              Set to a different path if you are not using the Docker runtime.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
+                              Default: `/var/lib/docker/containers`
+                            type: string
+                          containerSymlinksPath:
+                            description: |-
+                              ContainerSymlinksPath allows log collection to use symbolic links in this directory to validate container ID -> pod.
+                              Default: `/var/log/containers`
+                            type: string
+                          enabled:
+                            description: |-
+                              Enabled enables Log collection.
+                              Default: false
+                            type: boolean
+                          openFilesLimit:
+                            description: |-
+                              OpenFilesLimit sets the maximum number of log files that the Datadog Agent tails.
+                              Increasing this limit can increase resource consumption of the Agent.
+                              See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                              Default: 100
+                            format: int32
+                            type: integer
+                          podLogsPath:
+                            description: |-
+                              PodLogsPath allows log collection from a pod log path.
+                              Default: `/var/log/pods`
+                            type: string
+                          tempStoragePath:
+                            description: |-
+                              TempStoragePath (always mounted from the host) is used by the Agent to store information about processed log files.
+                              If the Agent is restarted, it starts tailing the log files immediately.
+                              Default: `/var/lib/datadog-agent/logs`
+                            type: string
+                        type: object
+                      npm:
+                        description: NPM (Network Performance Monitoring) configuration.
+                        properties:
+                          collectDNSStats:
+                            description: |-
+                              CollectDNSStats enables DNS stat collection.
+                              Default: false
+                            type: boolean
+                          enableConntrack:
+                            description: |-
+                              EnableConntrack enables the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data.
+                              See also: http://conntrack-tools.netfilter.org/
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables Network Performance Monitoring.
+                              Default: false
+                            type: boolean
+                        type: object
+                      oomKill:
+                        description: OOMKill configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the OOMKill eBPF-based check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      orchestratorExplorer:
+                        description: OrchestratorExplorer check configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Orchestrator Explorer check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          customResources:
+                            description: |-
+                              `CustomResources` defines custom resources for the orchestrator explorer to collect.
+                              Each item should follow the convention `group/version/kind`. For example, `datadoghq.com/v1alpha1/datadogmetrics`.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          ddUrl:
+                            description: |-
+                              Override the API endpoint for the Orchestrator Explorer.
+                              URL Default: "https://orchestrator.datadoghq.com".
+                            type: string
+                          enabled:
+                            description: |-
+                              Enabled enables the Orchestrator Explorer.
+                              Default: true
+                            type: boolean
+                          extraTags:
+                            description: |-
+                              Additional tags to associate with the collected data in the form of `a b c`.
+                              This is a Cluster Agent option distinct from DD_TAGS that is used in the Orchestrator Explorer.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          scrubContainers:
+                            description: |-
+                              ScrubContainers enables scrubbing of sensitive container data (passwords, tokens, etc. ).
+                              Default: true
+                            type: boolean
+                        type: object
+                      otelAgentGateway:
+                        description: OtelAgentGateway configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default OTel Agent Gateway.
+                              This must point to a ConfigMap containing a valid OTel collector configuration.
+                              When passing a configmap, file name *must* be otel-gateway-config.yaml.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the OTel Agent Gateway.
+                              Default: false
+                            type: boolean
+                          featureGates:
+                            description: |-
+                              FeatureGates are the feature gates to pass to the OTel collector as a comma-separated list.
+                              Example: "component.UseLocalHostAsDefaultHost,connector.datadogconnector.NativeIngest"
+                            type: string
+                          ports:
+                            description: |-
+                              Ports contains the ports that the OTel Collector is listening on.
+                              Defaults: otel-grpc:4317 / otel-http:4318.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      otelCollector:
+                        description: OtelCollector configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                              When passing a configmap, file name *must* be otel-config.yaml.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          coreConfig:
+                            description: OTelCollector Config Relevant to the Core
+                              agent
+                            properties:
+                              enabled:
+                                description: Enabled marks otelcollector as enabled
+                                  in core agent.
+                                type: boolean
+                              extensionTimeout:
+                                description: |-
+                                  Extension URL provides the timout of the ddflareextension to
+                                  the core agent.
+                                type: integer
+                              extensionURL:
+                                description: |-
+                                  Extension URL provides the URL of the ddflareextension to
+                                  the core agent.
+                                type: string
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the OTel Agent.
+                              Default: false
+                            type: boolean
+                          ports:
+                            description: |-
+                              Ports contains the ports for the otel-agent.
+                              Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317
+                              or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http).
+                              If not, this will lead to a port conflict.
+                              This limitation will be lifted once annotations support is removed.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      otlp:
+                        description: OTLP ingest configuration
+                        properties:
+                          receiver:
+                            description: Receiver contains configuration for the OTLP
+                              ingest receiver.
+                            properties:
+                              protocols:
+                                description: Protocols contains configuration for
+                                  the OTLP ingest receiver protocols.
+                                properties:
+                                  grpc:
+                                    description: GRPC contains configuration for the
+                                      OTLP ingest OTLP/gRPC receiver.
+                                    properties:
+                                      enabled:
+                                        description: Enable the OTLP/gRPC endpoint.
+                                          Host port is enabled by default and can
+                                          be disabled.
+                                        type: boolean
+                                      endpoint:
+                                        description: |-
+                                          Endpoint for OTLP/gRPC.
+                                          gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+                                          The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`).
+                                          Default: `0.0.0.0:4317`.
+                                        type: string
+                                      hostPortConfig:
+                                        description: |-
+                                          Enable hostPort for OTLP/gRPC
+                                          Default: true
+                                        properties:
+                                          enabled:
+                                            description: Enabled enables host port
+                                              configuration
+                                            type: boolean
+                                          hostPort:
+                                            description: |-
+                                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                              If HostNetwork is enabled, this value must match the ContainerPort.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  http:
+                                    description: HTTP contains configuration for the
+                                      OTLP ingest OTLP/HTTP receiver.
+                                    properties:
+                                      enabled:
+                                        description: Enable the OTLP/HTTP endpoint.
+                                          Host port is enabled by default and can
+                                          be disabled.
+                                        type: boolean
+                                      endpoint:
+                                        description: |-
+                                          Endpoint for OTLP/HTTP.
+                                          Default: '0.0.0.0:4318'.
+                                        type: string
+                                      hostPortConfig:
+                                        description: |-
+                                          Enable hostPorts for OTLP/HTTP
+                                          Default: true
+                                        properties:
+                                          enabled:
+                                            description: Enabled enables host port
+                                              configuration
+                                            type: boolean
+                                          hostPort:
+                                            description: |-
+                                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                              If HostNetwork is enabled, this value must match the ContainerPort.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      processDiscovery:
+                        description: ProcessDiscovery configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Process Discovery check in the Agent.
+                              Default: true
+                            type: boolean
+                        type: object
+                      prometheusScrape:
+                        description: PrometheusScrape configuration.
+                        properties:
+                          additionalConfigs:
+                            description: AdditionalConfigs allows adding advanced
+                              Prometheus check configurations with custom discovery
+                              rules.
+                            type: string
+                          enableServiceEndpoints:
+                            description: |-
+                              EnableServiceEndpoints enables generating dedicated checks for service endpoints.
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enable autodiscovery of pods and services exposing Prometheus metrics.
+                              Default: false
+                            type: boolean
+                          version:
+                            description: |-
+                              Version specifies the version of the OpenMetrics check.
+                              Default: 2
+                            type: integer
+                        type: object
+                      remoteConfiguration:
+                        description: Remote Configuration configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable this option to activate Remote Configuration.
+                              Default: true
+                            type: boolean
+                        type: object
+                      sbom:
+                        description: SBOM collection configuration.
+                        properties:
+                          containerImage:
+                            description: SBOMTypeConfig contains configuration for
+                              a SBOM collection type.
+                            properties:
+                              analyzers:
+                                description: Analyzers to use for SBOM collection.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM collection.
+                                  Default: false
+                                type: boolean
+                              overlayFSDirectScan:
+                                description: |-
+                                  Enable this option to enable experimental overlayFS direct scan.
+                                  Default: false
+                                type: boolean
+                              uncompressedLayersSupport:
+                                description: |-
+                                  Enable this option to enable support for uncompressed layers.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                          enrichment:
+                            description: SBOMEnrichmentConfig contains SBOM enrichment
+                              configuration.
+                            properties:
+                              usage:
+                                description: Usage contains configuration for the
+                                  "package in use" enrichment.
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enable this option to activate SBOM enrichment with runtime "package in use" detection.
+                                      Requires system-probe for eBPF-based file access tracking.
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                          host:
+                            description: SBOMTypeConfig contains configuration for
+                              a SBOM collection type.
+                            properties:
+                              analyzers:
+                                description: Analyzers to use for SBOM collection.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM collection.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      serviceDiscovery:
+                        description: ServiceDiscovery
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the service discovery check.
+                              Default: true when omitted and the node Agent image is >= 7.78.0. Otherwise false.
+                              If the image version cannot be determined, it is treated as latest.
+                            type: boolean
+                        type: object
+                      tcpQueueLength:
+                        description: TCPQueueLength configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the TCP queue length eBPF-based check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      usm:
+                        description: USM (Universal Service Monitoring) configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Universal Service Monitoring.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogagentprofiles.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogagentprofiles.yaml
@@ -1,0 +1,9222 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogagentprofiles.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgentProfile
+    listKind: DatadogAgentProfileList
+    plural: datadogagentprofiles
+    shortNames:
+    - dap
+    singular: datadogagentprofile
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.valid
+      name: valid
+      type: string
+    - jsonPath: .status.applied
+      name: applied
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogAgentProfile is the Schema for the datadogagentprofiles
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogAgentProfileSpec defines the desired state of DatadogAgentProfile
+            properties:
+              config:
+                description: DatadogAgentSpec defines the desired state of DatadogAgent
+                properties:
+                  features:
+                    description: Features running on the Agent and Cluster Agent
+                    properties:
+                      admissionController:
+                        description: AdmissionController configuration.
+                        properties:
+                          agentCommunicationMode:
+                            description: |-
+                              AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent.
+                              It can be "hostip", "service", or "socket".
+                            type: string
+                          agentSidecarInjection:
+                            description: AgentSidecarInjection contains Agent sidecar
+                              injection configurations.
+                            properties:
+                              clusterAgentCommunicationEnabled:
+                                description: |-
+                                  ClusterAgentCommunicationEnabled enables communication between Agent sidecars and the Cluster Agent.
+                                  Default : true
+                                type: boolean
+                              clusterAgentTlsVerification:
+                                description: ClusterAgentTLSVerification configures
+                                  TLS verification for Agent sidecar to Cluster Agent
+                                  communication.
+                                properties:
+                                  copyCaConfigMap:
+                                    description: |-
+                                      CopyCaConfigMap enables automatic creation of a ConfigMap containing the Cluster Agent's CA certificate
+                                      in namespaces where sidecar injection occurs.
+                                      Default: false
+                                    type: boolean
+                                  enabled:
+                                    description: |-
+                                      Enabled enables TLS verification for agent sidecars communicating with the Cluster Agent.
+                                      Default: false
+                                    type: boolean
+                                type: object
+                              enabled:
+                                description: |-
+                                  Enabled enables Sidecar injections.
+                                  Default: false
+                                type: boolean
+                              image:
+                                description: Image overrides the default Agent image
+                                  name and tag for the Agent sidecar.
+                                properties:
+                                  jmxEnabled:
+                                    description: |-
+                                      Define whether the Agent image should support JMX.
+                                      To be used if the `Name` field does not correspond to a full image string.
+                                    type: boolean
+                                  name:
+                                    description: |-
+                                      Defines the Agent image name for the pod. You can provide this as:
+                                      * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                      for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                      * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                      and `[key].image.jmxEnabled` are ignored.
+                                      * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                        like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                                    type: string
+                                  pullPolicy:
+                                    description: |-
+                                      The Kubernetes pull policy:
+                                      Use `Always`, `Never`, or `IfNotPresent`.
+                                    type: string
+                                  pullSecrets:
+                                    description: |-
+                                      It is possible to specify Docker registry credentials.
+                                      See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                                    items:
+                                      description: |-
+                                        LocalObjectReference contains enough information to let you locate the
+                                        referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                  tag:
+                                    description: |-
+                                      Define the image tag to use.
+                                      To be used if the `Name` field does not correspond to a full image string.
+                                    type: string
+                                type: object
+                              profiles:
+                                description: Profiles define the sidecar configuration
+                                  override. Only one profile is supported.
+                                items:
+                                  description: Profile defines a sidecar configuration
+                                    override.
+                                  properties:
+                                    env:
+                                      description: EnvVars specifies the environment
+                                        variables for the profile.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    resources:
+                                      description: ResourceRequirements specifies
+                                        the resource requirements for the profile.
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: SecurityContext specifies the security
+                                        context for the profile.
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              provider:
+                                description: |-
+                                  Provider is used to add infrastructure provider-specific configurations to the Agent sidecar.
+                                  Currently only "fargate" is supported.
+                                  To use the feature in other environments (including local testing) omit the config.
+                                  See also: https://docs.datadoghq.com/integrations/eks_fargate
+                                type: string
+                              registry:
+                                description: Registry overrides the default registry
+                                  for the sidecar Agent.
+                                type: string
+                              selectors:
+                                description: Selectors define the pod selector for
+                                  sidecar injection. Only one rule is supported.
+                                items:
+                                  description: Selectors define a pod selector for
+                                    sidecar injection.
+                                  properties:
+                                    namespaceSelector:
+                                      description: NamespaceSelector specifies the
+                                        label selector for namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    objectSelector:
+                                      description: ObjectSelector specifies the label
+                                        selector for objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          cwsInstrumentation:
+                            description: CWSInstrumentation holds the CWS Instrumentation
+                              endpoint configuration
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable the CWS Instrumentation admission controller endpoint.
+                                  Default: false
+                                type: boolean
+                              mode:
+                                description: |-
+                                  Mode defines the behavior of the CWS Instrumentation endpoint, and can be either "init_container" or "remote_copy".
+                                  Default: "remote_copy"
+                                type: string
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller.
+                              Default: true
+                            type: boolean
+                          failurePolicy:
+                            description: FailurePolicy determines how unrecognized
+                              and timeout errors are handled.
+                            type: string
+                          kubernetesAdmissionEvents:
+                            description: KubernetesAdmissionEvents holds the Kubernetes
+                              Admission Events configuration.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable the Kubernetes Admission Events feature.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          mutateUnlabelled:
+                            description: |-
+                              MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'.
+                              Default: false
+                            type: boolean
+                          mutation:
+                            description: Mutation contains Admission Controller mutation
+                              configurations.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the Admission Controller mutation webhook.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          probe:
+                            description: Probe holds the admission controller connectivity
+                              probe configuration.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the admission controller connectivity probe.
+                                  The probe periodically sends dry-run ConfigMap creation requests to verify the
+                                  webhook is reachable from the API server. Requires Cluster Agent 7.78.0+.
+                                  Default: true
+                                type: boolean
+                              gracePeriod:
+                                description: |-
+                                  GracePeriod is the number of seconds to wait at startup before the first probe.
+                                  Default: 60
+                                format: int32
+                                type: integer
+                              interval:
+                                description: |-
+                                  Interval is the number of seconds between probe executions.
+                                  Default: 60
+                                format: int32
+                                type: integer
+                            type: object
+                          registry:
+                            description: Registry defines an image registry for the
+                              admission controller.
+                            type: string
+                          serviceName:
+                            description: ServiceName corresponds to the webhook service
+                              name.
+                            type: string
+                          validation:
+                            description: Validation contains Admission Controller
+                              validation configurations.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the Admission Controller validation webhook.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          webhookName:
+                            description: |-
+                              WebhookName is a custom name for the MutatingWebhookConfiguration.
+                              Default: "datadog-webhook"
+                            type: string
+                        type: object
+                      apm:
+                        description: APM (Application Performance Monitoring) configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Application Performance Monitoring.
+                              Default: true
+                            type: boolean
+                          errorTrackingStandalone:
+                            description: |-
+                              ErrorTrackingStandalone contains the configuration for the Error Tracking standalone feature.
+                              Feature is in preview.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enables Error Tracking for backend services.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          hostPortConfig:
+                            description: |-
+                              HostPortConfig contains host port configuration.
+                              Enabled Default: false
+                              Port Default: 8126
+                            properties:
+                              enabled:
+                                description: Enabled enables host port configuration
+                                type: boolean
+                              hostPort:
+                                description: |-
+                                  Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                  If HostNetwork is enabled, this value must match the ContainerPort.
+                                format: int32
+                                type: integer
+                            type: object
+                          instrumentation:
+                            description: |-
+                              SingleStepInstrumentation allows the agent to inject the Datadog APM libraries into all pods in the cluster.
+                              Feature is in beta.
+                              See also: https://docs.datadoghq.com/tracing/trace_collection/single-step-apm
+                              Enabled Default: false
+                            properties:
+                              disabledNamespaces:
+                                description: DisabledNamespaces disables injecting
+                                  the Datadog APM libraries into pods in specific
+                                  namespaces.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enabled enables injecting the Datadog APM libraries into all pods in the cluster.
+                                  Default: false
+                                type: boolean
+                              enabledNamespaces:
+                                description: EnabledNamespaces enables injecting the
+                                  Datadog APM libraries into pods in specific namespaces.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              injectionMode:
+                                description: |-
+                                  InjectionMode is the injection mode to use for libraries injection.
+                                  Valid values are: "auto", "init_container", "csi" (experimental, requires Cluster Agent 7.76.0+ and Datadog CSI Driver 1.2.0+), "image_volume" (experimental, requires Cluster Agent 7.77.0+).
+                                  Empty by default so the Cluster Agent can apply its own defaults.
+                                enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                                type: string
+                              injector:
+                                description: Injector configures the APM Injector.
+                                properties:
+                                  imageTag:
+                                    description: |-
+                                      Set the image tag to use for the APM Injector.
+                                      (Requires Cluster Agent 7.57.0+)
+                                    type: string
+                                type: object
+                              languageDetection:
+                                description: |-
+                                  LanguageDetection detects languages and adds them as annotations on Deployments, but does not use these languages for injecting libraries to workload pods.
+                                  (Requires Agent 7.52.0+ and Cluster Agent 7.52.0+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables Language Detection to automatically detect languages of user workloads (beta).
+                                      Requires SingleStepInstrumentation.Enabled to be true.
+                                      Default: true
+                                    type: boolean
+                                type: object
+                              libVersions:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.
+                                  <Library>: <Version>
+                                  ex: "java": "v1.18.0"
+                                type: object
+                              targets:
+                                description: |-
+                                  Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
+                                  used. If no target matches, the auto instrumentation will not be applied.
+                                  (Requires Cluster Agent 7.64.0+)
+                                items:
+                                  description: SSITarget is a rule to apply the auto
+                                    instrumentation to a specific workload using the
+                                    pod and namespace selectors.
+                                  properties:
+                                    ddTraceConfigs:
+                                      description: |-
+                                        TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+                                        as environment variables in addition to the injected tracer.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    ddTraceVersions:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
+                                        name and the value is the version to inject.
+                                      type: object
+                                    name:
+                                      description: Name is the name of the target.
+                                        It will be appended to the pod annotations
+                                        to identify the target that was used.
+                                      type: string
+                                    namespaceSelector:
+                                      description: |-
+                                        NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
+                                        be used in conjunction with the Selector to match the pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: |-
+                                            MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
+                                            expressions are ANDed. This cannot be used with MatchNames.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
+                                            ANDed. This cannot be used with MatchNames.
+                                          type: object
+                                        matchNames:
+                                          description: MatchNames is a list of namespace
+                                            names to match. If empty, all namespaces
+                                            are matched.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    podSelector:
+                                      description: |-
+                                        PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
+                                        conjunction with the NamespaceSelector to match the pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                            type: object
+                          unixDomainSocketConfig:
+                            description: |-
+                              UnixDomainSocketConfig contains socket configuration.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                              Enabled Default: true
+                              Path Default: `/var/run/datadog/apm.socket`
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Unix Domain Socket.
+                                  Default: true
+                                type: boolean
+                              path:
+                                description: Path defines the socket path used when
+                                  enabled.
+                                type: string
+                            type: object
+                        type: object
+                      asm:
+                        description: ASM (Application Security Management) configuration.
+                        properties:
+                          iast:
+                            description: |-
+                              IAST configures Interactive Application Security Testing.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Interactive Application Security Testing (IAST).
+                                  Default: false
+                                type: boolean
+                            type: object
+                          sca:
+                            description: |-
+                              SCA configures Software Composition Analysis.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Software Composition Analysis (SCA).
+                                  Default: false
+                                type: boolean
+                            type: object
+                          threats:
+                            description: |-
+                              Threats configures ASM App & API Protection.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables ASM App & API Protection.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      autoscaling:
+                        description: Autoscaling configuration.
+                        properties:
+                          cluster:
+                            description: Cluster contains the configuration for the
+                              cluster autoscaling product.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the cluster autoscaling product.
+                                  (Requires Cluster Agent 7.74.0+)
+                                  Default: false
+                                type: boolean
+                              spot:
+                                description: |-
+                                  Spot contains the configuration for the spot instance scheduling sub-feature.
+                                  Requires cluster autoscaling to be enabled.
+                                  (Requires Cluster Agent 7.79.0+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables the cluster spot scheduling product.
+                                      (Requires Cluster Agent 7.79.0+)
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                          workload:
+                            description: Workload contains the configuration for the
+                              workload autoscaling product.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the workload autoscaling product.
+                                  Default: false
+                                type: boolean
+                              inPlaceVerticalScaling:
+                                description: |-
+                                  InPlaceVerticalScaling contains the configuration for the in-place vertical scaling sub-feature.
+                                  Requires workload autoscaling to be enabled.
+                                  (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables in-place vertical scaling for workload autoscaling.
+                                      (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                      clusterChecks:
+                        description: ClusterChecks configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables Cluster Checks scheduling in the Cluster Agent.
+                              Default: true
+                            type: boolean
+                          useClusterChecksRunners:
+                            description: |-
+                              Enabled enables Cluster Checks Runners to run all Cluster Checks.
+                              Default: false
+                            type: boolean
+                        type: object
+                      controlPlaneMonitoring:
+                        description: ControlPlaneMonitoring configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables control plane monitoring checks in the cluster agent.
+                              Default: true
+                            type: boolean
+                        type: object
+                      cspm:
+                        description: CSPM (Cloud Security Posture Management) configuration.
+                        properties:
+                          checkInterval:
+                            description: CheckInterval defines the check interval.
+                            type: string
+                          customBenchmarks:
+                            description: |-
+                              CustomBenchmarks contains CSPM benchmarks.
+                              The content of the ConfigMap will be merged with the benchmarks bundled with the agent.
+                              Any benchmarks with the same name as those existing in the agent will take precedence.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Security Posture Management, including Docker and Kubernetes benchmarks.
+                              Default: false
+                            type: boolean
+                          hostBenchmarks:
+                            description: HostBenchmarks contains configuration for
+                              host benchmarks.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Linux host benchmarks. Requires `features.cspm.enabled` to be set to `true`.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          runInSystemProbe:
+                            description: |-
+                              RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                              This is an experimental feature. Contact support before using.
+                              Default: false
+                            type: boolean
+                        type: object
+                      cws:
+                        description: CWS (Cloud Workload Security) configuration.
+                        properties:
+                          customPolicies:
+                            description: |-
+                              CustomPolicies contains security policies.
+                              The content of the ConfigMap will be merged with the policies bundled with the agent.
+                              Any policies with the same name as those existing in the agent will take precedence.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          directSendFromSystemProbe:
+                            description: |-
+                              DirectSendFromSystemProbe configures CWS to send payloads directly from the system-probe, without using the security-agent.
+                              This is an experimental feature. Contact support before using.
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Workload Security.
+                              Default: false
+                            type: boolean
+                          enforcement:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Enforcement for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          network:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Cloud Workload Security Network detections.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          remoteConfiguration:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Remote Configuration for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          securityProfiles:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Security Profiles collection for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          syscallMonitorEnabled:
+                            description: |-
+                              SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only).
+                              Default: false
+                            type: boolean
+                        type: object
+                      dataPlane:
+                        description: |-
+                          DataPlane configuration for the Agent Data Plane.
+                          Agent Data Plane is a high-performance sidecar that handles data ingestion.
+                        properties:
+                          dogstatsd:
+                            description: Dogstatsd configures DogStatsD handling by
+                              the Data Plane.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled configures the Data Plane to handle DogStatsD traffic.
+                                  When set to false, DogStatsD is handled by the Core Agent instead.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the Data Plane.
+                              Default: false
+                            type: boolean
+                        type: object
+                      dogstatsd:
+                        description: Dogstatsd configuration.
+                        properties:
+                          hostPortConfig:
+                            description: |-
+                              HostPortConfig contains host port configuration.
+                              Enabled Default: false
+                              Port Default: 8125
+                            properties:
+                              enabled:
+                                description: Enabled enables host port configuration
+                                type: boolean
+                              hostPort:
+                                description: |-
+                                  Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                  If HostNetwork is enabled, this value must match the ContainerPort.
+                                format: int32
+                                type: integer
+                            type: object
+                          mapperProfiles:
+                            description: |-
+                              Configure the Dogstasd Mapper Profiles.
+                              Can be passed as raw data or via a json encoded string in a config map.
+                              See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          nonLocalTraffic:
+                            description: |-
+                              NonLocalTraffic enables non-local traffic for Dogstatsd.
+                              Default: true
+                            type: boolean
+                          originDetectionEnabled:
+                            description: |-
+                              OriginDetectionEnabled enables origin detection for container tagging.
+                              See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+                            type: boolean
+                          tagCardinality:
+                            description: |-
+                              TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                              This setting only applies when OriginDetectionEnabled is true.
+                              See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
+                              Cardinality default: low
+                            type: string
+                          unixDomainSocketConfig:
+                            description: |-
+                              UnixDomainSocketConfig contains socket configuration.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                              Enabled Default: true
+                              Path Default: `/var/run/datadog/dsd.socket`
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Unix Domain Socket.
+                                  Default: true
+                                type: boolean
+                              path:
+                                description: Path defines the socket path used when
+                                  enabled.
+                                type: string
+                            type: object
+                        type: object
+                      dynamicInstrumentation:
+                        description: DynamicInstrumentation configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Dynamic Instrumentation system probe module.
+                              Default: false
+                            type: boolean
+                        type: object
+                      ebpfCheck:
+                        description: EBPFCheck configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the eBPF check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      eventCollection:
+                        description: EventCollection configuration.
+                        properties:
+                          collectKubernetesEvents:
+                            description: |-
+                              CollectKubernetesEvents enables Kubernetes event collection.
+                              Default: true
+                            type: boolean
+                          collectedEventTypes:
+                            description: |-
+                              CollectedEventTypes defines the list of events to collect when UnbundleEvents is enabled.
+                              Default:
+                              [
+                              {"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},
+                              {"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},
+                              {"kind":"CronJob","reasons":["SawCompletedJob"]}
+                              ]
+                            items:
+                              description: EventTypes defines the kind and reasons
+                                of events to collect.
+                              properties:
+                                kind:
+                                  description: 'Kind is the kind of event to collect.
+                                    (ex: Pod, Node, CronJob)'
+                                  type: string
+                                reasons:
+                                  description: 'Reasons is a list of event reasons
+                                    to collect. (ex: Failed, BackOff, Unhealthy)'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - kind
+                              - reasons
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          unbundleEvents:
+                            description: |-
+                              UnbundleEvents enables collection of Kubernetes events as individual events.
+                              Default: false
+                            type: boolean
+                        type: object
+                      externalMetricsServer:
+                        description: ExternalMetricsServer configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the External Metrics Server.
+                              Default: false
+                            type: boolean
+                          endpoint:
+                            description: |-
+                              Override the API endpoint for the External Metrics Server.
+                              URL Default: "https://app.datadoghq.com".
+                            properties:
+                              credentials:
+                                description: Credentials defines the Datadog credentials
+                                  used to submit data to/query data from Datadog.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey configures your Datadog API key.
+                                      See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                                    type: string
+                                  apiSecret:
+                                    description: |-
+                                      APISecret references an existing Secret which stores the API key instead of creating a new one.
+                                      If set, this parameter takes precedence over "APIKey".
+                                    properties:
+                                      keyName:
+                                        description: KeyName is the key of the secret
+                                          to use.
+                                        type: string
+                                      secretName:
+                                        description: SecretName is the name of the
+                                          secret.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                  appKey:
+                                    description: |-
+                                      AppKey configures your Datadog application key.
+                                      If you are using features.externalMetricsServer.enabled = true, you must set
+                                      a Datadog application key for read access to your metrics.
+                                    type: string
+                                  appSecret:
+                                    description: |-
+                                      AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                                      If set, this parameter takes precedence over "AppKey".
+                                    properties:
+                                      keyName:
+                                        description: KeyName is the key of the secret
+                                          to use.
+                                        type: string
+                                      secretName:
+                                        description: SecretName is the name of the
+                                          secret.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                type: object
+                              url:
+                                description: URL defines the endpoint URL.
+                                type: string
+                            type: object
+                          port:
+                            description: |-
+                              Port specifies the metricsProvider External Metrics Server service port.
+                              Default: 8443
+                            format: int32
+                            type: integer
+                          registerAPIService:
+                            description: |-
+                              RegisterAPIService registers the External Metrics endpoint as an APIService
+                              Default: true
+                            type: boolean
+                          useDatadogMetrics:
+                            description: |-
+                              UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries).
+                              Default: true
+                            type: boolean
+                          wpaController:
+                            description: |-
+                              WPAController enables the informer and controller of the Watermark Pod Autoscaler.
+                              NOTE: The Watermark Pod Autoscaler controller needs to be installed.
+                              See also: https://github.com/DataDog/watermarkpodautoscaler.
+                              Default: false
+                            type: boolean
+                        type: object
+                      gpu:
+                        description: GPU monitoring
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables GPU monitoring core check.
+                              Default: false
+                            type: boolean
+                          patchCgroupPermissions:
+                            description: |-
+                              PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case
+                              the container runtime is not properly configured and the Agent containers lose access to GPU devices.
+                              Default: false
+                            type: boolean
+                          privilegedMode:
+                            description: |-
+                              PrivilegedMode enables GPU Probe module in System Probe.
+                              Default: false
+                            type: boolean
+                          requiredRuntimeClassName:
+                            description: |-
+                              PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature.
+                              If the value is an empty string, the runtime class is not set.
+                              Default: nvidia
+                            type: string
+                        type: object
+                      helmCheck:
+                        description: HelmCheck configuration.
+                        properties:
+                          collectEvents:
+                            description: |-
+                              CollectEvents set to `true` enables event collection in the Helm check
+                              (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+)
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables the Helm check.
+                              Default: false
+                            type: boolean
+                          valuesAsTags:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ValuesAsTags collects Helm values from a release and uses them as tags
+                              (Requires Agent and Cluster Agent 7.40.0+).
+                              Default: {}
+                            type: object
+                        type: object
+                      kubeStateMetricsCore:
+                        description: KubeStateMetricsCore check configuration.
+                        properties:
+                          collectCrMetrics:
+                            description: |-
+                              `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                              The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                              The exact structure and existing fields of each item in this list can be found in:
+                              https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                            items:
+                              description: Resource configures a custom resource for
+                                metric generation.
+                              properties:
+                                commonLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: CommonLabels are added to all metrics.
+                                  type: object
+                                groupVersionKind:
+                                  description: GroupVersionKind of the custom resource
+                                    to be monitored.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  type: object
+                                labelsFromPath:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: LabelsFromPath adds additional labels
+                                    where the value is taken from a field in the resource.
+                                  type: object
+                                metricNamePrefix:
+                                  description: |-
+                                    MetricNamePrefix defines a prefix for all metrics of the resource.
+                                    If set to "", no prefix will be added.
+                                    Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                  type: string
+                                metrics:
+                                  description: Metrics are the custom resource fields
+                                    to be collected.
+                                  items:
+                                    description: Generator describes a unique metric
+                                      name.
+                                    properties:
+                                      commonLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonLabels are added to all
+                                          metrics.
+                                        type: object
+                                      each:
+                                        description: Each targets a value or values
+                                          from the resource.
+                                        properties:
+                                          gauge:
+                                            description: Gauge defines a gauge metric.
+                                            properties:
+                                              labelFromKey:
+                                                description: LabelFromKey adds a label
+                                                  with the given name if Path is an
+                                                  object. The label value will be
+                                                  the object key.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              nilIsZero:
+                                                description: NilIsZero indicates that
+                                                  if a value is nil it will be treated
+                                                  as zero value.
+                                                type: boolean
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              valueFrom:
+                                                description: ValueFrom is the path
+                                                  to a numeric field under Path that
+                                                  will be the metric value.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          info:
+                                            description: Info defines an info metric.
+                                            properties:
+                                              labelFromKey:
+                                                description: LabelFromKey adds a label
+                                                  with the given name if Path is an
+                                                  object. The label value will be
+                                                  the object key.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          stateSet:
+                                            description: StateSet defines a state
+                                              set metric.
+                                            properties:
+                                              labelName:
+                                                description: LabelName is the key
+                                                  of the label which is used for each
+                                                  entry in List to expose the value.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              list:
+                                                description: List is the list of values
+                                                  to expose a value for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              valueFrom:
+                                                description: ValueFrom is the subpath
+                                                  to compare the list to.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          type:
+                                            description: Type defines the type of
+                                              the metric.
+                                            type: string
+                                        type: object
+                                      help:
+                                        description: Help text for the metric.
+                                        type: string
+                                      labelsFromPath:
+                                        additionalProperties:
+                                          items:
+                                            type: string
+                                          type: array
+                                        description: LabelsFromPath adds additional
+                                          labels where the value is taken from a field
+                                          in the resource.
+                                        type: object
+                                      name:
+                                        description: Name of the metric. Subject to
+                                          prefixing based on the configuration of
+                                          the Resource.
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourcePlural:
+                                  description: ResourcePlural sets the plural name
+                                    of the resource. Defaults to the plural version
+                                    of the Kind according to flect.Pluralize.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Kube State Metrics Core.
+                              Default: true
+                            type: boolean
+                        type: object
+                      kubernetesActions:
+                        description: KubernetesActions configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Kubernetes Actions feature on the Cluster Agent.
+                              Default: false
+                            type: boolean
+                        type: object
+                      liveContainerCollection:
+                        description: LiveContainerCollection configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables container collection for the Live Container View.
+                              Default: true
+                            type: boolean
+                        type: object
+                      liveProcessCollection:
+                        description: LiveProcessCollection configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Process monitoring.
+                              Default: false
+                            type: boolean
+                          scrubProcessArguments:
+                            description: |-
+                              ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ).
+                              Default: true
+                            type: boolean
+                          stripProcessArguments:
+                            description: |-
+                              StripProcessArguments enables stripping of all process arguments.
+                              Default: false
+                            type: boolean
+                        type: object
+                      logCollection:
+                        description: LogCollection configuration.
+                        properties:
+                          autoMultiLineDetection:
+                            description: |-
+                              AutoMultiLineDetection allows the Agent to detect and aggregate common multi-line logs automatically.
+                              See also: https://docs.datadoghq.com/agent/logs/auto_multiline_detection/
+                            type: boolean
+                          containerCollectAll:
+                            description: |-
+                              ContainerCollectAll enables Log collection from all containers.
+                              Default: false
+                            type: boolean
+                          containerCollectUsingFiles:
+                            description: |-
+                              ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API.
+                              Collecting logs from files is usually the most efficient way of collecting logs.
+                              See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                              Default: true
+                            type: boolean
+                          containerLogsPath:
+                            description: |-
+                              ContainerLogsPath allows log collection from the container log path.
+                              Set to a different path if you are not using the Docker runtime.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
+                              Default: `/var/lib/docker/containers`
+                            type: string
+                          containerSymlinksPath:
+                            description: |-
+                              ContainerSymlinksPath allows log collection to use symbolic links in this directory to validate container ID -> pod.
+                              Default: `/var/log/containers`
+                            type: string
+                          enabled:
+                            description: |-
+                              Enabled enables Log collection.
+                              Default: false
+                            type: boolean
+                          openFilesLimit:
+                            description: |-
+                              OpenFilesLimit sets the maximum number of log files that the Datadog Agent tails.
+                              Increasing this limit can increase resource consumption of the Agent.
+                              See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                              Default: 100
+                            format: int32
+                            type: integer
+                          podLogsPath:
+                            description: |-
+                              PodLogsPath allows log collection from a pod log path.
+                              Default: `/var/log/pods`
+                            type: string
+                          tempStoragePath:
+                            description: |-
+                              TempStoragePath (always mounted from the host) is used by the Agent to store information about processed log files.
+                              If the Agent is restarted, it starts tailing the log files immediately.
+                              Default: `/var/lib/datadog-agent/logs`
+                            type: string
+                        type: object
+                      npm:
+                        description: NPM (Network Performance Monitoring) configuration.
+                        properties:
+                          collectDNSStats:
+                            description: |-
+                              CollectDNSStats enables DNS stat collection.
+                              Default: false
+                            type: boolean
+                          enableConntrack:
+                            description: |-
+                              EnableConntrack enables the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data.
+                              See also: http://conntrack-tools.netfilter.org/
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables Network Performance Monitoring.
+                              Default: false
+                            type: boolean
+                        type: object
+                      oomKill:
+                        description: OOMKill configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the OOMKill eBPF-based check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      orchestratorExplorer:
+                        description: OrchestratorExplorer check configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Orchestrator Explorer check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          customResources:
+                            description: |-
+                              `CustomResources` defines custom resources for the orchestrator explorer to collect.
+                              Each item should follow the convention `group/version/kind`. For example, `datadoghq.com/v1alpha1/datadogmetrics`.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          ddUrl:
+                            description: |-
+                              Override the API endpoint for the Orchestrator Explorer.
+                              URL Default: "https://orchestrator.datadoghq.com".
+                            type: string
+                          enabled:
+                            description: |-
+                              Enabled enables the Orchestrator Explorer.
+                              Default: true
+                            type: boolean
+                          extraTags:
+                            description: |-
+                              Additional tags to associate with the collected data in the form of `a b c`.
+                              This is a Cluster Agent option distinct from DD_TAGS that is used in the Orchestrator Explorer.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          scrubContainers:
+                            description: |-
+                              ScrubContainers enables scrubbing of sensitive container data (passwords, tokens, etc. ).
+                              Default: true
+                            type: boolean
+                        type: object
+                      otelAgentGateway:
+                        description: OtelAgentGateway configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default OTel Agent Gateway.
+                              This must point to a ConfigMap containing a valid OTel collector configuration.
+                              When passing a configmap, file name *must* be otel-gateway-config.yaml.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the OTel Agent Gateway.
+                              Default: false
+                            type: boolean
+                          featureGates:
+                            description: |-
+                              FeatureGates are the feature gates to pass to the OTel collector as a comma-separated list.
+                              Example: "component.UseLocalHostAsDefaultHost,connector.datadogconnector.NativeIngest"
+                            type: string
+                          ports:
+                            description: |-
+                              Ports contains the ports that the OTel Collector is listening on.
+                              Defaults: otel-grpc:4317 / otel-http:4318.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      otelCollector:
+                        description: OtelCollector configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                              When passing a configmap, file name *must* be otel-config.yaml.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          coreConfig:
+                            description: OTelCollector Config Relevant to the Core
+                              agent
+                            properties:
+                              enabled:
+                                description: Enabled marks otelcollector as enabled
+                                  in core agent.
+                                type: boolean
+                              extensionTimeout:
+                                description: |-
+                                  Extension URL provides the timout of the ddflareextension to
+                                  the core agent.
+                                type: integer
+                              extensionURL:
+                                description: |-
+                                  Extension URL provides the URL of the ddflareextension to
+                                  the core agent.
+                                type: string
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the OTel Agent.
+                              Default: false
+                            type: boolean
+                          ports:
+                            description: |-
+                              Ports contains the ports for the otel-agent.
+                              Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317
+                              or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http).
+                              If not, this will lead to a port conflict.
+                              This limitation will be lifted once annotations support is removed.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      otlp:
+                        description: OTLP ingest configuration
+                        properties:
+                          receiver:
+                            description: Receiver contains configuration for the OTLP
+                              ingest receiver.
+                            properties:
+                              protocols:
+                                description: Protocols contains configuration for
+                                  the OTLP ingest receiver protocols.
+                                properties:
+                                  grpc:
+                                    description: GRPC contains configuration for the
+                                      OTLP ingest OTLP/gRPC receiver.
+                                    properties:
+                                      enabled:
+                                        description: Enable the OTLP/gRPC endpoint.
+                                          Host port is enabled by default and can
+                                          be disabled.
+                                        type: boolean
+                                      endpoint:
+                                        description: |-
+                                          Endpoint for OTLP/gRPC.
+                                          gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+                                          The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`).
+                                          Default: `0.0.0.0:4317`.
+                                        type: string
+                                      hostPortConfig:
+                                        description: |-
+                                          Enable hostPort for OTLP/gRPC
+                                          Default: true
+                                        properties:
+                                          enabled:
+                                            description: Enabled enables host port
+                                              configuration
+                                            type: boolean
+                                          hostPort:
+                                            description: |-
+                                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                              If HostNetwork is enabled, this value must match the ContainerPort.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  http:
+                                    description: HTTP contains configuration for the
+                                      OTLP ingest OTLP/HTTP receiver.
+                                    properties:
+                                      enabled:
+                                        description: Enable the OTLP/HTTP endpoint.
+                                          Host port is enabled by default and can
+                                          be disabled.
+                                        type: boolean
+                                      endpoint:
+                                        description: |-
+                                          Endpoint for OTLP/HTTP.
+                                          Default: '0.0.0.0:4318'.
+                                        type: string
+                                      hostPortConfig:
+                                        description: |-
+                                          Enable hostPorts for OTLP/HTTP
+                                          Default: true
+                                        properties:
+                                          enabled:
+                                            description: Enabled enables host port
+                                              configuration
+                                            type: boolean
+                                          hostPort:
+                                            description: |-
+                                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                              If HostNetwork is enabled, this value must match the ContainerPort.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      processDiscovery:
+                        description: ProcessDiscovery configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Process Discovery check in the Agent.
+                              Default: true
+                            type: boolean
+                        type: object
+                      prometheusScrape:
+                        description: PrometheusScrape configuration.
+                        properties:
+                          additionalConfigs:
+                            description: AdditionalConfigs allows adding advanced
+                              Prometheus check configurations with custom discovery
+                              rules.
+                            type: string
+                          enableServiceEndpoints:
+                            description: |-
+                              EnableServiceEndpoints enables generating dedicated checks for service endpoints.
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enable autodiscovery of pods and services exposing Prometheus metrics.
+                              Default: false
+                            type: boolean
+                          version:
+                            description: |-
+                              Version specifies the version of the OpenMetrics check.
+                              Default: 2
+                            type: integer
+                        type: object
+                      remoteConfiguration:
+                        description: Remote Configuration configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable this option to activate Remote Configuration.
+                              Default: true
+                            type: boolean
+                        type: object
+                      sbom:
+                        description: SBOM collection configuration.
+                        properties:
+                          containerImage:
+                            description: SBOMTypeConfig contains configuration for
+                              a SBOM collection type.
+                            properties:
+                              analyzers:
+                                description: Analyzers to use for SBOM collection.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM collection.
+                                  Default: false
+                                type: boolean
+                              overlayFSDirectScan:
+                                description: |-
+                                  Enable this option to enable experimental overlayFS direct scan.
+                                  Default: false
+                                type: boolean
+                              uncompressedLayersSupport:
+                                description: |-
+                                  Enable this option to enable support for uncompressed layers.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                          enrichment:
+                            description: SBOMEnrichmentConfig contains SBOM enrichment
+                              configuration.
+                            properties:
+                              usage:
+                                description: Usage contains configuration for the
+                                  "package in use" enrichment.
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enable this option to activate SBOM enrichment with runtime "package in use" detection.
+                                      Requires system-probe for eBPF-based file access tracking.
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                          host:
+                            description: SBOMTypeConfig contains configuration for
+                              a SBOM collection type.
+                            properties:
+                              analyzers:
+                                description: Analyzers to use for SBOM collection.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM collection.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      serviceDiscovery:
+                        description: ServiceDiscovery
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the service discovery check.
+                              Default: true when omitted and the node Agent image is >= 7.78.0. Otherwise false.
+                              If the image version cannot be determined, it is treated as latest.
+                            type: boolean
+                        type: object
+                      tcpQueueLength:
+                        description: TCPQueueLength configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the TCP queue length eBPF-based check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      usm:
+                        description: USM (Universal Service Monitoring) configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Universal Service Monitoring.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                  global:
+                    description: Global settings to configure the agents
+                    properties:
+                      checksTagCardinality:
+                        description: |-
+                          ChecksTagCardinality configures tag cardinality for the metrics collected by integrations (`low`, `orchestrator` or `high`).
+                          See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#tags-cardinality.
+                          Not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low.
+                          Ref: https://github.com/DataDog/datadog-agent/blob/856cf4a66142ce91fd4f8a278149436eb971184a/pkg/config/setup/config.go#L625.
+                        type: string
+                      clusterAgentToken:
+                        description: ClusterAgentToken is the token for communication
+                          between the NodeAgent and ClusterAgent.
+                        type: string
+                      clusterAgentTokenSecret:
+                        description: ClusterAgentTokenSecret is the secret containing
+                          the Cluster Agent token.
+                        properties:
+                          keyName:
+                            description: KeyName is the key of the secret to use.
+                            type: string
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      clusterName:
+                        description: ClusterName sets a unique cluster name for the
+                          deployment to easily scope monitoring data in the Datadog
+                          app.
+                        type: string
+                      commonLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          CommonLabels specified labels to be added to all operator-managed Kubernetes resources
+                          (DaemonSets, Deployments, ConfigMaps, Services, ServiceAccounts, etc.).
+                          This is useful when external policy tools such as Kyverno enforce the presence of
+                          specific labels on all cluster resources.
+                          Labels defined here are merged with the operator's own default labels; operator labels
+                          take precedence on any key conflict.
+                        type: object
+                        x-kubernetes-map-type: granular
+                      containerStrategy:
+                        description: |-
+                          ContainerStrategy determines whether agents run in a single or multiple containers.
+                          Default: 'optimized'
+                        type: string
+                      credentials:
+                        description: Credentials defines the Datadog credentials used
+                          to submit data to/query data from Datadog.
+                        properties:
+                          apiKey:
+                            description: |-
+                              APIKey configures your Datadog API key.
+                              See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                            type: string
+                          apiSecret:
+                            description: |-
+                              APISecret references an existing Secret which stores the API key instead of creating a new one.
+                              If set, this parameter takes precedence over "APIKey".
+                            properties:
+                              keyName:
+                                description: KeyName is the key of the secret to use.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            required:
+                            - secretName
+                            type: object
+                          appKey:
+                            description: |-
+                              AppKey configures your Datadog application key.
+                              If you are using features.externalMetricsServer.enabled = true, you must set
+                              a Datadog application key for read access to your metrics.
+                            type: string
+                          appSecret:
+                            description: |-
+                              AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                              If set, this parameter takes precedence over "AppKey".
+                            properties:
+                              keyName:
+                                description: KeyName is the key of the secret to use.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            required:
+                            - secretName
+                            type: object
+                        type: object
+                      criSocketPath:
+                        description: Path to the container runtime socket (if different
+                          from Docker).
+                        type: string
+                      csi:
+                        description: CSI contains configuration for Datadog CSI Driver
+                        properties:
+                          autoManage:
+                            description: |-
+                              AutoManage controls whether the operator automatically manages the DatadogCSIDriver
+                              custom resource on behalf of this DatadogAgent. Set to false to hand ownership over to a
+                              DatadogCSIDriver CR that you maintain yourself (useful for migrations where you need
+                              customizations not exposed on the DatadogAgent spec). When toggled from true to false,
+                              the operator cleans up the DDA-owned DatadogCSIDriver CR; you are then responsible for
+                              providing a replacement so CSI continues to work.
+                              Default: true
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enables the usage of CSI driver in Datadog Agent. When the operator is started with
+                              `--datadogCSIDriverEnabled=true`, it will also install the driver by creating a
+                              DatadogCSIDriver custom resource, unless a cluster-scoped `k8s.csi.datadoghq.com`
+                              CSIDriver is already present, in which case it defers to the existing installation
+                              (e.g. from the Datadog CSI driver Helm chart).
+                              Default: false
+                            type: boolean
+                          nodeAffinity:
+                            description: NodeAffinity specifies node affinity scheduling
+                              rules for CSI driver DaemonSet pods.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            description: NodeSelector is a map of key-value pairs
+                              for CSI driver DaemonSet pod node selection.
+                            type: object
+                          tolerations:
+                            description: Tolerations configure the CSI driver DaemonSet
+                              pod tolerations.
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      disableNonResourceRules:
+                        description: |-
+                          Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.
+                          Required 'true' for Google Cloud Marketplace.
+                        type: boolean
+                      dockerSocketPath:
+                        description: Path to the docker runtime socket.
+                        type: string
+                      endpoint:
+                        description: |-
+                          Endpoint is the Datadog intake URL the Agent data are sent to.
+                          Only set this option if you need the Agent to send data to a custom URL.
+                          Overrides the site setting defined in `Site`.
+                        properties:
+                          credentials:
+                            description: Credentials defines the Datadog credentials
+                              used to submit data to/query data from Datadog.
+                            properties:
+                              apiKey:
+                                description: |-
+                                  APIKey configures your Datadog API key.
+                                  See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                                type: string
+                              apiSecret:
+                                description: |-
+                                  APISecret references an existing Secret which stores the API key instead of creating a new one.
+                                  If set, this parameter takes precedence over "APIKey".
+                                properties:
+                                  keyName:
+                                    description: KeyName is the key of the secret
+                                      to use.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of the secret.
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                              appKey:
+                                description: |-
+                                  AppKey configures your Datadog application key.
+                                  If you are using features.externalMetricsServer.enabled = true, you must set
+                                  a Datadog application key for read access to your metrics.
+                                type: string
+                              appSecret:
+                                description: |-
+                                  AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                                  If set, this parameter takes precedence over "AppKey".
+                                properties:
+                                  keyName:
+                                    description: KeyName is the key of the secret
+                                      to use.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of the secret.
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                            type: object
+                          url:
+                            description: URL defines the endpoint URL.
+                            type: string
+                        type: object
+                      env:
+                        description: Env contains a list of environment variables
+                          that are set for all Agents.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      fips:
+                        description: FIPS contains configuration used to customize
+                          the FIPS proxy sidecar.
+                        properties:
+                          customFIPSConfig:
+                            description: |-
+                              CustomFIPSConfig configures a custom configMap to provide the FIPS configuration.
+                              Specify custom contents for the FIPS proxy sidecar container config
+                              (/etc/datadog-fips-proxy/datadog-fips-proxy.cfg). If empty, the default FIPS
+                              proxy sidecar container config is used.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: Enable FIPS sidecar.
+                            type: boolean
+                          image:
+                            description: The container image of the FIPS sidecar.
+                            properties:
+                              jmxEnabled:
+                                description: |-
+                                  Define whether the Agent image should support JMX.
+                                  To be used if the `Name` field does not correspond to a full image string.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Defines the Agent image name for the pod. You can provide this as:
+                                  * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                  for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                  * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                  and `[key].image.jmxEnabled` are ignored.
+                                  * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                    like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                                type: string
+                              pullPolicy:
+                                description: |-
+                                  The Kubernetes pull policy:
+                                  Use `Always`, `Never`, or `IfNotPresent`.
+                                type: string
+                              pullSecrets:
+                                description: |-
+                                  It is possible to specify Docker registry credentials.
+                                  See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                                items:
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                              tag:
+                                description: |-
+                                  Define the image tag to use.
+                                  To be used if the `Name` field does not correspond to a full image string.
+                                type: string
+                            type: object
+                          localAddress:
+                            description: |-
+                              Set the local IP address.
+                              Default: `127.0.0.1`
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies which port is used by the containers to communicate to the FIPS sidecar.
+                              Default: 9803
+                            format: int32
+                            type: integer
+                          portRange:
+                            description: |-
+                              PortRange specifies the number of ports used.
+                              Default: 15
+                            format: int32
+                            type: integer
+                          resources:
+                            description: Resources is the requests and limits for
+                              the FIPS sidecar container.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          useHTTPS:
+                            description: |-
+                              UseHTTPS enables HTTPS.
+                              Default: false
+                            type: boolean
+                        type: object
+                      kubelet:
+                        description: Kubelet contains the kubelet configuration parameters.
+                        properties:
+                          agentCAPath:
+                            description: |-
+                              AgentCAPath is the container path where the kubelet CA certificate is stored.
+                              Default: '/var/run/host-kubelet-ca.crt' if hostCAPath is set, else '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+                            type: string
+                          host:
+                            description: Host overrides the host used to contact kubelet
+                              API (default to status.hostIP).
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          hostCAPath:
+                            description: HostCAPath is the host path where the kubelet
+                              CA certificate is stored.
+                            type: string
+                          podResourcesSocketPath:
+                            description: |-
+                              PodResourcesSocketPath is the host path where the pod resources socket is stored.
+                              Default: `/var/lib/kubelet/pod-resources/`
+                            type: string
+                          tlsVerify:
+                            description: |-
+                              TLSVerify toggles kubelet TLS verification.
+                              Default: true
+                            type: boolean
+                        type: object
+                      kubernetesResourcesAnnotationsAsTags:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: "Provide a mapping of Kubernetes Resource Groups
+                          to annotations mapping to Datadog Tags.\n<KUBERNETES_RESOURCE_GROUP>:\n\t\t<KUBERNETES_ANNOTATION>:
+                          <DATADOG_TAG_KEY>\nKUBERNETES_RESOURCE_GROUP should be in
+                          the form `{resource}.{group}` or `{resource}` (example:
+                          deployments.apps, pods)"
+                        type: object
+                      kubernetesResourcesLabelsAsTags:
+                        additionalProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description: "Provide a mapping of Kubernetes Resource Groups
+                          to labels mapping to Datadog Tags.\n<KUBERNETES_RESOURCE_GROUP>:\n\t\t<KUBERNETES_LABEL>:
+                          <DATADOG_TAG_KEY>\nKUBERNETES_RESOURCE_GROUP should be in
+                          the form `{resource}.{group}` or `{resource}` (example:
+                          deployments.apps, pods)"
+                        type: object
+                      localService:
+                        description: LocalService contains configuration to customize
+                          the internal traffic policy service.
+                        properties:
+                          forceEnableLocalService:
+                            description: |-
+                              ForceEnableLocalService forces the creation of the internal traffic policy service to target the agent running on the local node.
+                              This parameter only applies to Kubernetes 1.21, where the feature is in alpha and is disabled by default.
+                              (On Kubernetes 1.22+, the feature entered beta and the internal traffic service is created by default, so this parameter is ignored.)
+                              Default: false
+                            type: boolean
+                          nameOverride:
+                            description: NameOverride defines the name of the internal
+                              traffic service to target the agent running on the local
+                              node.
+                            type: string
+                        type: object
+                      logLevel:
+                        description: |-
+                          LogLevel sets logging verbosity. This can be overridden by container.
+                          Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                          Default: 'info'
+                        type: string
+                      namespaceAnnotationsAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Provide a mapping of Kubernetes Namespace Annotations to Datadog Tags.
+                          <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>
+                        type: object
+                      namespaceLabelsAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Provide a mapping of Kubernetes Namespace Labels to Datadog Tags.
+                          <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
+                        type: object
+                      networkPolicy:
+                        description: NetworkPolicy contains the network configuration.
+                        properties:
+                          create:
+                            description: Create defines whether to create a NetworkPolicy
+                              for the current deployment.
+                            type: boolean
+                          dnsSelectorEndpoints:
+                            description: DNSSelectorEndpoints defines the cilium selector
+                              of the DNS server entity.
+                            items:
+                              description: |-
+                                A label selector is a label query over a set of resources. The result of matchLabels and
+                                matchExpressions are ANDed. An empty label selector matches all objects. A null
+                                label selector matches no objects.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          flavor:
+                            description: Flavor defines Which network policy to use.
+                            type: string
+                        type: object
+                      nodeLabelsAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Provide a mapping of Kubernetes Node Labels to Datadog Tags.
+                          <KUBERNETES_NODE_LABEL>: <DATADOG_TAG_KEY>
+                        type: object
+                      originDetectionUnified:
+                        description: OriginDetectionUnified defines the origin detection
+                          unified mechanism behavior.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables unified mechanism for origin detection.
+                              Default: false
+                            type: boolean
+                        type: object
+                      podAnnotationsAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Provide a mapping of Kubernetes Annotations to Datadog Tags.
+                          <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY>
+                        type: object
+                      podLabelsAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Provide a mapping of Kubernetes Labels to Datadog Tags.
+                          <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>
+                        type: object
+                      registry:
+                        description: |-
+                          Registry is the image registry to use for all Agent images.
+                          Use 'public.ecr.aws/datadog' for AWS ECR.
+                          Use 'datadoghq.azurecr.io' for Azure Container Registry.
+                          Use 'gcr.io/datadoghq' for Google Container Registry.
+                          Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
+                          Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
+                          Use 'docker.io/datadog' for DockerHub.
+                          Default: 'registry.datadoghq.com'
+                        type: string
+                      secretBackend:
+                        description: |-
+                          Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management
+                          See also: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md
+                        properties:
+                          args:
+                            description: List of arguments to pass to the command
+                              (space-separated strings).
+                            type: string
+                          command:
+                            description: |-
+                              The secret backend command to use. Datadog provides a pre-defined binary `/readsecret_multiple_providers.sh`.
+                              Read more about `/readsecret_multiple_providers.sh` at https://docs.datadoghq.com/agent/configuration/secrets-management/?tab=linux#script-for-reading-from-multiple-secret-providers.
+                            type: string
+                          config:
+                            additionalProperties:
+                              x-kubernetes-preserve-unknown-fields: true
+                            description: Additional configuration for the secret backend
+                              type.
+                            type: object
+                          enableGlobalPermissions:
+                            description: |-
+                              Whether to create a global permission allowing Datadog agents to read all Kubernetes secrets.
+                              Default: `false`.
+                            type: boolean
+                          refreshInterval:
+                            description: |-
+                              The refresh interval for secrets (0 disables refreshing).
+                              Default: `0`.
+                            format: int32
+                            type: integer
+                          roles:
+                            description: |-
+                              Roles for Datadog to read the specified secrets, replacing `enableGlobalPermissions`.
+                              They are defined as a list of namespace/secrets.
+                              Each defined namespace needs to be present in the DatadogAgent controller using `WATCH_NAMESPACE` or `DD_AGENT_WATCH_NAMESPACE`.
+                              See also: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md#how-to-deploy-the-agent-components-using-the-secret-backend-feature-with-datadogagent.
+                            items:
+                              description: SecretBackendRolesConfig provides configuration
+                                of the secrets Datadog agents can read for the SecretBackend
+                                feature
+                              properties:
+                                namespace:
+                                  description: Namespace defines the namespace in
+                                    which the secrets reside.
+                                  type: string
+                                secrets:
+                                  description: Secrets defines the list of secrets
+                                    for which a role should be created.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              required:
+                              - namespace
+                              - secrets
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          timeout:
+                            description: |-
+                              The command timeout in seconds.
+                              Default: `30`.
+                            format: int32
+                            type: integer
+                          type:
+                            description: |-
+                              The built-in secret backend type to use (e.g., `k8s.secrets`, `docker.secrets`, `aws.secrets`).
+                              Alternative to Command; when Type is set, the Agent uses the built-in backend to resolve secrets.
+                              Requires Agent 7.70+.
+                            type: string
+                        type: object
+                      site:
+                        description: |-
+                          Site is the Datadog intake site Agent data are sent to.
+                          Set to 'datadoghq.com' to send data to the US1 site (default).
+                          Set to 'datadoghq.eu' to send data to the EU site.
+                          Set to 'us3.datadoghq.com' to send data to the US3 site.
+                          Set to 'us5.datadoghq.com' to send data to the US5 site.
+                          Set to 'ddog-gov.com' to send data to the US1-FED site.
+                          Set to 'ap1.datadoghq.com' to send data to the AP1 site.
+                          Default: 'datadoghq.com'
+                        type: string
+                      tags:
+                        description: |-
+                          Tags contains a list of tags to attach to every metric, event and service check collected.
+                          Learn more about tagging: https://docs.datadoghq.com/tagging/
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      useFIPSAgent:
+                        description: |-
+                          UseFIPSAgent enables the FIPS flavor of the Agent. If 'true', the FIPS proxy will always be disabled.
+                          Default: 'false'
+                        type: boolean
+                      useVSock:
+                        description: |-
+                          UseVSock allows the use of VSock communication between the Agent and containerized workloads.
+                          Default: 'false'
+                        type: boolean
+                    type: object
+                  override:
+                    additionalProperties:
+                      description: DatadogAgentComponentOverride is the generic description
+                        equivalent to a subset of the PodTemplate for a component.
+                      properties:
+                        affinity:
+                          description: If specified, the pod's scheduling constraints.
+                          properties:
+                            nodeAffinity:
+                              description: Describes node affinity scheduling rules
+                                for the pod.
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: |-
+                                      An empty preferred scheduling term matches all objects with implicit weight 0
+                                      (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                    properties:
+                                      preference:
+                                        description: A node selector term, associated
+                                          with the corresponding weight.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      weight:
+                                        description: Weight associated with matching
+                                          the corresponding nodeSelectorTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to an update), the system
+                                    may or may not try to eventually evict the pod from its node.
+                                  properties:
+                                    nodeSelectorTerms:
+                                      description: Required. A list of node selector
+                                        terms. The terms are ORed.
+                                      items:
+                                        description: |-
+                                          A null or empty node selector term matches no objects. The requirements of
+                                          them are ANDed.
+                                          The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            podAffinity:
+                              description: Describes pod affinity scheduling rules
+                                (e.g. co-locate this pod in the same node, zone, etc.
+                                as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: |-
+                                          weight associated with matching the corresponding podAffinityTerm,
+                                          in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes corresponding to each
+                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: |-
+                                      Defines a set of pods (namely those matching the labelSelector
+                                      relative to the given namespace(s)) that this pod should be
+                                      co-located (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node whose value of
+                                      the label with key <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling
+                                rules (e.g. avoid putting this pod in the same node,
+                                zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the anti-affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and subtracting
+                                    "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: |-
+                                          weight associated with matching the corresponding podAffinityTerm,
+                                          in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the anti-affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the anti-affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes corresponding to each
+                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: |-
+                                      Defines a set of pods (namely those matching the labelSelector
+                                      relative to the given namespace(s)) that this pod should be
+                                      co-located (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node whose value of
+                                      the label with key <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                          type: object
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations provide annotations that are added
+                            to the different component (Datadog Agent, Cluster Agent,
+                            Cluster Check Runner) pods.
+                          type: object
+                        celWorkloadExclude:
+                          description: |-
+                            CELWorkloadExclude enables excluding workloads from monitoring using Common Expression Language (CEL).
+                            See https://docs.datadoghq.com/containers/guide/container-discovery-management
+                            (Requires Agent 7.73+ and Cluster Agent 7.73+)
+                          items:
+                            description: |-
+                              CelWorkloadExcludeConfig configures CEL-based filtering to exclude specific workloads
+                              from Agent collection.
+                            properties:
+                              products:
+                                description: Products specifies which products these
+                                  exclusion rules apply to.
+                                items:
+                                  description: |-
+                                    Product defines which Datadog product(s) the CEL-based workload exclusion rules apply to.
+                                    Use "global" to apply rules across all products, or specify individual products for granular control.
+                                  enum:
+                                  - metrics
+                                  - logs
+                                  - sbom
+                                  - global
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              rules:
+                                description: Rules defines the CEL expressions used
+                                  to identify workloads to exclude.
+                                properties:
+                                  containers:
+                                    description: Containers exclude rule
+                                    items:
+                                      type: string
+                                    type: array
+                                  kube_endpoints:
+                                    description: KubeEndpoints exclude rule
+                                    items:
+                                      type: string
+                                    type: array
+                                  kube_services:
+                                    description: KubeServices exclude rule
+                                    items:
+                                      type: string
+                                    type: array
+                                  pods:
+                                    description: Pods exclude rule
+                                    items:
+                                      type: string
+                                    type: array
+                                  processes:
+                                    description: Processes exclude rule
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        containers:
+                          additionalProperties:
+                            description: DatadogAgentGenericContainer is the generic
+                              structure describing any container's common configuration.
+                            properties:
+                              appArmorProfileName:
+                                description: AppArmorProfileName specifies an apparmor
+                                  profile.
+                                type: string
+                              args:
+                                description: Args allows the specification of extra
+                                  args to the `Command` parameter
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              command:
+                                description: Command allows the specification of a
+                                  custom entrypoint for container
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              env:
+                                description: |-
+                                  Specify additional environment variables in the container.
+                                  See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fileKeyRef:
+                                          description: |-
+                                            FileKeyRef selects a key of the env file.
+                                            Requires the EnvFiles feature gate to be enabled.
+                                          properties:
+                                            key:
+                                              description: |-
+                                                The key within the env file. An invalid key will prevent the pod from starting.
+                                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                              type: string
+                                            optional:
+                                              default: false
+                                              description: |-
+                                                Specify whether the file or its key must be defined. If the file or key
+                                                does not exist, then the env var is not published.
+                                                If optional is set to true and the specified key does not exist,
+                                                the environment variable will not be set in the Pod's containers.
+
+                                                If optional is set to false and the specified key does not exist,
+                                                an error will be returned during Pod creation.
+                                              type: boolean
+                                            path:
+                                              description: |-
+                                                The path within the volume from which to select the file.
+                                                Must be relative and may not contain the '..' path or start with '..'.
+                                              type: string
+                                            volumeName:
+                                              description: The name of the volume
+                                                mount containing the env file.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          - volumeName
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              healthPort:
+                                description: |-
+                                  HealthPort of the container for the internal liveness probe.
+                                  Must be the same as the Liveness/Readiness probes.
+                                format: int32
+                                type: integer
+                              livenessProbe:
+                                description: Configure the Liveness Probe of the container
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service.
+                                          Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection
+                                      to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              logLevel:
+                                description: |-
+                                  LogLevel sets logging verbosity (overrides global setting).
+                                  Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                                  Default: 'info'
+                                type: string
+                              name:
+                                description: Name of the container that is overridden
+                                type: string
+                              ports:
+                                description: |-
+                                  Specify additional ports to be exposed by the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed.
+                                  See https://pkg.go.dev/k8s.io/api/core/v1#Container documentation for more details.
+                                items:
+                                  description: ContainerPort represents a network
+                                    port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external
+                                        port to.
+                                      type: string
+                                    hostPort:
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              readinessProbe:
+                                description: Configure the Readiness Probe of the
+                                  container
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service.
+                                          Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection
+                                      to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                description: |-
+                                  Specify the Request and Limits of the pods
+                                  To get guaranteed QoS class, specify requests and limits equal.
+                                  See also: http://kubernetes.io/docs/user-guide/compute-resources/
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              seccompConfig:
+                                description: |-
+                                  Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation,
+                                  use SecurityContext.
+                                properties:
+                                  customProfile:
+                                    description: |-
+                                      CustomProfile specifies a ConfigMap containing a custom Seccomp Profile.
+                                      ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items
+                                      must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.
+                                    properties:
+                                      configData:
+                                        description: ConfigData corresponds to the
+                                          configuration file content.
+                                        type: string
+                                      configMap:
+                                        description: ConfigMap references an existing
+                                          ConfigMap with the configuration file content.
+                                        properties:
+                                          items:
+                                            description: Items maps a ConfigMap data
+                                              `key` to a file `path` mount.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - key
+                                            x-kubernetes-list-type: map
+                                          name:
+                                            description: Name is the name of the ConfigMap.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  customRootPath:
+                                    description: CustomRootPath specifies a custom
+                                      Seccomp Profile root location.
+                                    type: string
+                                type: object
+                              securityContext:
+                                description: Container-level SecurityContext.
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default value is Default which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      This requires the ProcMountType feature flag to be enabled.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: Configure the Startup Probe of the container
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute
+                                      in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service.
+                                          Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection
+                                      to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              volumeMounts:
+                                description: Specify additional volume mounts in the
+                                  container.
+                                items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                - mountPath
+                                x-kubernetes-list-type: map
+                            type: object
+                          description: |-
+                            Configure the basic configurations for each Agent container. Valid Agent container names are:
+                            `agent`, `cluster-agent`, `init-config`, `init-volume`, `process-agent`, `seccomp-setup`,
+                            `security-agent`, `system-probe`, and `trace-agent`.
+                          type: object
+                        createPodDisruptionBudget:
+                          description: |-
+                            Set CreatePodDisruptionBudget to true to create a PodDisruptionBudget for this component.
+                            Not applicable for the Node Agent. A Cluster Agent PDB is set with 1 minimum available pod, and a Cluster Checks Runner PDB is set with 1 maximum unavailable pod.
+                          type: boolean
+                        createRbac:
+                          description: Set CreateRbac to false to prevent automatic
+                            creation of Role/ClusterRole for this component
+                          type: boolean
+                        customConfigurations:
+                          additionalProperties:
+                            description: |-
+                              CustomConfig provides a place for custom configuration of the Agent or Cluster Agent, corresponding to datadog.yaml,
+                              system-probe.yaml, security-agent.yaml or datadog-cluster.yaml.
+                              The configuration can be provided in the ConfigData field as raw data, or referenced in a ConfigMap.
+                              Note: `ConfigData` and `ConfigMap` cannot be set together.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          description: |-
+                            CustomConfigurations specifies custom contents for `datadog.yaml`, `datadog-cluster.yaml`, `security-agent.yaml`, and `system-probe.yaml`.
+                            Each provided file replaces the corresponding default file from the Agent image without merging.
+                            Agent settings provided through environment variables take precedence over these files.
+                          type: object
+                        disabled:
+                          description: Disabled force disables a component.
+                          type: boolean
+                        dnsConfig:
+                          description: |-
+                            Specifies the DNS parameters of a pod.
+                            Parameters specified here will be merged to the generated DNS
+                            configuration based on DNSPolicy.
+                          properties:
+                            nameservers:
+                              description: |-
+                                A list of DNS name server IP addresses.
+                                This will be appended to the base nameservers generated from DNSPolicy.
+                                Duplicated nameservers will be removed.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            options:
+                              description: |-
+                                A list of DNS resolver options.
+                                This will be merged with the base options generated from DNSPolicy.
+                                Duplicated entries will be removed. Resolution options given in Options
+                                will override those that appear in the base DNSPolicy.
+                              items:
+                                description: PodDNSConfigOption defines DNS resolver
+                                  options of a pod.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is this DNS resolver option's name.
+                                      Required.
+                                    type: string
+                                  value:
+                                    description: Value is this DNS resolver option's
+                                      value.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            searches:
+                              description: |-
+                                A list of DNS search domains for host-name lookup.
+                                This will be appended to the base search paths generated from DNSPolicy.
+                                Duplicated search paths will be removed.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        dnsPolicy:
+                          description: |-
+                            Set DNS policy for the pod.
+                            Defaults to "ClusterFirst".
+                            Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                            DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                            To have DNS options set along with hostNetwork, you have to specify DNS policy
+                            explicitly to 'ClusterFirstWithHostNet'.
+                          type: string
+                        env:
+                          description: |-
+                            Specify additional environment variables for all containers in this component
+                            Priority is Container > Component.
+                            See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: |-
+                            EnvFrom specifies the ConfigMaps and Secrets to expose as environment variables.
+                            Priority is env > envFrom.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps or Secrets
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              prefix:
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                        extraChecksd:
+                          description: |-
+                            Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/
+                            See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
+                          properties:
+                            configDataMap:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                ConfigDataMap corresponds to the content of the configuration files.
+                                The key should be the filename the contents get mounted to; for instance check.py or check.yaml.
+                              type: object
+                            configMap:
+                              description: ConfigMap references an existing ConfigMap
+                                with the content of the configuration files.
+                              properties:
+                                items:
+                                  description: Items maps a ConfigMap data `key` to
+                                    a file `path` mount.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  description: Name is the name of the ConfigMap.
+                                  type: string
+                              type: object
+                          type: object
+                        extraConfd:
+                          description: |-
+                            Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/.
+                            See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
+                          properties:
+                            configDataMap:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                ConfigDataMap corresponds to the content of the configuration files.
+                                The key should be the filename the contents get mounted to; for instance check.py or check.yaml.
+                              type: object
+                            configMap:
+                              description: ConfigMap references an existing ConfigMap
+                                with the content of the configuration files.
+                              properties:
+                                items:
+                                  description: Items maps a ConfigMap data `key` to
+                                    a file `path` mount.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - key
+                                  x-kubernetes-list-type: map
+                                name:
+                                  description: Name is the name of the ConfigMap.
+                                  type: string
+                              type: object
+                          type: object
+                        hostNetwork:
+                          description: Host networking requested for this pod. Use
+                            the host's network namespace.
+                          type: boolean
+                        hostPID:
+                          description: Use the host's PID namespace.
+                          type: boolean
+                        image:
+                          description: The container image of the different components
+                            (Datadog Agent, Cluster Agent, Cluster Check Runner).
+                          properties:
+                            jmxEnabled:
+                              description: |-
+                                Define whether the Agent image should support JMX.
+                                To be used if the `Name` field does not correspond to a full image string.
+                              type: boolean
+                            name:
+                              description: |-
+                                Defines the Agent image name for the pod. You can provide this as:
+                                * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                and `[key].image.jmxEnabled` are ignored.
+                                * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                  like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                              type: string
+                            pullPolicy:
+                              description: |-
+                                The Kubernetes pull policy:
+                                Use `Always`, `Never`, or `IfNotPresent`.
+                              type: string
+                            pullSecrets:
+                              description: |-
+                                It is possible to specify Docker registry credentials.
+                                See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                              items:
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                            tag:
+                              description: |-
+                                Define the image tag to use.
+                                To be used if the `Name` field does not correspond to a full image string.
+                              type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: AdditionalLabels provide labels that are added
+                            to the different component (Datadog Agent, Cluster Agent,
+                            Cluster Check Runner) pods.
+                          type: object
+                          x-kubernetes-map-type: granular
+                        name:
+                          description: Name overrides the default name for the resource
+                          type: string
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            A map of key-value pairs. For this pod to run on a specific node, the node must have these key-value pairs as labels.
+                            See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                          type: object
+                        priorityClassName:
+                          description: |-
+                            If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
+                            are two special keywords which indicate the highest priorities with the former being the highest priority.
+                            Any other name must be defined by creating a PriorityClass object with that name. If not specified,
+                            the pod priority is default, or zero if there is no default.
+                          type: string
+                        replicas:
+                          description: |-
+                            Number of the replicas.
+                            Not applicable for a DaemonSet/ExtendedDaemonSet deployment
+                          format: int32
+                          type: integer
+                        runtimeClassName:
+                          description: |-
+                            If specified, indicates the pod's RuntimeClass kubelet should use to run the pod.
+                            If the named RuntimeClass does not exist, or the CRI cannot run the corresponding handler, the pod enters the Failed terminal phase.
+                            If no runtimeClassName is specified, the default RuntimeHandler is used, which is equivalent to the behavior when the RuntimeClass feature is disabled.
+                          type: string
+                        securityContext:
+                          description: Pod-level SecurityContext.
+                          properties:
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            fsGroup:
+                              description: |-
+                                A special supplemental group that applies to all containers in a pod.
+                                Some volume types allow the Kubelet to change the ownership of that volume
+                                to be owned by the pod:
+
+                                1. The owning GID will be the FSGroup
+                                2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                3. The permission bits are OR'd with rw-rw----
+
+                                If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              description: |-
+                                fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                before being exposed inside Pod. This field will only apply to
+                                volume types which support fsGroup based ownership(and permissions).
+                                It will have no effect on ephemeral volume types such as: secret, configmaps
+                                and emptydir.
+                                Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            runAsGroup:
+                              description: |-
+                                The GID to run the entrypoint of the container process.
+                                Uses runtime default if unset.
+                                May also be set in SecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence
+                                for that container.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: |-
+                                Indicates that the container must run as a non-root user.
+                                If true, the Kubelet will validate the image at runtime to ensure that it
+                                does not run as UID 0 (root) and fail to start the container if it does.
+                                If unset or false, no such validation will be performed.
+                                May also be set in SecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: |-
+                                The UID to run the entrypoint of the container process.
+                                Defaults to user specified in image metadata if unspecified.
+                                May also be set in SecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence
+                                for that container.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxChangePolicy:
+                              description: |-
+                                seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                Valid values are "MountOption" and "Recursive".
+
+                                "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                This requires all Pods that share the same volume to use the same SELinux label.
+                                It is not possible to share the same volume among privileged and unprivileged Pods.
+                                Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                CSIDriver instance. Other volumes are always re-labelled recursively.
+                                "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                and "Recursive" for all other volumes.
+
+                                This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            seLinuxOptions:
+                              description: |-
+                                The SELinux context to be applied to all containers.
+                                If unspecified, the container runtime will allocate a random SELinux context for each
+                                container.  May also be set in SecurityContext.  If set in
+                                both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence for that container.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: |-
+                                The seccomp options to use by the containers in this pod.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied.
+                                    Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used.
+                                    RuntimeDefault - the container runtime default profile should be used.
+                                    Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            supplementalGroups:
+                              description: |-
+                                A list of groups applied to the first process run in each container, in
+                                addition to the container's primary GID and fsGroup (if specified).  If
+                                the SupplementalGroupsPolicy feature is enabled, the
+                                supplementalGroupsPolicy field determines whether these are in addition
+                                to or instead of any group memberships defined in the container image.
+                                If unspecified, no additional groups are added, though group memberships
+                                defined in the container image may still be used, depending on the
+                                supplementalGroupsPolicy field.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            supplementalGroupsPolicy:
+                              description: |-
+                                Defines how supplemental groups of the first container processes are calculated.
+                                Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                and the container runtime must implement support for this feature.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            sysctls:
+                              description: |-
+                                Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                sysctls (by the container runtime) might fail to launch.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              items:
+                                description: Sysctl defines a kernel parameter to
+                                  be set
+                                properties:
+                                  name:
+                                    description: Name of a property to set
+                                    type: string
+                                  value:
+                                    description: Value of a property to set
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            windowsOptions:
+                              description: |-
+                                The Windows specific settings applied to all containers.
+                                If unspecified, the options within a container's SecurityContext will be used.
+                                If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: |-
+                                    GMSACredentialSpec is where the GMSA admission webhook
+                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: |-
+                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                    All of a Pod's containers must have the same effective HostProcess value
+                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: |-
+                                    The UserName in Windows to run the entrypoint of the container process.
+                                    Defaults to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        serviceAccountAnnotations:
+                          additionalProperties:
+                            type: string
+                          description: Sets the ServiceAccountAnnotations used by
+                            this component.
+                          type: object
+                        serviceAccountName:
+                          description: |-
+                            Sets the ServiceAccount used by this component.
+                            Ignored if the field CreateRbac is true.
+                          type: string
+                        tolerations:
+                          description: Configure the component tolerations.
+                          items:
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                type: string
+                              tolerationSeconds:
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        topologySpreadConstraints:
+                          description: |-
+                            TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                            domains. Scheduler will schedule pods in a way which abides by the constraints.
+                            All topologySpreadConstraints are ANDed.
+                          items:
+                            description: TopologySpreadConstraint specifies how to
+                              spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is used to find matching pods.
+                                  Pods that match this label selector are counted to determine the number of pods
+                                  in their corresponding topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select the pods over which
+                                  spreading will be calculated. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are ANDed with labelSelector
+                                  to select the group of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. A null or empty list means only match against labelSelector.
+
+                                  This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              maxSkew:
+                                description: |-
+                                  MaxSkew describes the degree to which pods may be unevenly distributed.
+                                  When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                  between the number of matching pods in the target topology and the global minimum.
+                                  The global minimum is the minimum number of matching pods in an eligible domain
+                                  or zero if the number of eligible domains is less than MinDomains.
+                                  For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                  labelSelector spread as 2/2/1:
+                                  In this case, the global minimum is 1.
+                                  | zone1 | zone2 | zone3 |
+                                  |  P P  |  P P  |   P   |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                  scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                  violate MaxSkew(1).
+                                  - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                  When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                  to topologies that satisfy it.
+                                  It's a required field. Default value is 1 and 0 is not allowed.
+                                format: int32
+                                type: integer
+                              minDomains:
+                                description: |-
+                                  MinDomains indicates a minimum number of eligible domains.
+                                  When the number of eligible domains with matching topology keys is less than minDomains,
+                                  Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                  And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                  this value has no effect on scheduling.
+                                  As a result, when the number of eligible domains is less than minDomains,
+                                  scheduler won't schedule more than maxSkew Pods to those domains.
+                                  If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                  Valid values are integers greater than 0.
+                                  When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                  For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                  labelSelector spread as 2/2/2:
+                                  | zone1 | zone2 | zone3 |
+                                  |  P P  |  P P  |  P P  |
+                                  The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                  In this situation, new pod with the same labelSelector cannot be scheduled,
+                                  because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                  it will violate MaxSkew.
+                                format: int32
+                                type: integer
+                              nodeAffinityPolicy:
+                                description: |-
+                                  NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                  when calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                  - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                  If this value is nil, the behavior is equivalent to the Honor policy.
+                                type: string
+                              nodeTaintsPolicy:
+                                description: |-
+                                  NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                  pod topology spread skew. Options are:
+                                  - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                  has a toleration, are included.
+                                  - Ignore: node taints are ignored. All nodes are included.
+
+                                  If this value is nil, the behavior is equivalent to the Ignore policy.
+                                type: string
+                              topologyKey:
+                                description: |-
+                                  TopologyKey is the key of node labels. Nodes that have a label with this key
+                                  and identical values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and try to put balanced number
+                                  of pods into each bucket.
+                                  We define a domain as a particular instance of a topology.
+                                  Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                  nodeAffinityPolicy and nodeTaintsPolicy.
+                                  e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                  And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                  It's a required field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: |-
+                                  WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                  the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                  - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                    but giving higher precedence to topologies that would help reduce the
+                                    skew.
+                                  A constraint is considered "Unsatisfiable" for an incoming pod
+                                  if and only if every possible node assignment for that pod would violate
+                                  "MaxSkew" on some topology.
+                                  For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                  labelSelector spread as 3/1/1:
+                                  | zone1 | zone2 | zone3 |
+                                  | P P P |   P   |   P   |
+                                  If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                  MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                  won't make it *more* imbalanced.
+                                  It's a required field.
+                                type: string
+                            required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - topologyKey
+                          - whenUnsatisfiable
+                          x-kubernetes-list-type: map
+                        updateStrategy:
+                          description: The deployment strategy to use to replace existing
+                            pods with new ones.
+                          properties:
+                            rollingUpdate:
+                              description: Configure the rolling update strategy of
+                                the Deployment or DaemonSet.
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                                    Kubernetes API documentation for additional details.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    The maximum number of pods that can be unavailable during the update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                    Refer to the Kubernetes API documentation for additional details..
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: |-
+                                Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                                or "Recreate" for Deployments
+                              type: string
+                          type: object
+                        volumes:
+                          description: Specify additional volumes in the different
+                            components (Datadog Agent, Cluster Agent, Cluster Check
+                            Runner).
+                          items:
+                            description: Volume represents a named volume in a pod
+                              that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: |-
+                                  awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                  awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: string
+                                  partition:
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: |-
+                                      readOnly value true will force the readOnly setting in VolumeMounts.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: boolean
+                                  volumeID:
+                                    description: |-
+                                      volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                description: |-
+                                  azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                  are redirected to the disk.csi.azure.com CSI driver.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching
+                                      mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data
+                                      disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in
+                                      the blob storage
+                                    type: string
+                                  fsType:
+                                    default: ext4
+                                    description: |-
+                                      fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared:
+                                      multiple blob disks per storage account  Dedicated:
+                                      single blob disk per storage account  Managed:
+                                      azure managed data disk (only in managed availability
+                                      set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    default: false
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                description: |-
+                                  azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                  are redirected to the file.csi.azure.com CSI driver.
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret
+                                      that contains Azure Storage Account Name and
+                                      Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                description: |-
+                                  cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                  Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                properties:
+                                  monitors:
+                                    description: |-
+                                      monitors is Required: Monitors is a collection of Ceph monitors
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: 'path is Optional: Used as the mounted
+                                      root, rather than the full Ceph tree, default
+                                      is /'
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: boolean
+                                  secretFile:
+                                    description: |-
+                                      secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: string
+                                  secretRef:
+                                    description: |-
+                                      secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: |-
+                                      user is optional: User is the rados user name, default is admin
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                description: |-
+                                  cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                  are redirected to the cinder.csi.openstack.org CSI driver.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is optional: points to a secret object containing parameters used to connect
+                                      to OpenStack.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: |-
+                                      volumeID used to identify the volume in cinder.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that
+                                  should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents
+                                  ephemeral storage that is handled by certain external
+                                  CSI drivers.
+                                properties:
+                                  driver:
+                                    description: |-
+                                      driver is the name of the CSI driver that handles this volume.
+                                      Consult with your admin for the correct name as registered in the cluster.
+                                    type: string
+                                  fsType:
+                                    description: |-
+                                      fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                      If not provided, the empty value is passed to the associated CSI driver
+                                      which will determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: |-
+                                      nodePublishSecretRef is a reference to the secret object containing
+                                      sensitive information to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if no secret is required. If the
+                                      secret object contains more than one secret, all secret references are passed.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: |-
+                                      readOnly specifies a read-only configuration for the volume.
+                                      Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      volumeAttributes stores driver-specific properties that are passed to the CSI
+                                      driver. Consult your driver's documentation for supported values.
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about
+                                  the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      Optional: mode bits to use on created files by default. Must be a
+                                      Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              emptyDir:
+                                description: |-
+                                  emptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                properties:
+                                  medium:
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: |-
+                                  ephemeral represents a volume that is handled by a cluster storage driver.
+                                  The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                  and deleted when the pod is removed.
+
+                                  Use this if:
+                                  a) the volume is only needed while the pod runs,
+                                  b) features of normal volumes like restoring from snapshot or capacity
+                                     tracking are needed,
+                                  c) the storage driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning through
+                                     a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                     information on the connection between this volume type
+                                     and PersistentVolumeClaim).
+
+                                  Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the lifecycle
+                                  of an individual pod.
+
+                                  Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                  be used that way - see the documentation of the driver for
+                                  more information.
+
+                                  A pod can use both types of ephemeral volumes and
+                                  persistent volumes at the same time.
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: |-
+                                      Will be used to create a stand-alone PVC to provision the volume.
+                                      The pod in which this EphemeralVolumeSource is embedded will be the
+                                      owner of the PVC, i.e. the PVC will be deleted together with the
+                                      pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes` array
+                                      entry. Pod validation will reject the pod if the concatenated name
+                                      is not valid for a PVC (for example, too long).
+
+                                      An existing PVC with that name that is not owned by the pod
+                                      will *not* be used for the pod to avoid using an unrelated
+                                      volume by mistake. Starting the pod is then blocked until
+                                      the unrelated PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to updated with an
+                                      owner reference to the pod once the pod exists. Normally
+                                      this should not be necessary, but it may be useful when
+                                      manually reconstructing a broken cluster.
+
+                                      This field is read-only and no changes will be made by Kubernetes
+                                      to the PVC after it has been created.
+
+                                      Required, must not be nil.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          May contain labels and annotations that will be copied into the PVC
+                                          when creating it. No other fields are allowed and will be rejected during
+                                          validation.
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          The specification for the PersistentVolumeClaim. The entire content is
+                                          copied unchanged into the PVC that gets created from this
+                                          template. The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: |-
+                                              accessModes contains the desired access modes the volume should have.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          dataSource:
+                                            description: |-
+                                              dataSource field can be used to specify either:
+                                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller can support the specified data source,
+                                              it will create a new volume based on the contents of the specified data source.
+                                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                            properties:
+                                              apiGroup:
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: |-
+                                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                              volume is desired. This may be any object from a non-empty API group (non
+                                              core object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume binding will only succeed if the type of
+                                              the specified object matches some installed volume populator or dynamic
+                                              provisioner.
+                                              This field will replace the functionality of the dataSource field and as such
+                                              if both fields are non-empty, they must have the same value. For backwards
+                                              compatibility, when namespace isn't specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef) will be set to the same
+                                              value automatically if one of them is empty and the other is non-empty.
+                                              When namespace is specified in dataSourceRef,
+                                              dataSource isn't set to the same value and must be empty.
+                                              There are three important differences between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                preserves all values, and generates an error if a disallowed value is
+                                                specified.
+                                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                                in any namespaces.
+                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            properties:
+                                              apiGroup:
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource
+                                                  being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource
+                                                  being referenced
+                                                type: string
+                                              namespace:
+                                                description: |-
+                                                  Namespace is the namespace of resource being referenced
+                                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                type: string
+                                            required:
+                                            - kind
+                                            - name
+                                            type: object
+                                          resources:
+                                            description: |-
+                                              resources represents the minimum resources the volume should have.
+                                              Users are allowed to specify resource requirements
+                                              that are lower than previous value but must still be higher than capacity recorded in the
+                                              status field of the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query
+                                              over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: |-
+                                              storageClassName is the name of the StorageClass required by the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: |-
+                                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                              If specified, the CSI driver will create or update the volume with the attributes defined
+                                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                              it can be changed after the claim is created. An empty string or nil value indicates that no
+                                              VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                              this field can be reset to its previous value (including nil) to cancel the modification.
+                                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                              exists.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                            type: string
+                                          volumeMode:
+                                            description: |-
+                                              volumeMode defines what type of volume is required by the claim.
+                                              Value of Filesystem is implied when not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding
+                                              reference to the PersistentVolume backing
+                                              this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                    - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource
+                                  that is attached to a kubelet's host machine and
+                                  then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target
+                                      worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  wwids:
+                                    description: |-
+                                      wwids Optional: FC volume world wide identifiers (wwids)
+                                      Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              flexVolume:
+                                description: |-
+                                  flexVolume represents a generic volume resource that is
+                                  provisioned/attached using an exec based plugin.
+                                  Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver
+                                      to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field
+                                      holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is Optional: secretRef is reference to the secret object containing
+                                      sensitive information to pass to the plugin scripts. This may be
+                                      empty if no secret object is specified. If the secret object
+                                      contains more than one secret, all secrets are passed to the plugin
+                                      scripts.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                description: |-
+                                  flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                  Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                properties:
+                                  datasetName:
+                                    description: |-
+                                      datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                      should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset.
+                                      This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: |-
+                                  gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                  gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: string
+                                  partition:
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: |-
+                                      pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                description: |-
+                                  gitRepo represents a git repository at a particular revision.
+                                  Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                  EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                  into the Pod's container.
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is the target directory name.
+                                      Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                      git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the
+                                      specified revision.
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                description: |-
+                                  glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                properties:
+                                  endpoints:
+                                    description: endpoints is the endpoint name that
+                                      details Glusterfs topology.
+                                    type: string
+                                  path:
+                                    description: |-
+                                      path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                description: |-
+                                  hostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                properties:
+                                  path:
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              image:
+                                description: |-
+                                  image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                  The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                  - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                  The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                  A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                  The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                  The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                  The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                properties:
+                                  pullPolicy:
+                                    description: |-
+                                      Policy for pulling OCI objects. Possible values are:
+                                      Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                      Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                      IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    type: string
+                                  reference:
+                                    description: |-
+                                      Required: Image or artifact reference to be used.
+                                      Behaves in the same way as pod.spec.containers[*].image.
+                                      Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
+                                type: object
+                              iscsi:
+                                description: |-
+                                  iscsi represents an ISCSI Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether
+                                      support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support
+                                      iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    type: string
+                                  initiatorName:
+                                    description: |-
+                                      initiatorName is the custom iSCSI Initiator Name.
+                                      If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                      <target portal>:<volume name> will be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified
+                                      Name.
+                                    type: string
+                                  iscsiInterface:
+                                    default: default
+                                    description: |-
+                                      iscsiInterface is the interface Name that uses an iSCSI transport.
+                                      Defaults to 'default' (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: |-
+                                      portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for
+                                      iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: |-
+                                      targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: |-
+                                  persistentVolumeClaimVolumeSource represents a reference to a
+                                  PersistentVolumeClaim in the same namespace.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                properties:
+                                  claimName:
+                                    description: |-
+                                      claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly Will force the ReadOnly setting in VolumeMounts.
+                                      Default false.
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: |-
+                                  photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                  Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon
+                                      Controller persistent disk
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                description: |-
+                                  portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                  Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                  is on.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fSType represents the filesystem type to mount
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx
+                                      volume
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources
+                                  secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
+                                    items:
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
+                                      properties:
+                                        clusterTrustBundle:
+                                          description: |-
+                                            ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                            of ClusterTrustBundle objects in an auto-updating file.
+
+                                            Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                            ClusterTrustBundle objects can either be selected by name, or by the
+                                            combination of signer name and a label selector.
+
+                                            Kubelet performs aggressive normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM features such as inter-block
+                                            comments and block headers are stripped.  Certificates are deduplicated.
+                                            The ordering of certificates within the file is arbitrary, and Kubelet
+                                            may change the order over time.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                Select all ClusterTrustBundles that match this label selector.  Only has
+                                                effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: |-
+                                                Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: |-
+                                                If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name, then the named ClusterTrustBundle is
+                                                allowed not to exist.  If using signerName, then the combination of
+                                                signerName and labelSelector is allowed to match zero
+                                                ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the
+                                                volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: |-
+                                                Select all ClusterTrustBundles that match this signer name.
+                                                Mutually-exclusive with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified and deduplicated.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                        configMap:
+                                          description: configMap information about
+                                            the configMap data to project
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: optional specify whether
+                                                the ConfigMap or its keys must be
+                                                defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about
+                                            the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume
+                                                file
+                                              items:
+                                                description: DownwardAPIVolumeFile
+                                                  represents information to create
+                                                  the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects
+                                                      a field of the pod: only annotations,
+                                                      labels, name, namespace and
+                                                      uid are supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the
+                                                          schema the FieldPath is
+                                                          written in terms of, defaults
+                                                          to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field
+                                                          to select in the specified
+                                                          API version.
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the
+                                                      relative path name of the file
+                                                      to be created. Must not be absolute
+                                                      or contain the ''..'' path.
+                                                      Must be utf-8 encoded. The first
+                                                      item of the relative path must
+                                                      not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name:
+                                                          required for volumes, optional
+                                                          for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: Specifies the
+                                                          output format of the exposed
+                                                          resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource
+                                                          to select'
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        podCertificate:
+                                          description: |-
+                                            Projects an auto-rotating credential bundle (private key and certificate
+                                            chain) that the pod can use either as a TLS client or server.
+
+                                            Kubelet generates a private key and uses it to send a
+                                            PodCertificateRequest to the named signer.  Once the signer approves the
+                                            request and issues a certificate chain, Kubelet writes the key and
+                                            certificate chain to the pod filesystem.  The pod does not start until
+                                            certificates have been issued for each podCertificate projected volume
+                                            source in its spec.
+
+                                            Kubelet will begin trying to rotate the certificate at the time indicated
+                                            by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                            timestamp.
+
+                                            Kubelet can write a single file, indicated by the credentialBundlePath
+                                            field, or separate files, indicated by the keyPath and
+                                            certificateChainPath fields.
+
+                                            The credential bundle is a single file in PEM format.  The first PEM
+                                            entry is the private key (in PKCS#8 format), and the remaining PEM
+                                            entries are the certificate chain issued by the signer (typically,
+                                            signers will return their certificate chain in leaf-to-root order).
+
+                                            Prefer using the credential bundle format, since your application code
+                                            can read it atomically.  If you use keyPath and certificateChainPath,
+                                            your application must make two separate file reads. If these coincide
+                                            with a certificate rotation, it is possible that the private key and leaf
+                                            certificate you read may not correspond to each other.  Your application
+                                            will need to check for this condition, and re-read until they are
+                                            consistent.
+
+                                            The named signer controls chooses the format of the certificate it
+                                            issues; consult the signer implementation's documentation to learn how to
+                                            use the certificates it issues.
+                                          properties:
+                                            certificateChainPath:
+                                              description: |-
+                                                Write the certificate chain at this path in the projected volume.
+
+                                                Most applications should use credentialBundlePath.  When using keyPath
+                                                and certificateChainPath, your application needs to check that the key
+                                                and leaf certificate are consistent, because it is possible to read the
+                                                files mid-rotation.
+                                              type: string
+                                            credentialBundlePath:
+                                              description: |-
+                                                Write the credential bundle at this path in the projected volume.
+
+                                                The credential bundle is a single file that contains multiple PEM blocks.
+                                                The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                key.
+
+                                                The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                certificate chain from the signer (leaf and any intermediates).
+
+                                                Using credentialBundlePath lets your Pod's application code make a single
+                                                atomic read that retrieves a consistent key and certificate chain.  If you
+                                                project them to separate files, your application code will need to
+                                                additionally check that the leaf certificate was issued to the key.
+                                              type: string
+                                            keyPath:
+                                              description: |-
+                                                Write the key at this path in the projected volume.
+
+                                                Most applications should use credentialBundlePath.  When using keyPath
+                                                and certificateChainPath, your application needs to check that the key
+                                                and leaf certificate are consistent, because it is possible to read the
+                                                files mid-rotation.
+                                              type: string
+                                            keyType:
+                                              description: |-
+                                                The type of keypair Kubelet will generate for the pod.
+
+                                                Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                "ECDSAP521", and "ED25519".
+                                              type: string
+                                            maxExpirationSeconds:
+                                              description: |-
+                                                maxExpirationSeconds is the maximum lifetime permitted for the
+                                                certificate.
+
+                                                Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                generates for this projection.
+
+                                                If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                value is 7862400 (91 days).
+
+                                                The signer implementation is then free to issue a certificate with any
+                                                lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                `kubernetes.io` signers will never issue certificates with a lifetime
+                                                longer than 24 hours.
+                                              format: int32
+                                              type: integer
+                                            signerName:
+                                              description: Kubelet's generated CSRs
+                                                will be addressed to this signer.
+                                              type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                userAnnotations allow pod authors to pass additional information to
+                                                the signer implementation.  Kubernetes does not restrict or validate this
+                                                metadata in any way.
+
+                                                These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                the PodCertificateRequest objects that Kubelet creates.
+
+                                                Entries are subject to the same validation as object metadata annotations,
+                                                with the addition that all keys must be domain-prefixed. No restrictions
+                                                are placed on values, except an overall size limitation on the entire field.
+
+                                                Signers should document the keys and values they support. Signers should
+                                                deny requests that contain keys they do not recognize.
+                                              type: object
+                                          required:
+                                          - keyType
+                                          - signerName
+                                          type: object
+                                        secret:
+                                          description: secret information about the
+                                            secret data to project
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to
+                                                  a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to
+                                                      project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: optional field specify
+                                                whether the Secret or its key must
+                                                be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information
+                                            about the serviceAccountToken data to
+                                            project
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              quobyte:
+                                description: |-
+                                  quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                  Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                properties:
+                                  group:
+                                    description: |-
+                                      group to map volume access to
+                                      Default is no group
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: |-
+                                      registry represents a single or multiple Quobyte Registry services
+                                      specified as a string as host:port pair (multiple entries are separated with commas)
+                                      which acts as the central registry for volumes
+                                    type: string
+                                  tenant:
+                                    description: |-
+                                      tenant owning the given Quobyte volume in the Backend
+                                      Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: |-
+                                      user to map volume access to
+                                      Defaults to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references
+                                      an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                description: |-
+                                  rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    type: string
+                                  image:
+                                    description: |-
+                                      image is the rados image name.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  keyring:
+                                    default: /etc/ceph/keyring
+                                    description: |-
+                                      keyring is the path to key ring for RBDUser.
+                                      Default is /etc/ceph/keyring.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  monitors:
+                                    description: |-
+                                      monitors is a collection of Ceph monitors.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  pool:
+                                    default: rbd
+                                    description: |-
+                                      pool is the rados pool name.
+                                      Default is rbd.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is name of the authentication secret for RBDUser. If provided
+                                      overrides keyring.
+                                      Default is nil.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    default: admin
+                                    description: |-
+                                      user is the rados user name.
+                                      Default is admin.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                description: |-
+                                  scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                properties:
+                                  fsType:
+                                    default: xfs
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs".
+                                      Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the
+                                      ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the
+                                      ScaleIO Protection Domain for the configured
+                                      storage.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef references to the secret for ScaleIO user and other
+                                      sensitive information. If this is not provided, Login operation will fail.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL
+                                      communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    default: ThinProvisioned
+                                    description: |-
+                                      storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                      Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage
+                                      Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage
+                                      system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: |-
+                                      volumeName is the name of a volume already created in the ScaleIO system
+                                      that is associated with this volume source.
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+                                type: object
+                              storageos:
+                                description: |-
+                                  storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef specifies the secret to use for obtaining the StorageOS API
+                                      credentials.  If not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: |-
+                                      volumeName is the human-readable name of the StorageOS volume.  Volume
+                                      names are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: |-
+                                      volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                      namespace is specified then the Pod's namespace will be used.  This allows the
+                                      Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                      Set VolumeName to any name to override the default behaviour.
+                                      Set to "default" if you are not using namespaces within StorageOS.
+                                      Namespaces that do not pre-exist within StorageOS will be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: |-
+                                  vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                  Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                  are redirected to the csi.vsphere.vmware.com CSI driver.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy
+                                      Based Management (SPBM) profile ID associated
+                                      with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage
+                                      Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies
+                                      vSphere volume vmdk
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    description: Override the default configurations of the agents
+                    type: object
+                type: object
+              profileAffinity:
+                properties:
+                  profileNodeAffinity:
+                    items:
+                      description: |-
+                        A node selector requirement is a selector that contains values, a key, and an operator
+                        that relates the key and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: |-
+                            Represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                          type: string
+                        values:
+                          description: |-
+                            An array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted as an integer.
+                            This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DatadogAgentProfileStatus defines the observed state of DatadogAgentProfile
+            properties:
+              applied:
+                description: Applied shows whether the DatadogAgentProfile conflicts
+                  with an existing DatadogAgentProfile.
+                type: string
+              conditions:
+                description: Conditions represents the latest available observations
+                  of a DatadogAgentProfile's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              createStrategy:
+                description: CreateStrategy is the state of the create strategy feature.
+                properties:
+                  lastTransition:
+                    description: LastTransition is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  maxUnavailable:
+                    description: MaxUnavailable shows the number of pods that can
+                      be in an unready state.
+                    format: int32
+                    type: integer
+                  nodesLabeled:
+                    description: NodesLabeled shows the number of nodes currently
+                      labeled.
+                    format: int32
+                    type: integer
+                  podsReady:
+                    description: PodsReady shows the number of pods in the ready state.
+                    format: int32
+                    type: integer
+                  status:
+                    description: Status shows the current state of the feature.
+                    type: string
+                type: object
+              currentHash:
+                description: CurrentHash is the stored hash of the DatadogAgentProfile.
+                type: string
+              lastUpdate:
+                description: LastUpdate is the last time the status was updated.
+                format: date-time
+                type: string
+              valid:
+                description: Valid shows if the DatadogAgentProfile has a valid config
+                  spec.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogagents.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogagents.yaml
@@ -1,0 +1,12110 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogagents.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogAgent
+    listKind: DatadogAgentList
+    plural: datadogagents
+    shortNames:
+    - dd
+    singular: datadogagent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.agent.status
+      name: agent
+      type: string
+    - jsonPath: .status.clusterAgent.status
+      name: cluster-agent
+      type: string
+    - jsonPath: .status.clusterChecksRunner.status
+      name: cluster-checks-runner
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    - jsonPath: .status.experiment.phase
+      name: experiment-phase
+      priority: 1
+      type: string
+    name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogAgent defines Agent configuration, see reference https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogAgentSpec defines the desired state of DatadogAgent
+            properties:
+              features:
+                description: Features running on the Agent and Cluster Agent
+                properties:
+                  admissionController:
+                    description: AdmissionController configuration.
+                    properties:
+                      agentCommunicationMode:
+                        description: |-
+                          AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent.
+                          It can be "hostip", "service", or "socket".
+                        type: string
+                      agentSidecarInjection:
+                        description: AgentSidecarInjection contains Agent sidecar
+                          injection configurations.
+                        properties:
+                          clusterAgentCommunicationEnabled:
+                            description: |-
+                              ClusterAgentCommunicationEnabled enables communication between Agent sidecars and the Cluster Agent.
+                              Default : true
+                            type: boolean
+                          clusterAgentTlsVerification:
+                            description: ClusterAgentTLSVerification configures TLS
+                              verification for Agent sidecar to Cluster Agent communication.
+                            properties:
+                              copyCaConfigMap:
+                                description: |-
+                                  CopyCaConfigMap enables automatic creation of a ConfigMap containing the Cluster Agent's CA certificate
+                                  in namespaces where sidecar injection occurs.
+                                  Default: false
+                                type: boolean
+                              enabled:
+                                description: |-
+                                  Enabled enables TLS verification for agent sidecars communicating with the Cluster Agent.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Sidecar injections.
+                              Default: false
+                            type: boolean
+                          image:
+                            description: Image overrides the default Agent image name
+                              and tag for the Agent sidecar.
+                            properties:
+                              jmxEnabled:
+                                description: |-
+                                  Define whether the Agent image should support JMX.
+                                  To be used if the `Name` field does not correspond to a full image string.
+                                type: boolean
+                              name:
+                                description: |-
+                                  Defines the Agent image name for the pod. You can provide this as:
+                                  * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                  for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                  * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                  and `[key].image.jmxEnabled` are ignored.
+                                  * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                    like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                                type: string
+                              pullPolicy:
+                                description: |-
+                                  The Kubernetes pull policy:
+                                  Use `Always`, `Never`, or `IfNotPresent`.
+                                type: string
+                              pullSecrets:
+                                description: |-
+                                  It is possible to specify Docker registry credentials.
+                                  See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                                items:
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                              tag:
+                                description: |-
+                                  Define the image tag to use.
+                                  To be used if the `Name` field does not correspond to a full image string.
+                                type: string
+                            type: object
+                          profiles:
+                            description: Profiles define the sidecar configuration
+                              override. Only one profile is supported.
+                            items:
+                              description: Profile defines a sidecar configuration
+                                override.
+                              properties:
+                                env:
+                                  description: EnvVars specifies the environment variables
+                                    for the profile.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                resources:
+                                  description: ResourceRequirements specifies the
+                                    resource requirements for the profile.
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This field depends on the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                securityContext:
+                                  description: SecurityContext specifies the security
+                                    context for the profile.
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX
+                                              capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label
+                                            that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label
+                                            that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label
+                                            that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label
+                                            that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the
+                                            name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          provider:
+                            description: |-
+                              Provider is used to add infrastructure provider-specific configurations to the Agent sidecar.
+                              Currently only "fargate" is supported.
+                              To use the feature in other environments (including local testing) omit the config.
+                              See also: https://docs.datadoghq.com/integrations/eks_fargate
+                            type: string
+                          registry:
+                            description: Registry overrides the default registry for
+                              the sidecar Agent.
+                            type: string
+                          selectors:
+                            description: Selectors define the pod selector for sidecar
+                              injection. Only one rule is supported.
+                            items:
+                              description: Selectors define a pod selector for sidecar
+                                injection.
+                              properties:
+                                namespaceSelector:
+                                  description: NamespaceSelector specifies the label
+                                    selector for namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                objectSelector:
+                                  description: ObjectSelector specifies the label
+                                    selector for objects.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      cwsInstrumentation:
+                        description: CWSInstrumentation holds the CWS Instrumentation
+                          endpoint configuration
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable the CWS Instrumentation admission controller endpoint.
+                              Default: false
+                            type: boolean
+                          mode:
+                            description: |-
+                              Mode defines the behavior of the CWS Instrumentation endpoint, and can be either "init_container" or "remote_copy".
+                              Default: "remote_copy"
+                            type: string
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the Admission Controller.
+                          Default: true
+                        type: boolean
+                      failurePolicy:
+                        description: FailurePolicy determines how unrecognized and
+                          timeout errors are handled.
+                        type: string
+                      kubernetesAdmissionEvents:
+                        description: KubernetesAdmissionEvents holds the Kubernetes
+                          Admission Events configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable the Kubernetes Admission Events feature.
+                              Default: false
+                            type: boolean
+                        type: object
+                      mutateUnlabelled:
+                        description: |-
+                          MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'.
+                          Default: false
+                        type: boolean
+                      mutation:
+                        description: Mutation contains Admission Controller mutation
+                          configurations.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller mutation webhook.
+                              Default: true
+                            type: boolean
+                        type: object
+                      probe:
+                        description: Probe holds the admission controller connectivity
+                          probe configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the admission controller connectivity probe.
+                              The probe periodically sends dry-run ConfigMap creation requests to verify the
+                              webhook is reachable from the API server. Requires Cluster Agent 7.78.0+.
+                              Default: true
+                            type: boolean
+                          gracePeriod:
+                            description: |-
+                              GracePeriod is the number of seconds to wait at startup before the first probe.
+                              Default: 60
+                            format: int32
+                            type: integer
+                          interval:
+                            description: |-
+                              Interval is the number of seconds between probe executions.
+                              Default: 60
+                            format: int32
+                            type: integer
+                        type: object
+                      registry:
+                        description: Registry defines an image registry for the admission
+                          controller.
+                        type: string
+                      serviceName:
+                        description: ServiceName corresponds to the webhook service
+                          name.
+                        type: string
+                      validation:
+                        description: Validation contains Admission Controller validation
+                          configurations.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller validation webhook.
+                              Default: true
+                            type: boolean
+                        type: object
+                      webhookName:
+                        description: |-
+                          WebhookName is a custom name for the MutatingWebhookConfiguration.
+                          Default: "datadog-webhook"
+                        type: string
+                    type: object
+                  apm:
+                    description: APM (Application Performance Monitoring) configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables Application Performance Monitoring.
+                          Default: true
+                        type: boolean
+                      errorTrackingStandalone:
+                        description: |-
+                          ErrorTrackingStandalone contains the configuration for the Error Tracking standalone feature.
+                          Feature is in preview.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables Error Tracking for backend services.
+                              Default: false
+                            type: boolean
+                        type: object
+                      hostPortConfig:
+                        description: |-
+                          HostPortConfig contains host port configuration.
+                          Enabled Default: false
+                          Port Default: 8126
+                        properties:
+                          enabled:
+                            description: Enabled enables host port configuration
+                            type: boolean
+                          hostPort:
+                            description: |-
+                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                              If HostNetwork is enabled, this value must match the ContainerPort.
+                            format: int32
+                            type: integer
+                        type: object
+                      instrumentation:
+                        description: |-
+                          SingleStepInstrumentation allows the agent to inject the Datadog APM libraries into all pods in the cluster.
+                          Feature is in beta.
+                          See also: https://docs.datadoghq.com/tracing/trace_collection/single-step-apm
+                          Enabled Default: false
+                        properties:
+                          disabledNamespaces:
+                            description: DisabledNamespaces disables injecting the
+                              Datadog APM libraries into pods in specific namespaces.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          enabled:
+                            description: |-
+                              Enabled enables injecting the Datadog APM libraries into all pods in the cluster.
+                              Default: false
+                            type: boolean
+                          enabledNamespaces:
+                            description: EnabledNamespaces enables injecting the Datadog
+                              APM libraries into pods in specific namespaces.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          injectionMode:
+                            description: |-
+                              InjectionMode is the injection mode to use for libraries injection.
+                              Valid values are: "auto", "init_container", "csi" (experimental, requires Cluster Agent 7.76.0+ and Datadog CSI Driver 1.2.0+), "image_volume" (experimental, requires Cluster Agent 7.77.0+).
+                              Empty by default so the Cluster Agent can apply its own defaults.
+                            enum:
+                            - auto
+                            - init_container
+                            - csi
+                            - image_volume
+                            type: string
+                          injector:
+                            description: Injector configures the APM Injector.
+                            properties:
+                              imageTag:
+                                description: |-
+                                  Set the image tag to use for the APM Injector.
+                                  (Requires Cluster Agent 7.57.0+)
+                                type: string
+                            type: object
+                          languageDetection:
+                            description: |-
+                              LanguageDetection detects languages and adds them as annotations on Deployments, but does not use these languages for injecting libraries to workload pods.
+                              (Requires Agent 7.52.0+ and Cluster Agent 7.52.0+)
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Language Detection to automatically detect languages of user workloads (beta).
+                                  Requires SingleStepInstrumentation.Enabled to be true.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          libVersions:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.
+                              <Library>: <Version>
+                              ex: "java": "v1.18.0"
+                            type: object
+                          targets:
+                            description: |-
+                              Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
+                              used. If no target matches, the auto instrumentation will not be applied.
+                              (Requires Cluster Agent 7.64.0+)
+                            items:
+                              description: SSITarget is a rule to apply the auto instrumentation
+                                to a specific workload using the pod and namespace
+                                selectors.
+                              properties:
+                                ddTraceConfigs:
+                                  description: |-
+                                    TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+                                    as environment variables in addition to the injected tracer.
+                                  items:
+                                    description: EnvVar represents an environment
+                                      variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name of the environment variable.
+                                          May consist of any printable ASCII characters except '='.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's
+                                          value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fileKeyRef:
+                                            description: |-
+                                              FileKeyRef selects a key of the env file.
+                                              Requires the EnvFiles feature gate to be enabled.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                type: string
+                                              optional:
+                                                default: false
+                                                description: |-
+                                                  Specify whether the file or its key must be defined. If the file or key
+                                                  does not exist, then the env var is not published.
+                                                  If optional is set to true and the specified key does not exist,
+                                                  the environment variable will not be set in the Pod's containers.
+
+                                                  If optional is set to false and the specified key does not exist,
+                                                  an error will be returned during Pod creation.
+                                                type: boolean
+                                              path:
+                                                description: |-
+                                                  The path within the volume from which to select the file.
+                                                  Must be relative and may not contain the '..' path or start with '..'.
+                                                type: string
+                                              volumeName:
+                                                description: The name of the volume
+                                                  mount containing the env file.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            - volumeName
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret
+                                              in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret
+                                                  to select from.  Must be a valid
+                                                  secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                ddTraceVersions:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
+                                    name and the value is the version to inject.
+                                  type: object
+                                name:
+                                  description: Name is the name of the target. It
+                                    will be appended to the pod annotations to identify
+                                    the target that was used.
+                                  type: string
+                                namespaceSelector:
+                                  description: |-
+                                    NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
+                                    be used in conjunction with the Selector to match the pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: |-
+                                        MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
+                                        expressions are ANDed. This cannot be used with MatchNames.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
+                                        ANDed. This cannot be used with MatchNames.
+                                      type: object
+                                    matchNames:
+                                      description: MatchNames is a list of namespace
+                                        names to match. If empty, all namespaces are
+                                        matched.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                podSelector:
+                                  description: |-
+                                    PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
+                                    conjunction with the NamespaceSelector to match the pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            type: array
+                        type: object
+                      unixDomainSocketConfig:
+                        description: |-
+                          UnixDomainSocketConfig contains socket configuration.
+                          See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                          Enabled Default: true
+                          Path Default: `/var/run/datadog/apm.socket`
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Unix Domain Socket.
+                              Default: true
+                            type: boolean
+                          path:
+                            description: Path defines the socket path used when enabled.
+                            type: string
+                        type: object
+                    type: object
+                  asm:
+                    description: ASM (Application Security Management) configuration.
+                    properties:
+                      iast:
+                        description: |-
+                          IAST configures Interactive Application Security Testing.
+                          Enabled Default: false
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Interactive Application Security Testing (IAST).
+                              Default: false
+                            type: boolean
+                        type: object
+                      sca:
+                        description: |-
+                          SCA configures Software Composition Analysis.
+                          Enabled Default: false
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Software Composition Analysis (SCA).
+                              Default: false
+                            type: boolean
+                        type: object
+                      threats:
+                        description: |-
+                          Threats configures ASM App & API Protection.
+                          Enabled Default: false
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables ASM App & API Protection.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                  autoscaling:
+                    description: Autoscaling configuration.
+                    properties:
+                      cluster:
+                        description: Cluster contains the configuration for the cluster
+                          autoscaling product.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the cluster autoscaling product.
+                              (Requires Cluster Agent 7.74.0+)
+                              Default: false
+                            type: boolean
+                          spot:
+                            description: |-
+                              Spot contains the configuration for the spot instance scheduling sub-feature.
+                              Requires cluster autoscaling to be enabled.
+                              (Requires Cluster Agent 7.79.0+)
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the cluster spot scheduling product.
+                                  (Requires Cluster Agent 7.79.0+)
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      workload:
+                        description: Workload contains the configuration for the workload
+                          autoscaling product.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the workload autoscaling product.
+                              Default: false
+                            type: boolean
+                          inPlaceVerticalScaling:
+                            description: |-
+                              InPlaceVerticalScaling contains the configuration for the in-place vertical scaling sub-feature.
+                              Requires workload autoscaling to be enabled.
+                              (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables in-place vertical scaling for workload autoscaling.
+                                  (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                    type: object
+                  clusterChecks:
+                    description: ClusterChecks configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables Cluster Checks scheduling in the Cluster Agent.
+                          Default: true
+                        type: boolean
+                      useClusterChecksRunners:
+                        description: |-
+                          Enabled enables Cluster Checks Runners to run all Cluster Checks.
+                          Default: false
+                        type: boolean
+                    type: object
+                  controlPlaneMonitoring:
+                    description: ControlPlaneMonitoring configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables control plane monitoring checks in the cluster agent.
+                          Default: true
+                        type: boolean
+                    type: object
+                  cspm:
+                    description: CSPM (Cloud Security Posture Management) configuration.
+                    properties:
+                      checkInterval:
+                        description: CheckInterval defines the check interval.
+                        type: string
+                      customBenchmarks:
+                        description: |-
+                          CustomBenchmarks contains CSPM benchmarks.
+                          The content of the ConfigMap will be merged with the benchmarks bundled with the agent.
+                          Any benchmarks with the same name as those existing in the agent will take precedence.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables Cloud Security Posture Management, including Docker and Kubernetes benchmarks.
+                          Default: false
+                        type: boolean
+                      hostBenchmarks:
+                        description: HostBenchmarks contains configuration for host
+                          benchmarks.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Linux host benchmarks. Requires `features.cspm.enabled` to be set to `true`.
+                              Default: true
+                            type: boolean
+                        type: object
+                      runInSystemProbe:
+                        description: |-
+                          RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                          This is an experimental feature. Contact support before using.
+                          Default: false
+                        type: boolean
+                    type: object
+                  cws:
+                    description: CWS (Cloud Workload Security) configuration.
+                    properties:
+                      customPolicies:
+                        description: |-
+                          CustomPolicies contains security policies.
+                          The content of the ConfigMap will be merged with the policies bundled with the agent.
+                          Any policies with the same name as those existing in the agent will take precedence.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      directSendFromSystemProbe:
+                        description: |-
+                          DirectSendFromSystemProbe configures CWS to send payloads directly from the system-probe, without using the security-agent.
+                          This is an experimental feature. Contact support before using.
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enabled enables Cloud Workload Security.
+                          Default: false
+                        type: boolean
+                      enforcement:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Enforcement for Cloud Workload Security.
+                              Default: true
+                            type: boolean
+                        type: object
+                      network:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Workload Security Network detections.
+                              Default: true
+                            type: boolean
+                        type: object
+                      remoteConfiguration:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Remote Configuration for Cloud Workload Security.
+                              Default: true
+                            type: boolean
+                        type: object
+                      securityProfiles:
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Security Profiles collection for Cloud Workload Security.
+                              Default: true
+                            type: boolean
+                        type: object
+                      syscallMonitorEnabled:
+                        description: |-
+                          SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only).
+                          Default: false
+                        type: boolean
+                    type: object
+                  dataPlane:
+                    description: |-
+                      DataPlane configuration for the Agent Data Plane.
+                      Agent Data Plane is a high-performance sidecar that handles data ingestion.
+                    properties:
+                      dogstatsd:
+                        description: Dogstatsd configures DogStatsD handling by the
+                          Data Plane.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled configures the Data Plane to handle DogStatsD traffic.
+                              When set to false, DogStatsD is handled by the Core Agent instead.
+                              Default: true
+                            type: boolean
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the Data Plane.
+                          Default: false
+                        type: boolean
+                    type: object
+                  dogstatsd:
+                    description: Dogstatsd configuration.
+                    properties:
+                      hostPortConfig:
+                        description: |-
+                          HostPortConfig contains host port configuration.
+                          Enabled Default: false
+                          Port Default: 8125
+                        properties:
+                          enabled:
+                            description: Enabled enables host port configuration
+                            type: boolean
+                          hostPort:
+                            description: |-
+                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                              If HostNetwork is enabled, this value must match the ContainerPort.
+                            format: int32
+                            type: integer
+                        type: object
+                      mapperProfiles:
+                        description: |-
+                          Configure the Dogstasd Mapper Profiles.
+                          Can be passed as raw data or via a json encoded string in a config map.
+                          See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      nonLocalTraffic:
+                        description: |-
+                          NonLocalTraffic enables non-local traffic for Dogstatsd.
+                          Default: true
+                        type: boolean
+                      originDetectionEnabled:
+                        description: |-
+                          OriginDetectionEnabled enables origin detection for container tagging.
+                          See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+                        type: boolean
+                      tagCardinality:
+                        description: |-
+                          TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                          This setting only applies when OriginDetectionEnabled is true.
+                          See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
+                          Cardinality default: low
+                        type: string
+                      unixDomainSocketConfig:
+                        description: |-
+                          UnixDomainSocketConfig contains socket configuration.
+                          See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                          Enabled Default: true
+                          Path Default: `/var/run/datadog/dsd.socket`
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Unix Domain Socket.
+                              Default: true
+                            type: boolean
+                          path:
+                            description: Path defines the socket path used when enabled.
+                            type: string
+                        type: object
+                    type: object
+                  dynamicInstrumentation:
+                    description: DynamicInstrumentation configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the Dynamic Instrumentation system probe module.
+                          Default: false
+                        type: boolean
+                    type: object
+                  ebpfCheck:
+                    description: EBPFCheck configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the eBPF check.
+                          Default: false
+                        type: boolean
+                    type: object
+                  eventCollection:
+                    description: EventCollection configuration.
+                    properties:
+                      collectKubernetesEvents:
+                        description: |-
+                          CollectKubernetesEvents enables Kubernetes event collection.
+                          Default: true
+                        type: boolean
+                      collectedEventTypes:
+                        description: |-
+                          CollectedEventTypes defines the list of events to collect when UnbundleEvents is enabled.
+                          Default:
+                          [
+                          {"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},
+                          {"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},
+                          {"kind":"CronJob","reasons":["SawCompletedJob"]}
+                          ]
+                        items:
+                          description: EventTypes defines the kind and reasons of
+                            events to collect.
+                          properties:
+                            kind:
+                              description: 'Kind is the kind of event to collect.
+                                (ex: Pod, Node, CronJob)'
+                              type: string
+                            reasons:
+                              description: 'Reasons is a list of event reasons to
+                                collect. (ex: Failed, BackOff, Unhealthy)'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - kind
+                          - reasons
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      unbundleEvents:
+                        description: |-
+                          UnbundleEvents enables collection of Kubernetes events as individual events.
+                          Default: false
+                        type: boolean
+                    type: object
+                  externalMetricsServer:
+                    description: ExternalMetricsServer configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the External Metrics Server.
+                          Default: false
+                        type: boolean
+                      endpoint:
+                        description: |-
+                          Override the API endpoint for the External Metrics Server.
+                          URL Default: "https://app.datadoghq.com".
+                        properties:
+                          credentials:
+                            description: Credentials defines the Datadog credentials
+                              used to submit data to/query data from Datadog.
+                            properties:
+                              apiKey:
+                                description: |-
+                                  APIKey configures your Datadog API key.
+                                  See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                                type: string
+                              apiSecret:
+                                description: |-
+                                  APISecret references an existing Secret which stores the API key instead of creating a new one.
+                                  If set, this parameter takes precedence over "APIKey".
+                                properties:
+                                  keyName:
+                                    description: KeyName is the key of the secret
+                                      to use.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of the secret.
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                              appKey:
+                                description: |-
+                                  AppKey configures your Datadog application key.
+                                  If you are using features.externalMetricsServer.enabled = true, you must set
+                                  a Datadog application key for read access to your metrics.
+                                type: string
+                              appSecret:
+                                description: |-
+                                  AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                                  If set, this parameter takes precedence over "AppKey".
+                                properties:
+                                  keyName:
+                                    description: KeyName is the key of the secret
+                                      to use.
+                                    type: string
+                                  secretName:
+                                    description: SecretName is the name of the secret.
+                                    type: string
+                                required:
+                                - secretName
+                                type: object
+                            type: object
+                          url:
+                            description: URL defines the endpoint URL.
+                            type: string
+                        type: object
+                      port:
+                        description: |-
+                          Port specifies the metricsProvider External Metrics Server service port.
+                          Default: 8443
+                        format: int32
+                        type: integer
+                      registerAPIService:
+                        description: |-
+                          RegisterAPIService registers the External Metrics endpoint as an APIService
+                          Default: true
+                        type: boolean
+                      useDatadogMetrics:
+                        description: |-
+                          UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries).
+                          Default: true
+                        type: boolean
+                      wpaController:
+                        description: |-
+                          WPAController enables the informer and controller of the Watermark Pod Autoscaler.
+                          NOTE: The Watermark Pod Autoscaler controller needs to be installed.
+                          See also: https://github.com/DataDog/watermarkpodautoscaler.
+                          Default: false
+                        type: boolean
+                    type: object
+                  gpu:
+                    description: GPU monitoring
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables GPU monitoring core check.
+                          Default: false
+                        type: boolean
+                      patchCgroupPermissions:
+                        description: |-
+                          PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case
+                          the container runtime is not properly configured and the Agent containers lose access to GPU devices.
+                          Default: false
+                        type: boolean
+                      privilegedMode:
+                        description: |-
+                          PrivilegedMode enables GPU Probe module in System Probe.
+                          Default: false
+                        type: boolean
+                      requiredRuntimeClassName:
+                        description: |-
+                          PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature.
+                          If the value is an empty string, the runtime class is not set.
+                          Default: nvidia
+                        type: string
+                    type: object
+                  helmCheck:
+                    description: HelmCheck configuration.
+                    properties:
+                      collectEvents:
+                        description: |-
+                          CollectEvents set to `true` enables event collection in the Helm check
+                          (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+)
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enabled enables the Helm check.
+                          Default: false
+                        type: boolean
+                      valuesAsTags:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ValuesAsTags collects Helm values from a release and uses them as tags
+                          (Requires Agent and Cluster Agent 7.40.0+).
+                          Default: {}
+                        type: object
+                    type: object
+                  kubeStateMetricsCore:
+                    description: KubeStateMetricsCore check configuration.
+                    properties:
+                      collectCrMetrics:
+                        description: |-
+                          `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                          The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                          The exact structure and existing fields of each item in this list can be found in:
+                          https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                        items:
+                          description: Resource configures a custom resource for metric
+                            generation.
+                          properties:
+                            commonLabels:
+                              additionalProperties:
+                                type: string
+                              description: CommonLabels are added to all metrics.
+                              type: object
+                            groupVersionKind:
+                              description: GroupVersionKind of the custom resource
+                                to be monitored.
+                              properties:
+                                group:
+                                  type: string
+                                kind:
+                                  type: string
+                                version:
+                                  type: string
+                              type: object
+                            labelsFromPath:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: LabelsFromPath adds additional labels where
+                                the value is taken from a field in the resource.
+                              type: object
+                            metricNamePrefix:
+                              description: |-
+                                MetricNamePrefix defines a prefix for all metrics of the resource.
+                                If set to "", no prefix will be added.
+                                Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                              type: string
+                            metrics:
+                              description: Metrics are the custom resource fields
+                                to be collected.
+                              items:
+                                description: Generator describes a unique metric name.
+                                properties:
+                                  commonLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: CommonLabels are added to all metrics.
+                                    type: object
+                                  each:
+                                    description: Each targets a value or values from
+                                      the resource.
+                                    properties:
+                                      gauge:
+                                        description: Gauge defines a gauge metric.
+                                        properties:
+                                          labelFromKey:
+                                            description: LabelFromKey adds a label
+                                              with the given name if Path is an object.
+                                              The label value will be the object key.
+                                            type: string
+                                          labelsFromPath:
+                                            additionalProperties:
+                                              items:
+                                                type: string
+                                              type: array
+                                            description: LabelsFromPath adds additional
+                                              labels where the value of the label
+                                              is taken from a field under Path.
+                                            type: object
+                                          nilIsZero:
+                                            description: NilIsZero indicates that
+                                              if a value is nil it will be treated
+                                              as zero value.
+                                            type: boolean
+                                          path:
+                                            description: Path is the path to to generate
+                                              metric(s) for.
+                                            items:
+                                              type: string
+                                            type: array
+                                          valueFrom:
+                                            description: ValueFrom is the path to
+                                              a numeric field under Path that will
+                                              be the metric value.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - path
+                                        type: object
+                                      info:
+                                        description: Info defines an info metric.
+                                        properties:
+                                          labelFromKey:
+                                            description: LabelFromKey adds a label
+                                              with the given name if Path is an object.
+                                              The label value will be the object key.
+                                            type: string
+                                          labelsFromPath:
+                                            additionalProperties:
+                                              items:
+                                                type: string
+                                              type: array
+                                            description: LabelsFromPath adds additional
+                                              labels where the value of the label
+                                              is taken from a field under Path.
+                                            type: object
+                                          path:
+                                            description: Path is the path to to generate
+                                              metric(s) for.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - path
+                                        type: object
+                                      stateSet:
+                                        description: StateSet defines a state set
+                                          metric.
+                                        properties:
+                                          labelName:
+                                            description: LabelName is the key of the
+                                              label which is used for each entry in
+                                              List to expose the value.
+                                            type: string
+                                          labelsFromPath:
+                                            additionalProperties:
+                                              items:
+                                                type: string
+                                              type: array
+                                            description: LabelsFromPath adds additional
+                                              labels where the value of the label
+                                              is taken from a field under Path.
+                                            type: object
+                                          list:
+                                            description: List is the list of values
+                                              to expose a value for.
+                                            items:
+                                              type: string
+                                            type: array
+                                          path:
+                                            description: Path is the path to to generate
+                                              metric(s) for.
+                                            items:
+                                              type: string
+                                            type: array
+                                          valueFrom:
+                                            description: ValueFrom is the subpath
+                                              to compare the list to.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - path
+                                        type: object
+                                      type:
+                                        description: Type defines the type of the
+                                          metric.
+                                        type: string
+                                    type: object
+                                  help:
+                                    description: Help text for the metric.
+                                    type: string
+                                  labelsFromPath:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: LabelsFromPath adds additional labels
+                                      where the value is taken from a field in the
+                                      resource.
+                                    type: object
+                                  name:
+                                    description: Name of the metric. Subject to prefixing
+                                      based on the configuration of the Resource.
+                                    type: string
+                                type: object
+                              type: array
+                            resourcePlural:
+                              description: ResourcePlural sets the plural name of
+                                the resource. Defaults to the plural version of the
+                                Kind according to flect.Pluralize.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                          This must point to a ConfigMap containing a valid cluster check configuration.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables Kube State Metrics Core.
+                          Default: true
+                        type: boolean
+                    type: object
+                  kubernetesActions:
+                    description: KubernetesActions configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the Kubernetes Actions feature on the Cluster Agent.
+                          Default: false
+                        type: boolean
+                    type: object
+                  liveContainerCollection:
+                    description: LiveContainerCollection configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables container collection for the Live Container View.
+                          Default: true
+                        type: boolean
+                    type: object
+                  liveProcessCollection:
+                    description: LiveProcessCollection configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables Process monitoring.
+                          Default: false
+                        type: boolean
+                      scrubProcessArguments:
+                        description: |-
+                          ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ).
+                          Default: true
+                        type: boolean
+                      stripProcessArguments:
+                        description: |-
+                          StripProcessArguments enables stripping of all process arguments.
+                          Default: false
+                        type: boolean
+                    type: object
+                  logCollection:
+                    description: LogCollection configuration.
+                    properties:
+                      autoMultiLineDetection:
+                        description: |-
+                          AutoMultiLineDetection allows the Agent to detect and aggregate common multi-line logs automatically.
+                          See also: https://docs.datadoghq.com/agent/logs/auto_multiline_detection/
+                        type: boolean
+                      containerCollectAll:
+                        description: |-
+                          ContainerCollectAll enables Log collection from all containers.
+                          Default: false
+                        type: boolean
+                      containerCollectUsingFiles:
+                        description: |-
+                          ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API.
+                          Collecting logs from files is usually the most efficient way of collecting logs.
+                          See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                          Default: true
+                        type: boolean
+                      containerLogsPath:
+                        description: |-
+                          ContainerLogsPath allows log collection from the container log path.
+                          Set to a different path if you are not using the Docker runtime.
+                          See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
+                          Default: `/var/lib/docker/containers`
+                        type: string
+                      containerSymlinksPath:
+                        description: |-
+                          ContainerSymlinksPath allows log collection to use symbolic links in this directory to validate container ID -> pod.
+                          Default: `/var/log/containers`
+                        type: string
+                      enabled:
+                        description: |-
+                          Enabled enables Log collection.
+                          Default: false
+                        type: boolean
+                      openFilesLimit:
+                        description: |-
+                          OpenFilesLimit sets the maximum number of log files that the Datadog Agent tails.
+                          Increasing this limit can increase resource consumption of the Agent.
+                          See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                          Default: 100
+                        format: int32
+                        type: integer
+                      podLogsPath:
+                        description: |-
+                          PodLogsPath allows log collection from a pod log path.
+                          Default: `/var/log/pods`
+                        type: string
+                      tempStoragePath:
+                        description: |-
+                          TempStoragePath (always mounted from the host) is used by the Agent to store information about processed log files.
+                          If the Agent is restarted, it starts tailing the log files immediately.
+                          Default: `/var/lib/datadog-agent/logs`
+                        type: string
+                    type: object
+                  npm:
+                    description: NPM (Network Performance Monitoring) configuration.
+                    properties:
+                      collectDNSStats:
+                        description: |-
+                          CollectDNSStats enables DNS stat collection.
+                          Default: false
+                        type: boolean
+                      enableConntrack:
+                        description: |-
+                          EnableConntrack enables the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data.
+                          See also: http://conntrack-tools.netfilter.org/
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enabled enables Network Performance Monitoring.
+                          Default: false
+                        type: boolean
+                    type: object
+                  oomKill:
+                    description: OOMKill configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the OOMKill eBPF-based check.
+                          Default: false
+                        type: boolean
+                    type: object
+                  orchestratorExplorer:
+                    description: OrchestratorExplorer check configuration.
+                    properties:
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default Orchestrator Explorer check.
+                          This must point to a ConfigMap containing a valid cluster check configuration.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      customResources:
+                        description: |-
+                          `CustomResources` defines custom resources for the orchestrator explorer to collect.
+                          Each item should follow the convention `group/version/kind`. For example, `datadoghq.com/v1alpha1/datadogmetrics`.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      ddUrl:
+                        description: |-
+                          Override the API endpoint for the Orchestrator Explorer.
+                          URL Default: "https://orchestrator.datadoghq.com".
+                        type: string
+                      enabled:
+                        description: |-
+                          Enabled enables the Orchestrator Explorer.
+                          Default: true
+                        type: boolean
+                      extraTags:
+                        description: |-
+                          Additional tags to associate with the collected data in the form of `a b c`.
+                          This is a Cluster Agent option distinct from DD_TAGS that is used in the Orchestrator Explorer.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      scrubContainers:
+                        description: |-
+                          ScrubContainers enables scrubbing of sensitive container data (passwords, tokens, etc. ).
+                          Default: true
+                        type: boolean
+                    type: object
+                  otelAgentGateway:
+                    description: OtelAgentGateway configuration.
+                    properties:
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default OTel Agent Gateway.
+                          This must point to a ConfigMap containing a valid OTel collector configuration.
+                          When passing a configmap, file name *must* be otel-gateway-config.yaml.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the OTel Agent Gateway.
+                          Default: false
+                        type: boolean
+                      featureGates:
+                        description: |-
+                          FeatureGates are the feature gates to pass to the OTel collector as a comma-separated list.
+                          Example: "component.UseLocalHostAsDefaultHost,connector.datadogconnector.NativeIngest"
+                        type: string
+                      ports:
+                        description: |-
+                          Ports contains the ports that the OTel Collector is listening on.
+                          Defaults: otel-grpc:4317 / otel-http:4318.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  otelCollector:
+                    description: OtelCollector configuration.
+                    properties:
+                      conf:
+                        description: |-
+                          Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                          This must point to a ConfigMap containing a valid cluster check configuration.
+                          When passing a configmap, file name *must* be otel-config.yaml.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      coreConfig:
+                        description: OTelCollector Config Relevant to the Core agent
+                        properties:
+                          enabled:
+                            description: Enabled marks otelcollector as enabled in
+                              core agent.
+                            type: boolean
+                          extensionTimeout:
+                            description: |-
+                              Extension URL provides the timout of the ddflareextension to
+                              the core agent.
+                            type: integer
+                          extensionURL:
+                            description: |-
+                              Extension URL provides the URL of the ddflareextension to
+                              the core agent.
+                            type: string
+                        type: object
+                      enabled:
+                        description: |-
+                          Enabled enables the OTel Agent.
+                          Default: false
+                        type: boolean
+                      ports:
+                        description: |-
+                          Ports contains the ports for the otel-agent.
+                          Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317
+                          or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http).
+                          If not, this will lead to a port conflict.
+                          This limitation will be lifted once annotations support is removed.
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                          - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  otlp:
+                    description: OTLP ingest configuration
+                    properties:
+                      receiver:
+                        description: Receiver contains configuration for the OTLP
+                          ingest receiver.
+                        properties:
+                          protocols:
+                            description: Protocols contains configuration for the
+                              OTLP ingest receiver protocols.
+                            properties:
+                              grpc:
+                                description: GRPC contains configuration for the OTLP
+                                  ingest OTLP/gRPC receiver.
+                                properties:
+                                  enabled:
+                                    description: Enable the OTLP/gRPC endpoint. Host
+                                      port is enabled by default and can be disabled.
+                                    type: boolean
+                                  endpoint:
+                                    description: |-
+                                      Endpoint for OTLP/gRPC.
+                                      gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+                                      The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`).
+                                      Default: `0.0.0.0:4317`.
+                                    type: string
+                                  hostPortConfig:
+                                    description: |-
+                                      Enable hostPort for OTLP/gRPC
+                                      Default: true
+                                    properties:
+                                      enabled:
+                                        description: Enabled enables host port configuration
+                                        type: boolean
+                                      hostPort:
+                                        description: |-
+                                          Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                          If HostNetwork is enabled, this value must match the ContainerPort.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              http:
+                                description: HTTP contains configuration for the OTLP
+                                  ingest OTLP/HTTP receiver.
+                                properties:
+                                  enabled:
+                                    description: Enable the OTLP/HTTP endpoint. Host
+                                      port is enabled by default and can be disabled.
+                                    type: boolean
+                                  endpoint:
+                                    description: |-
+                                      Endpoint for OTLP/HTTP.
+                                      Default: '0.0.0.0:4318'.
+                                    type: string
+                                  hostPortConfig:
+                                    description: |-
+                                      Enable hostPorts for OTLP/HTTP
+                                      Default: true
+                                    properties:
+                                      enabled:
+                                        description: Enabled enables host port configuration
+                                        type: boolean
+                                      hostPort:
+                                        description: |-
+                                          Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                          If HostNetwork is enabled, this value must match the ContainerPort.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  processDiscovery:
+                    description: ProcessDiscovery configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables the Process Discovery check in the Agent.
+                          Default: true
+                        type: boolean
+                    type: object
+                  prometheusScrape:
+                    description: PrometheusScrape configuration.
+                    properties:
+                      additionalConfigs:
+                        description: AdditionalConfigs allows adding advanced Prometheus
+                          check configurations with custom discovery rules.
+                        type: string
+                      enableServiceEndpoints:
+                        description: |-
+                          EnableServiceEndpoints enables generating dedicated checks for service endpoints.
+                          Default: false
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enable autodiscovery of pods and services exposing Prometheus metrics.
+                          Default: false
+                        type: boolean
+                      version:
+                        description: |-
+                          Version specifies the version of the OpenMetrics check.
+                          Default: 2
+                        type: integer
+                    type: object
+                  remoteConfiguration:
+                    description: Remote Configuration configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enable this option to activate Remote Configuration.
+                          Default: true
+                        type: boolean
+                    type: object
+                  sbom:
+                    description: SBOM collection configuration.
+                    properties:
+                      containerImage:
+                        description: SBOMTypeConfig contains configuration for a SBOM
+                          collection type.
+                        properties:
+                          analyzers:
+                            description: Analyzers to use for SBOM collection.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                          overlayFSDirectScan:
+                            description: |-
+                              Enable this option to enable experimental overlayFS direct scan.
+                              Default: false
+                            type: boolean
+                          uncompressedLayersSupport:
+                            description: |-
+                              Enable this option to enable support for uncompressed layers.
+                              Default: false
+                            type: boolean
+                        type: object
+                      enabled:
+                        description: |-
+                          Enable this option to activate SBOM collection.
+                          Default: false
+                        type: boolean
+                      enrichment:
+                        description: SBOMEnrichmentConfig contains SBOM enrichment
+                          configuration.
+                        properties:
+                          usage:
+                            description: Usage contains configuration for the "package
+                              in use" enrichment.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM enrichment with runtime "package in use" detection.
+                                  Requires system-probe for eBPF-based file access tracking.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      host:
+                        description: SBOMTypeConfig contains configuration for a SBOM
+                          collection type.
+                        properties:
+                          analyzers:
+                            description: Analyzers to use for SBOM collection.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                  serviceDiscovery:
+                    description: ServiceDiscovery
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the service discovery check.
+                          Default: true when omitted and the node Agent image is >= 7.78.0. Otherwise false.
+                          If the image version cannot be determined, it is treated as latest.
+                        type: boolean
+                    type: object
+                  tcpQueueLength:
+                    description: TCPQueueLength configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enables the TCP queue length eBPF-based check.
+                          Default: false
+                        type: boolean
+                    type: object
+                  usm:
+                    description: USM (Universal Service Monitoring) configuration.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables Universal Service Monitoring.
+                          Default: false
+                        type: boolean
+                    type: object
+                type: object
+              global:
+                description: Global settings to configure the agents
+                properties:
+                  checksTagCardinality:
+                    description: |-
+                      ChecksTagCardinality configures tag cardinality for the metrics collected by integrations (`low`, `orchestrator` or `high`).
+                      See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#tags-cardinality.
+                      Not set by default to avoid overriding existing DD_CHECKS_TAG_CARDINALITY configurations, the default value in the Agent is low.
+                      Ref: https://github.com/DataDog/datadog-agent/blob/856cf4a66142ce91fd4f8a278149436eb971184a/pkg/config/setup/config.go#L625.
+                    type: string
+                  clusterAgentToken:
+                    description: ClusterAgentToken is the token for communication
+                      between the NodeAgent and ClusterAgent.
+                    type: string
+                  clusterAgentTokenSecret:
+                    description: ClusterAgentTokenSecret is the secret containing
+                      the Cluster Agent token.
+                    properties:
+                      keyName:
+                        description: KeyName is the key of the secret to use.
+                        type: string
+                      secretName:
+                        description: SecretName is the name of the secret.
+                        type: string
+                    required:
+                    - secretName
+                    type: object
+                  clusterName:
+                    description: ClusterName sets a unique cluster name for the deployment
+                      to easily scope monitoring data in the Datadog app.
+                    type: string
+                  commonLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      CommonLabels specified labels to be added to all operator-managed Kubernetes resources
+                      (DaemonSets, Deployments, ConfigMaps, Services, ServiceAccounts, etc.).
+                      This is useful when external policy tools such as Kyverno enforce the presence of
+                      specific labels on all cluster resources.
+                      Labels defined here are merged with the operator's own default labels; operator labels
+                      take precedence on any key conflict.
+                    type: object
+                    x-kubernetes-map-type: granular
+                  containerStrategy:
+                    description: |-
+                      ContainerStrategy determines whether agents run in a single or multiple containers.
+                      Default: 'optimized'
+                    type: string
+                  credentials:
+                    description: Credentials defines the Datadog credentials used
+                      to submit data to/query data from Datadog.
+                    properties:
+                      apiKey:
+                        description: |-
+                          APIKey configures your Datadog API key.
+                          See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                        type: string
+                      apiSecret:
+                        description: |-
+                          APISecret references an existing Secret which stores the API key instead of creating a new one.
+                          If set, this parameter takes precedence over "APIKey".
+                        properties:
+                          keyName:
+                            description: KeyName is the key of the secret to use.
+                            type: string
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                      appKey:
+                        description: |-
+                          AppKey configures your Datadog application key.
+                          If you are using features.externalMetricsServer.enabled = true, you must set
+                          a Datadog application key for read access to your metrics.
+                        type: string
+                      appSecret:
+                        description: |-
+                          AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                          If set, this parameter takes precedence over "AppKey".
+                        properties:
+                          keyName:
+                            description: KeyName is the key of the secret to use.
+                            type: string
+                          secretName:
+                            description: SecretName is the name of the secret.
+                            type: string
+                        required:
+                        - secretName
+                        type: object
+                    type: object
+                  criSocketPath:
+                    description: Path to the container runtime socket (if different
+                      from Docker).
+                    type: string
+                  csi:
+                    description: CSI contains configuration for Datadog CSI Driver
+                    properties:
+                      autoManage:
+                        description: |-
+                          AutoManage controls whether the operator automatically manages the DatadogCSIDriver
+                          custom resource on behalf of this DatadogAgent. Set to false to hand ownership over to a
+                          DatadogCSIDriver CR that you maintain yourself (useful for migrations where you need
+                          customizations not exposed on the DatadogAgent spec). When toggled from true to false,
+                          the operator cleans up the DDA-owned DatadogCSIDriver CR; you are then responsible for
+                          providing a replacement so CSI continues to work.
+                          Default: true
+                        type: boolean
+                      enabled:
+                        description: |-
+                          Enables the usage of CSI driver in Datadog Agent. When the operator is started with
+                          `--datadogCSIDriverEnabled=true`, it will also install the driver by creating a
+                          DatadogCSIDriver custom resource, unless a cluster-scoped `k8s.csi.datadoghq.com`
+                          CSIDriver is already present, in which case it defers to the existing installation
+                          (e.g. from the Datadog CSI driver Helm chart).
+                          Default: false
+                        type: boolean
+                      nodeAffinity:
+                        description: NodeAffinity specifies node affinity scheduling
+                          rules for CSI driver DaemonSet pods.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector is a map of key-value pairs for
+                          CSI driver DaemonSet pod node selection.
+                        type: object
+                      tolerations:
+                        description: Tolerations configure the CSI driver DaemonSet
+                          pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  disableNonResourceRules:
+                    description: |-
+                      Set DisableNonResourceRules to exclude NonResourceURLs from default ClusterRoles.
+                      Required 'true' for Google Cloud Marketplace.
+                    type: boolean
+                  dockerSocketPath:
+                    description: Path to the docker runtime socket.
+                    type: string
+                  endpoint:
+                    description: |-
+                      Endpoint is the Datadog intake URL the Agent data are sent to.
+                      Only set this option if you need the Agent to send data to a custom URL.
+                      Overrides the site setting defined in `Site`.
+                    properties:
+                      credentials:
+                        description: Credentials defines the Datadog credentials used
+                          to submit data to/query data from Datadog.
+                        properties:
+                          apiKey:
+                            description: |-
+                              APIKey configures your Datadog API key.
+                              See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                            type: string
+                          apiSecret:
+                            description: |-
+                              APISecret references an existing Secret which stores the API key instead of creating a new one.
+                              If set, this parameter takes precedence over "APIKey".
+                            properties:
+                              keyName:
+                                description: KeyName is the key of the secret to use.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            required:
+                            - secretName
+                            type: object
+                          appKey:
+                            description: |-
+                              AppKey configures your Datadog application key.
+                              If you are using features.externalMetricsServer.enabled = true, you must set
+                              a Datadog application key for read access to your metrics.
+                            type: string
+                          appSecret:
+                            description: |-
+                              AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                              If set, this parameter takes precedence over "AppKey".
+                            properties:
+                              keyName:
+                                description: KeyName is the key of the secret to use.
+                                type: string
+                              secretName:
+                                description: SecretName is the name of the secret.
+                                type: string
+                            required:
+                            - secretName
+                            type: object
+                        type: object
+                      url:
+                        description: URL defines the endpoint URL.
+                        type: string
+                    type: object
+                  env:
+                    description: Env contains a list of environment variables that
+                      are set for all Agents.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  fips:
+                    description: FIPS contains configuration used to customize the
+                      FIPS proxy sidecar.
+                    properties:
+                      customFIPSConfig:
+                        description: |-
+                          CustomFIPSConfig configures a custom configMap to provide the FIPS configuration.
+                          Specify custom contents for the FIPS proxy sidecar container config
+                          (/etc/datadog-fips-proxy/datadog-fips-proxy.cfg). If empty, the default FIPS
+                          proxy sidecar container config is used.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      enabled:
+                        description: Enable FIPS sidecar.
+                        type: boolean
+                      image:
+                        description: The container image of the FIPS sidecar.
+                        properties:
+                          jmxEnabled:
+                            description: |-
+                              Define whether the Agent image should support JMX.
+                              To be used if the `Name` field does not correspond to a full image string.
+                            type: boolean
+                          name:
+                            description: |-
+                              Defines the Agent image name for the pod. You can provide this as:
+                              * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                              for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                              * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                              and `[key].image.jmxEnabled` are ignored.
+                              * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                            type: string
+                          pullPolicy:
+                            description: |-
+                              The Kubernetes pull policy:
+                              Use `Always`, `Never`, or `IfNotPresent`.
+                            type: string
+                          pullSecrets:
+                            description: |-
+                              It is possible to specify Docker registry credentials.
+                              See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          tag:
+                            description: |-
+                              Define the image tag to use.
+                              To be used if the `Name` field does not correspond to a full image string.
+                            type: string
+                        type: object
+                      localAddress:
+                        description: |-
+                          Set the local IP address.
+                          Default: `127.0.0.1`
+                        type: string
+                      port:
+                        description: |-
+                          Port specifies which port is used by the containers to communicate to the FIPS sidecar.
+                          Default: 9803
+                        format: int32
+                        type: integer
+                      portRange:
+                        description: |-
+                          PortRange specifies the number of ports used.
+                          Default: 15
+                        format: int32
+                        type: integer
+                      resources:
+                        description: Resources is the requests and limits for the
+                          FIPS sidecar container.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      useHTTPS:
+                        description: |-
+                          UseHTTPS enables HTTPS.
+                          Default: false
+                        type: boolean
+                    type: object
+                  kubelet:
+                    description: Kubelet contains the kubelet configuration parameters.
+                    properties:
+                      agentCAPath:
+                        description: |-
+                          AgentCAPath is the container path where the kubelet CA certificate is stored.
+                          Default: '/var/run/host-kubelet-ca.crt' if hostCAPath is set, else '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+                        type: string
+                      host:
+                        description: Host overrides the host used to contact kubelet
+                          API (default to status.hostIP).
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing
+                                  the env file.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            - volumeName
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      hostCAPath:
+                        description: HostCAPath is the host path where the kubelet
+                          CA certificate is stored.
+                        type: string
+                      podResourcesSocketPath:
+                        description: |-
+                          PodResourcesSocketPath is the host path where the pod resources socket is stored.
+                          Default: `/var/lib/kubelet/pod-resources/`
+                        type: string
+                      tlsVerify:
+                        description: |-
+                          TLSVerify toggles kubelet TLS verification.
+                          Default: true
+                        type: boolean
+                    type: object
+                  kubernetesResourcesAnnotationsAsTags:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: "Provide a mapping of Kubernetes Resource Groups
+                      to annotations mapping to Datadog Tags.\n<KUBERNETES_RESOURCE_GROUP>:\n\t\t<KUBERNETES_ANNOTATION>:
+                      <DATADOG_TAG_KEY>\nKUBERNETES_RESOURCE_GROUP should be in the
+                      form `{resource}.{group}` or `{resource}` (example: deployments.apps,
+                      pods)"
+                    type: object
+                  kubernetesResourcesLabelsAsTags:
+                    additionalProperties:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    description: "Provide a mapping of Kubernetes Resource Groups
+                      to labels mapping to Datadog Tags.\n<KUBERNETES_RESOURCE_GROUP>:\n\t\t<KUBERNETES_LABEL>:
+                      <DATADOG_TAG_KEY>\nKUBERNETES_RESOURCE_GROUP should be in the
+                      form `{resource}.{group}` or `{resource}` (example: deployments.apps,
+                      pods)"
+                    type: object
+                  localService:
+                    description: LocalService contains configuration to customize
+                      the internal traffic policy service.
+                    properties:
+                      forceEnableLocalService:
+                        description: |-
+                          ForceEnableLocalService forces the creation of the internal traffic policy service to target the agent running on the local node.
+                          This parameter only applies to Kubernetes 1.21, where the feature is in alpha and is disabled by default.
+                          (On Kubernetes 1.22+, the feature entered beta and the internal traffic service is created by default, so this parameter is ignored.)
+                          Default: false
+                        type: boolean
+                      nameOverride:
+                        description: NameOverride defines the name of the internal
+                          traffic service to target the agent running on the local
+                          node.
+                        type: string
+                    type: object
+                  logLevel:
+                    description: |-
+                      LogLevel sets logging verbosity. This can be overridden by container.
+                      Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                      Default: 'info'
+                    type: string
+                  namespaceAnnotationsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Namespace Annotations to Datadog Tags.
+                      <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  namespaceLabelsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Namespace Labels to Datadog Tags.
+                      <KUBERNETES_NAMESPACE_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  networkPolicy:
+                    description: NetworkPolicy contains the network configuration.
+                    properties:
+                      create:
+                        description: Create defines whether to create a NetworkPolicy
+                          for the current deployment.
+                        type: boolean
+                      dnsSelectorEndpoints:
+                        description: DNSSelectorEndpoints defines the cilium selector
+                          of the DNS server entity.
+                        items:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      flavor:
+                        description: Flavor defines Which network policy to use.
+                        type: string
+                    type: object
+                  nodeLabelsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Node Labels to Datadog Tags.
+                      <KUBERNETES_NODE_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  originDetectionUnified:
+                    description: OriginDetectionUnified defines the origin detection
+                      unified mechanism behavior.
+                    properties:
+                      enabled:
+                        description: |-
+                          Enabled enables unified mechanism for origin detection.
+                          Default: false
+                        type: boolean
+                    type: object
+                  podAnnotationsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Annotations to Datadog Tags.
+                      <KUBERNETES_ANNOTATIONS>: <DATADOG_TAG_KEY>
+                    type: object
+                  podLabelsAsTags:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Provide a mapping of Kubernetes Labels to Datadog Tags.
+                      <KUBERNETES_LABEL>: <DATADOG_TAG_KEY>
+                    type: object
+                  registry:
+                    description: |-
+                      Registry is the image registry to use for all Agent images.
+                      Use 'public.ecr.aws/datadog' for AWS ECR.
+                      Use 'datadoghq.azurecr.io' for Azure Container Registry.
+                      Use 'gcr.io/datadoghq' for Google Container Registry.
+                      Use 'eu.gcr.io/datadoghq' for Google Container Registry in the EU region.
+                      Use 'asia.gcr.io/datadoghq' for Google Container Registry in the Asia region.
+                      Use 'docker.io/datadog' for DockerHub.
+                      Default: 'registry.datadoghq.com'
+                    type: string
+                  secretBackend:
+                    description: |-
+                      Configure the secret backend feature https://docs.datadoghq.com/agent/guide/secrets-management
+                      See also: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md
+                    properties:
+                      args:
+                        description: List of arguments to pass to the command (space-separated
+                          strings).
+                        type: string
+                      command:
+                        description: |-
+                          The secret backend command to use. Datadog provides a pre-defined binary `/readsecret_multiple_providers.sh`.
+                          Read more about `/readsecret_multiple_providers.sh` at https://docs.datadoghq.com/agent/configuration/secrets-management/?tab=linux#script-for-reading-from-multiple-secret-providers.
+                        type: string
+                      config:
+                        additionalProperties:
+                          x-kubernetes-preserve-unknown-fields: true
+                        description: Additional configuration for the secret backend
+                          type.
+                        type: object
+                      enableGlobalPermissions:
+                        description: |-
+                          Whether to create a global permission allowing Datadog agents to read all Kubernetes secrets.
+                          Default: `false`.
+                        type: boolean
+                      refreshInterval:
+                        description: |-
+                          The refresh interval for secrets (0 disables refreshing).
+                          Default: `0`.
+                        format: int32
+                        type: integer
+                      roles:
+                        description: |-
+                          Roles for Datadog to read the specified secrets, replacing `enableGlobalPermissions`.
+                          They are defined as a list of namespace/secrets.
+                          Each defined namespace needs to be present in the DatadogAgent controller using `WATCH_NAMESPACE` or `DD_AGENT_WATCH_NAMESPACE`.
+                          See also: https://github.com/DataDog/datadog-operator/blob/main/docs/secret_management.md#how-to-deploy-the-agent-components-using-the-secret-backend-feature-with-datadogagent.
+                        items:
+                          description: SecretBackendRolesConfig provides configuration
+                            of the secrets Datadog agents can read for the SecretBackend
+                            feature
+                          properties:
+                            namespace:
+                              description: Namespace defines the namespace in which
+                                the secrets reside.
+                              type: string
+                            secrets:
+                              description: Secrets defines the list of secrets for
+                                which a role should be created.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: set
+                          required:
+                          - namespace
+                          - secrets
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      timeout:
+                        description: |-
+                          The command timeout in seconds.
+                          Default: `30`.
+                        format: int32
+                        type: integer
+                      type:
+                        description: |-
+                          The built-in secret backend type to use (e.g., `k8s.secrets`, `docker.secrets`, `aws.secrets`).
+                          Alternative to Command; when Type is set, the Agent uses the built-in backend to resolve secrets.
+                          Requires Agent 7.70+.
+                        type: string
+                    type: object
+                  site:
+                    description: |-
+                      Site is the Datadog intake site Agent data are sent to.
+                      Set to 'datadoghq.com' to send data to the US1 site (default).
+                      Set to 'datadoghq.eu' to send data to the EU site.
+                      Set to 'us3.datadoghq.com' to send data to the US3 site.
+                      Set to 'us5.datadoghq.com' to send data to the US5 site.
+                      Set to 'ddog-gov.com' to send data to the US1-FED site.
+                      Set to 'ap1.datadoghq.com' to send data to the AP1 site.
+                      Default: 'datadoghq.com'
+                    type: string
+                  tags:
+                    description: |-
+                      Tags contains a list of tags to attach to every metric, event and service check collected.
+                      Learn more about tagging: https://docs.datadoghq.com/tagging/
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  useFIPSAgent:
+                    description: |-
+                      UseFIPSAgent enables the FIPS flavor of the Agent. If 'true', the FIPS proxy will always be disabled.
+                      Default: 'false'
+                    type: boolean
+                  useVSock:
+                    description: |-
+                      UseVSock allows the use of VSock communication between the Agent and containerized workloads.
+                      Default: 'false'
+                    type: boolean
+                type: object
+              override:
+                additionalProperties:
+                  description: DatadogAgentComponentOverride is the generic description
+                    equivalent to a subset of the PodTemplate for a component.
+                  properties:
+                    affinity:
+                      description: If specified, the pod's scheduling constraints.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range
+                                      1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the
+                                                selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and subtracting
+                                "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations provide annotations that are added
+                        to the different component (Datadog Agent, Cluster Agent,
+                        Cluster Check Runner) pods.
+                      type: object
+                    celWorkloadExclude:
+                      description: |-
+                        CELWorkloadExclude enables excluding workloads from monitoring using Common Expression Language (CEL).
+                        See https://docs.datadoghq.com/containers/guide/container-discovery-management
+                        (Requires Agent 7.73+ and Cluster Agent 7.73+)
+                      items:
+                        description: |-
+                          CelWorkloadExcludeConfig configures CEL-based filtering to exclude specific workloads
+                          from Agent collection.
+                        properties:
+                          products:
+                            description: Products specifies which products these exclusion
+                              rules apply to.
+                            items:
+                              description: |-
+                                Product defines which Datadog product(s) the CEL-based workload exclusion rules apply to.
+                                Use "global" to apply rules across all products, or specify individual products for granular control.
+                              enum:
+                              - metrics
+                              - logs
+                              - sbom
+                              - global
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          rules:
+                            description: Rules defines the CEL expressions used to
+                              identify workloads to exclude.
+                            properties:
+                              containers:
+                                description: Containers exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              kube_endpoints:
+                                description: KubeEndpoints exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              kube_services:
+                                description: KubeServices exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              pods:
+                                description: Pods exclude rule
+                                items:
+                                  type: string
+                                type: array
+                              processes:
+                                description: Processes exclude rule
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    containers:
+                      additionalProperties:
+                        description: DatadogAgentGenericContainer is the generic structure
+                          describing any container's common configuration.
+                        properties:
+                          appArmorProfileName:
+                            description: AppArmorProfileName specifies an apparmor
+                              profile.
+                            type: string
+                          args:
+                            description: Args allows the specification of extra args
+                              to the `Command` parameter
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          command:
+                            description: Command allows the specification of a custom
+                              entrypoint for container
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          env:
+                            description: |-
+                              Specify additional environment variables in the container.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          default: false
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount
+                                            containing the env file.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          healthPort:
+                            description: |-
+                              HealthPort of the container for the internal liveness probe.
+                              Must be the same as the Liveness/Readiness probes.
+                            format: int32
+                            type: integer
+                          livenessProbe:
+                            description: Configure the Liveness Probe of the container
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          logLevel:
+                            description: |-
+                              LogLevel sets logging verbosity (overrides global setting).
+                              Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                              Default: 'info'
+                            type: string
+                          name:
+                            description: Name of the container that is overridden
+                            type: string
+                          ports:
+                            description: |-
+                              Specify additional ports to be exposed by the container. Not specifying a port here
+                              DOES NOT prevent that port from being exposed.
+                              See https://pkg.go.dev/k8s.io/api/core/v1#Container documentation for more details.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          readinessProbe:
+                            description: Configure the Readiness Probe of the container
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: |-
+                              Specify the Request and Limits of the pods
+                              To get guaranteed QoS class, specify requests and limits equal.
+                              See also: http://kubernetes.io/docs/user-guide/compute-resources/
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This field depends on the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          seccompConfig:
+                            description: |-
+                              Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation,
+                              use SecurityContext.
+                            properties:
+                              customProfile:
+                                description: |-
+                                  CustomProfile specifies a ConfigMap containing a custom Seccomp Profile.
+                                  ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items
+                                  must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.
+                                properties:
+                                  configData:
+                                    description: ConfigData corresponds to the configuration
+                                      file content.
+                                    type: string
+                                  configMap:
+                                    description: ConfigMap references an existing
+                                      ConfigMap with the configuration file content.
+                                    properties:
+                                      items:
+                                        description: Items maps a ConfigMap data `key`
+                                          to a file `path` mount.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - key
+                                        x-kubernetes-list-type: map
+                                      name:
+                                        description: Name is the name of the ConfigMap.
+                                        type: string
+                                    type: object
+                                type: object
+                              customRootPath:
+                                description: CustomRootPath specifies a custom Seccomp
+                                  Profile root location.
+                                type: string
+                            type: object
+                          securityContext:
+                            description: Container-level SecurityContext.
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: |-
+                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                  privileges than its parent process. This bool directly controls if
+                                  the no_new_privs flag will be set on the container process.
+                                  AllowPrivilegeEscalation is true always when the container is:
+                                  1) run as Privileged
+                                  2) has CAP_SYS_ADMIN
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              appArmorProfile:
+                                description: |-
+                                  appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                  overrides the pod's appArmorProfile.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile loaded on the node that should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must match the loaded name of the profile.
+                                      Must be set if and only if type is "Localhost".
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of AppArmor profile will be applied.
+                                      Valid options are:
+                                        Localhost - a profile pre-loaded on the node.
+                                        RuntimeDefault - the container runtime's default profile.
+                                        Unconfined - no AppArmor enforcement.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              capabilities:
+                                description: |-
+                                  The capabilities to add/drop when running containers.
+                                  Defaults to the default set of capabilities granted by the container runtime.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                description: |-
+                                  Run container in privileged mode.
+                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                  Defaults to false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              procMount:
+                                description: |-
+                                  procMount denotes the type of proc mount to use for the containers.
+                                  The default value is Default which uses the container runtime defaults for
+                                  readonly paths and masked paths.
+                                  This requires the ProcMountType feature flag to be enabled.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: |-
+                                  Whether this container has a read-only root filesystem.
+                                  Default is false.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                type: boolean
+                              runAsGroup:
+                                description: |-
+                                  The GID to run the entrypoint of the container process.
+                                  Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: |-
+                                  Indicates that the container must run as a non-root user.
+                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                  If unset or false, no such validation will be performed.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: |-
+                                  The UID to run the entrypoint of the container process.
+                                  Defaults to user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: |-
+                                  The SELinux context to be applied to the container.
+                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                description: |-
+                                  The seccomp options to use by this container. If seccomp options are
+                                  provided at both the pod & container level, the container options
+                                  override the pod options.
+                                  Note that this field cannot be set when spec.os.name is windows.
+                                properties:
+                                  localhostProfile:
+                                    description: |-
+                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                      The profile must be preconfigured on the node to work.
+                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type indicates which kind of seccomp profile will be applied.
+                                      Valid options are:
+
+                                      Localhost - a profile defined in a file on the node should be used.
+                                      RuntimeDefault - the container runtime default profile should be used.
+                                      Unconfined - no profile should be applied.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              windowsOptions:
+                                description: |-
+                                  The Windows specific settings applied to all containers.
+                                  If unspecified, the options from the PodSecurityContext will be used.
+                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  Note that this field cannot be set when spec.os.name is linux.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: |-
+                                      GMSACredentialSpec is where the GMSA admission webhook
+                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use.
+                                    type: string
+                                  hostProcess:
+                                    description: |-
+                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                      All of a Pod's containers must have the same effective HostProcess value
+                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                    type: boolean
+                                  runAsUserName:
+                                    description: |-
+                                      The UserName in Windows to run the entrypoint of the container process.
+                                      Defaults to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: Configure the Startup Probe of the container
+                            properties:
+                              exec:
+                                description: Exec specifies a command to execute in
+                                  the container.
+                                properties:
+                                  command:
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              failureThreshold:
+                                description: |-
+                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              grpc:
+                                description: GRPC specifies a GRPC HealthCheckRequest.
+                                properties:
+                                  port:
+                                    description: Port number of the gRPC service.
+                                      Number must be in the range 1 to 65535.
+                                    format: int32
+                                    type: integer
+                                  service:
+                                    default: ""
+                                    description: |-
+                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                      If this is not specified, the default behavior is defined by gRPC.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies an HTTP GET request
+                                  to perform.
+                                properties:
+                                  host:
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: |-
+                                  Number of seconds after the container has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: |-
+                                  How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: |-
+                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: TCPSocket specifies a connection to a
+                                  TCP port.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                  value overrides the value provided by the pod spec.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                format: int64
+                                type: integer
+                              timeoutSeconds:
+                                description: |-
+                                  Number of seconds after which the probe times out.
+                                  Defaults to 1 second. Minimum value is 1.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                format: int32
+                                type: integer
+                            type: object
+                          volumeMounts:
+                            description: Specify additional volume mounts in the container.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            - mountPath
+                            x-kubernetes-list-type: map
+                        type: object
+                      description: |-
+                        Configure the basic configurations for each Agent container. Valid Agent container names are:
+                        `agent`, `cluster-agent`, `init-config`, `init-volume`, `process-agent`, `seccomp-setup`,
+                        `security-agent`, `system-probe`, and `trace-agent`.
+                      type: object
+                    createPodDisruptionBudget:
+                      description: |-
+                        Set CreatePodDisruptionBudget to true to create a PodDisruptionBudget for this component.
+                        Not applicable for the Node Agent. A Cluster Agent PDB is set with 1 minimum available pod, and a Cluster Checks Runner PDB is set with 1 maximum unavailable pod.
+                      type: boolean
+                    createRbac:
+                      description: Set CreateRbac to false to prevent automatic creation
+                        of Role/ClusterRole for this component
+                      type: boolean
+                    customConfigurations:
+                      additionalProperties:
+                        description: |-
+                          CustomConfig provides a place for custom configuration of the Agent or Cluster Agent, corresponding to datadog.yaml,
+                          system-probe.yaml, security-agent.yaml or datadog-cluster.yaml.
+                          The configuration can be provided in the ConfigData field as raw data, or referenced in a ConfigMap.
+                          Note: `ConfigData` and `ConfigMap` cannot be set together.
+                        properties:
+                          configData:
+                            description: ConfigData corresponds to the configuration
+                              file content.
+                            type: string
+                          configMap:
+                            description: ConfigMap references an existing ConfigMap
+                              with the configuration file content.
+                            properties:
+                              items:
+                                description: Items maps a ConfigMap data `key` to
+                                  a file `path` mount.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                              name:
+                                description: Name is the name of the ConfigMap.
+                                type: string
+                            type: object
+                        type: object
+                      description: |-
+                        CustomConfigurations specifies custom contents for `datadog.yaml`, `datadog-cluster.yaml`, `security-agent.yaml`, and `system-probe.yaml`.
+                        Each provided file replaces the corresponding default file from the Agent image without merging.
+                        Agent settings provided through environment variables take precedence over these files.
+                      type: object
+                    disabled:
+                      description: Disabled force disables a component.
+                      type: boolean
+                    dnsConfig:
+                      description: |-
+                        Specifies the DNS parameters of a pod.
+                        Parameters specified here will be merged to the generated DNS
+                        configuration based on DNSPolicy.
+                      properties:
+                        nameservers:
+                          description: |-
+                            A list of DNS name server IP addresses.
+                            This will be appended to the base nameservers generated from DNSPolicy.
+                            Duplicated nameservers will be removed.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        options:
+                          description: |-
+                            A list of DNS resolver options.
+                            This will be merged with the base options generated from DNSPolicy.
+                            Duplicated entries will be removed. Resolution options given in Options
+                            will override those that appear in the base DNSPolicy.
+                          items:
+                            description: PodDNSConfigOption defines DNS resolver options
+                              of a pod.
+                            properties:
+                              name:
+                                description: |-
+                                  Name is this DNS resolver option's name.
+                                  Required.
+                                type: string
+                              value:
+                                description: Value is this DNS resolver option's value.
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        searches:
+                          description: |-
+                            A list of DNS search domains for host-name lookup.
+                            This will be appended to the base search paths generated from DNSPolicy.
+                            Duplicated search paths will be removed.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    dnsPolicy:
+                      description: |-
+                        Set DNS policy for the pod.
+                        Defaults to "ClusterFirst".
+                        Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                        DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                        To have DNS options set along with hostNetwork, you have to specify DNS policy
+                        explicitly to 'ClusterFirstWithHostNet'.
+                      type: string
+                    env:
+                      description: |-
+                        Specify additional environment variables for all containers in this component
+                        Priority is Container > Component.
+                        See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    envFrom:
+                      description: |-
+                        EnvFrom specifies the ConfigMaps and Secrets to expose as environment variables.
+                        Priority is env > envFrom.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                    extraChecksd:
+                      description: |-
+                        Checksd configuration allowing to specify custom checks placed under /etc/datadog-agent/checks.d/
+                        See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
+                      properties:
+                        configDataMap:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            ConfigDataMap corresponds to the content of the configuration files.
+                            The key should be the filename the contents get mounted to; for instance check.py or check.yaml.
+                          type: object
+                        configMap:
+                          description: ConfigMap references an existing ConfigMap
+                            with the content of the configuration files.
+                          properties:
+                            items:
+                              description: Items maps a ConfigMap data `key` to a
+                                file `path` mount.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - key
+                              x-kubernetes-list-type: map
+                            name:
+                              description: Name is the name of the ConfigMap.
+                              type: string
+                          type: object
+                      type: object
+                    extraConfd:
+                      description: |-
+                        Confd configuration allowing to specify config files for custom checks placed under /etc/datadog-agent/conf.d/.
+                        See https://docs.datadoghq.com/agent/guide/agent-configuration-files/?tab=agentv6 for more details.
+                      properties:
+                        configDataMap:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            ConfigDataMap corresponds to the content of the configuration files.
+                            The key should be the filename the contents get mounted to; for instance check.py or check.yaml.
+                          type: object
+                        configMap:
+                          description: ConfigMap references an existing ConfigMap
+                            with the content of the configuration files.
+                          properties:
+                            items:
+                              description: Items maps a ConfigMap data `key` to a
+                                file `path` mount.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - key
+                              x-kubernetes-list-type: map
+                            name:
+                              description: Name is the name of the ConfigMap.
+                              type: string
+                          type: object
+                      type: object
+                    hostNetwork:
+                      description: Host networking requested for this pod. Use the
+                        host's network namespace.
+                      type: boolean
+                    hostPID:
+                      description: Use the host's PID namespace.
+                      type: boolean
+                    image:
+                      description: The container image of the different components
+                        (Datadog Agent, Cluster Agent, Cluster Check Runner).
+                      properties:
+                        jmxEnabled:
+                          description: |-
+                            Define whether the Agent image should support JMX.
+                            To be used if the `Name` field does not correspond to a full image string.
+                          type: boolean
+                        name:
+                          description: |-
+                            Defines the Agent image name for the pod. You can provide this as:
+                            * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                            for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                            * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                            and `[key].image.jmxEnabled` are ignored.
+                            * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                              like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                          type: string
+                        pullPolicy:
+                          description: |-
+                            The Kubernetes pull policy:
+                            Use `Always`, `Never`, or `IfNotPresent`.
+                          type: string
+                        pullSecrets:
+                          description: |-
+                            It is possible to specify Docker registry credentials.
+                            See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        tag:
+                          description: |-
+                            Define the image tag to use.
+                            To be used if the `Name` field does not correspond to a full image string.
+                          type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalLabels provide labels that are added
+                        to the different component (Datadog Agent, Cluster Agent,
+                        Cluster Check Runner) pods.
+                      type: object
+                      x-kubernetes-map-type: granular
+                    name:
+                      description: Name overrides the default name for the resource
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        A map of key-value pairs. For this pod to run on a specific node, the node must have these key-value pairs as labels.
+                        See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                      type: object
+                    priorityClassName:
+                      description: |-
+                        If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical"
+                        are two special keywords which indicate the highest priorities with the former being the highest priority.
+                        Any other name must be defined by creating a PriorityClass object with that name. If not specified,
+                        the pod priority is default, or zero if there is no default.
+                      type: string
+                    replicas:
+                      description: |-
+                        Number of the replicas.
+                        Not applicable for a DaemonSet/ExtendedDaemonSet deployment
+                      format: int32
+                      type: integer
+                    runtimeClassName:
+                      description: |-
+                        If specified, indicates the pod's RuntimeClass kubelet should use to run the pod.
+                        If the named RuntimeClass does not exist, or the CRI cannot run the corresponding handler, the pod enters the Failed terminal phase.
+                        If no runtimeClassName is specified, the default RuntimeHandler is used, which is equivalent to the behavior when the RuntimeClass feature is disabled.
+                      type: string
+                    securityContext:
+                      description: Pod-level SecurityContext.
+                      properties:
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxChangePolicy:
+                          description: |-
+                            seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                            It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                            Valid values are "MountOption" and "Recursive".
+
+                            "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                            This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                            "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                            This requires all Pods that share the same volume to use the same SELinux label.
+                            It is not possible to share the same volume among privileged and unprivileged Pods.
+                            Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                            whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                            CSIDriver instance. Other volumes are always re-labelled recursively.
+                            "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                            If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                            If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                            and "Recursive" for all other volumes.
+
+                            This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                            All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in
+                            addition to the container's primary GID and fsGroup (if specified).  If
+                            the SupplementalGroupsPolicy feature is enabled, the
+                            supplementalGroupsPolicy field determines whether these are in addition
+                            to or instead of any group memberships defined in the container image.
+                            If unspecified, no additional groups are added, though group memberships
+                            defined in the container image may still be used, depending on the
+                            supplementalGroupsPolicy field.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          description: |-
+                            Defines how supplemental groups of the first container processes are calculated.
+                            Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                            (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                            and the container runtime must implement support for this feature.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccountAnnotations:
+                      additionalProperties:
+                        type: string
+                      description: Sets the ServiceAccountAnnotations used by this
+                        component.
+                      type: object
+                    serviceAccountName:
+                      description: |-
+                        Sets the ServiceAccount used by this component.
+                        Ignored if the field CreateRbac is true.
+                      type: string
+                    tolerations:
+                      description: Configure the component tolerations.
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    topologySpreadConstraints:
+                      description: |-
+                        TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                        domains. Scheduler will schedule pods in a way which abides by the constraints.
+                        All topologySpreadConstraints are ANDed.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - topologyKey
+                      - whenUnsatisfiable
+                      x-kubernetes-list-type: map
+                    updateStrategy:
+                      description: The deployment strategy to use to replace existing
+                        pods with new ones.
+                      properties:
+                        rollingUpdate:
+                          description: Configure the rolling update strategy of the
+                            Deployment or DaemonSet.
+                          properties:
+                            maxSurge:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                                Kubernetes API documentation for additional details.
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                The maximum number of pods that can be unavailable during the update.
+                                Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                Refer to the Kubernetes API documentation for additional details..
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          description: |-
+                            Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                            or "Recreate" for Deployments
+                          type: string
+                      type: object
+                    volumes:
+                      description: Specify additional volumes in the different components
+                        (Datadog Agent, Cluster Agent, Cluster Check Runner).
+                      items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: |-
+                              awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                              awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: string
+                              partition:
+                                description: |-
+                                  partition is the partition in the volume that you want to mount.
+                                  If omitted, the default is to mount by volume name.
+                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: |-
+                                  readOnly value true will force the readOnly setting in VolumeMounts.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: boolean
+                              volumeID:
+                                description: |-
+                                  volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            description: |-
+                              azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                              are redirected to the disk.csi.azure.com CSI driver.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode:
+                                  None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk
+                                  in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the
+                                  blob storage
+                                type: string
+                              fsType:
+                                default: ext4
+                                description: |-
+                                  fsType is Filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple
+                                  blob disks per storage account  Dedicated: single
+                                  blob disk per storage account  Managed: azure managed
+                                  data disk (only in managed availability set). defaults
+                                  to shared'
+                                type: string
+                              readOnly:
+                                default: false
+                                description: |-
+                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            description: |-
+                              azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                              are redirected to the file.csi.azure.com CSI driver.
+                            properties:
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that
+                                  contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            description: |-
+                              cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                              Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                            properties:
+                              monitors:
+                                description: |-
+                                  monitors is Required: Monitors is a collection of Ceph monitors
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              path:
+                                description: 'path is Optional: Used as the mounted
+                                  root, rather than the full Ceph tree, default is
+                                  /'
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: boolean
+                              secretFile:
+                                description: |-
+                                  secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: string
+                              secretRef:
+                                description: |-
+                                  secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                description: |-
+                                  user is optional: User is the rados user name, default is admin
+                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            description: |-
+                              cinder represents a cinder volume attached and mounted on kubelets host machine.
+                              Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                              are redirected to the cinder.csi.openstack.org CSI driver.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is optional: points to a secret object containing parameters used to connect
+                                  to OpenStack.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeID:
+                                description: |-
+                                  volumeID used to identify the volume in cinder.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should
+                              populate this volume
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode is optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: |-
+                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                  ConfigMap will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the ConfigMap,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap
+                                  or its keys must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          csi:
+                            description: csi (Container Storage Interface) represents
+                              ephemeral storage that is handled by certain external
+                              CSI drivers.
+                            properties:
+                              driver:
+                                description: |-
+                                  driver is the name of the CSI driver that handles this volume.
+                                  Consult with your admin for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: |-
+                                  fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                  If not provided, the empty value is passed to the associated CSI driver
+                                  which will determine the default filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: |-
+                                  nodePublishSecretRef is a reference to the secret object containing
+                                  sensitive information to pass to the CSI driver to complete the CSI
+                                  NodePublishVolume and NodeUnpublishVolume calls.
+                                  This field is optional, and  may be empty if no secret is required. If the
+                                  secret object contains more than one secret, all secret references are passed.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              readOnly:
+                                description: |-
+                                  readOnly specifies a read-only configuration for the volume.
+                                  Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  volumeAttributes stores driver-specific properties that are passed to the CSI
+                                  driver. Consult your driver's documentation for supported values.
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about
+                              the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  Optional: mode bits to use on created files by default. Must be a
+                                  Optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume
+                                  file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information
+                                    to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the
+                                        pod: only annotations, labels, name, namespace
+                                        and uid are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    mode:
+                                      description: |-
+                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative
+                                        path name of the file to be created. Must
+                                        not be absolute or contain the ''..'' path.
+                                        Must be utf-8 encoded. The first item of the
+                                        relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          emptyDir:
+                            description: |-
+                              emptyDir represents a temporary directory that shares a pod's lifetime.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                            properties:
+                              medium:
+                                description: |-
+                                  medium represents what type of storage medium should back this directory.
+                                  The default is "" which means to use the node's default medium.
+                                  Must be an empty string (default) or Memory.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                  The size limit is also applicable for memory medium.
+                                  The maximum usage on memory medium EmptyDir would be the minimum value between
+                                  the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                  The default is nil which means that the limit is undefined.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver.
+                              The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                              and deleted when the pod is removed.
+
+                              Use this if:
+                              a) the volume is only needed while the pod runs,
+                              b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and
+                              d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific
+                              APIs for volumes that persist for longer than the lifecycle
+                              of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                              be used that way - see the documentation of the driver for
+                              more information.
+
+                              A pod can use both types of ephemeral volumes and
+                              persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume.
+                                  The pod in which this EphemeralVolumeSource is embedded will be the
+                                  owner of the PVC, i.e. the PVC will be deleted together with the
+                                  pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                  `<volume name>` is the name from the `PodSpec.Volumes` array
+                                  entry. Pod validation will reject the pod if the concatenated name
+                                  is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod
+                                  will *not* be used for the pod to avoid using an unrelated
+                                  volume by mistake. Starting the pod is then blocked until
+                                  the unrelated PVC is removed. If such a pre-created PVC is
+                                  meant to be used by the pod, the PVC has to updated with an
+                                  owner reference to the pod once the pod exists. Normally
+                                  this should not be necessary, but it may be useful when
+                                  manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes
+                                  to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      May contain labels and annotations that will be copied into the PVC
+                                      when creating it. No other fields are allowed and will be rejected during
+                                      validation.
+                                    type: object
+                                  spec:
+                                    description: |-
+                                      The specification for the PersistentVolumeClaim. The entire content is
+                                      copied unchanged into the PVC that gets created from this
+                                      template. The same fields as in a PersistentVolumeClaim
+                                      are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: |-
+                                          accessModes contains the desired access modes the volume should have.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      dataSource:
+                                        description: |-
+                                          dataSource field can be used to specify either:
+                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                          * An existing PVC (PersistentVolumeClaim)
+                                          If the provisioner or an external controller can support the specified data source,
+                                          it will create a new volume based on the contents of the specified data source.
+                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                          volume is desired. This may be any object from a non-empty API group (non
+                                          core object) or a PersistentVolumeClaim object.
+                                          When this field is specified, volume binding will only succeed if the type of
+                                          the specified object matches some installed volume populator or dynamic
+                                          provisioner.
+                                          This field will replace the functionality of the dataSource field and as such
+                                          if both fields are non-empty, they must have the same value. For backwards
+                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                          value automatically if one of them is empty and the other is non-empty.
+                                          When namespace is specified in dataSourceRef,
+                                          dataSource isn't set to the same value and must be empty.
+                                          There are three important differences between dataSource and dataSourceRef:
+                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: |-
+                                              APIGroup is the group for the resource being referenced.
+                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                              For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource
+                                              being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource
+                                              being referenced
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of resource being referenced
+                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        description: |-
+                                          resources represents the minimum resources the volume should have.
+                                          Users are allowed to specify resource requirements
+                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                          status field of the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Requests describes the minimum amount of compute resources required.
+                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over
+                                          volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      storageClassName:
+                                        description: |-
+                                          storageClassName is the name of the StorageClass required by the claim.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                        type: string
+                                      volumeAttributesClassName:
+                                        description: |-
+                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                          this field can be reset to its previous value (including nil) to cancel the modification.
+                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                          exists.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        type: string
+                                      volumeMode:
+                                        description: |-
+                                          volumeMode defines what type of volume is required by the claim.
+                                          Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference
+                                          to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that
+                              is attached to a kubelet's host machine and then exposed
+                              to the pod.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide
+                                  names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              wwids:
+                                description: |-
+                                  wwids Optional: FC volume world wide identifiers (wwids)
+                                  Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          flexVolume:
+                            description: |-
+                              flexVolume represents a generic volume resource that is
+                              provisioned/attached using an exec based plugin.
+                              Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use
+                                  for this volume.
+                                type: string
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds
+                                  extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: |-
+                                  readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is Optional: secretRef is reference to the secret object containing
+                                  sensitive information to pass to the plugin scripts. This may be
+                                  empty if no secret object is specified. If the secret object
+                                  contains more than one secret, all secrets are passed to the plugin
+                                  scripts.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            description: |-
+                              flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                              Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                            properties:
+                              datasetName:
+                                description: |-
+                                  datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                  should be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset.
+                                  This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: |-
+                              gcePersistentDisk represents a GCE Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                              gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: string
+                              partition:
+                                description: |-
+                                  partition is the partition in the volume that you want to mount.
+                                  If omitted, the default is to mount by volume name.
+                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: |-
+                                  pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            description: |-
+                              gitRepo represents a git repository at a particular revision.
+                              Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                              EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                              into the Pod's container.
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is the target directory name.
+                                  Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                  git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                  the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified
+                                  revision.
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            description: |-
+                              glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                              Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                            properties:
+                              endpoints:
+                                description: endpoints is the endpoint name that details
+                                  Glusterfs topology.
+                                type: string
+                              path:
+                                description: |-
+                                  path is the Glusterfs volume path.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            description: |-
+                              hostPath represents a pre-existing file or directory on the host
+                              machine that is directly exposed to the container. This is generally
+                              used for system agents or other privileged things that are allowed
+                              to see the host machine. Most containers will NOT need this.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                            properties:
+                              path:
+                                description: |-
+                                  path of the directory on the host.
+                                  If the path is a symlink, it will follow the link to the real path.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                type: string
+                              type:
+                                description: |-
+                                  type for HostPath Volume
+                                  Defaults to ""
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          image:
+                            description: |-
+                              image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                              The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                              - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                              - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                              - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                              The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                              A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                              The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                              The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                              The volume will be mounted read-only (ro) and non-executable files (noexec).
+                              Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                              The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          iscsi:
+                            description: |-
+                              iscsi represents an ISCSI Disk resource that is attached to a
+                              kubelet's host machine and then exposed to the pod.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support
+                                  iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support
+                                  iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                type: string
+                              initiatorName:
+                                description: |-
+                                  initiatorName is the custom iSCSI Initiator Name.
+                                  If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                  <target portal>:<volume name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                default: default
+                                description: |-
+                                  iscsiInterface is the interface Name that uses an iSCSI transport.
+                                  Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: |-
+                                  portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI
+                                  target and initiator authentication
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              targetPortal:
+                                description: |-
+                                  targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                  is other than default (typically TCP ports 860 and 3260).
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            description: |-
+                              name of the volume.
+                              Must be a DNS_LABEL and unique within the pod.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          nfs:
+                            description: |-
+                              nfs represents an NFS mount on the host that shares a pod's lifetime
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                            properties:
+                              path:
+                                description: |-
+                                  path that is exported by the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the NFS export to be mounted with read-only permissions.
+                                  Defaults to false.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: boolean
+                              server:
+                                description: |-
+                                  server is the hostname or IP address of the NFS server.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            description: |-
+                              persistentVolumeClaimVolumeSource represents a reference to a
+                              PersistentVolumeClaim in the same namespace.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                            properties:
+                              claimName:
+                                description: |-
+                                  claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly Will force the ReadOnly setting in VolumeMounts.
+                                  Default false.
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: |-
+                              photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                              Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon
+                                  Controller persistent disk
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            description: |-
+                              portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                              Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                              are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                              is on.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fSType represents the filesystem type to mount
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx
+                                  volume
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources
+                              secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode are the mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: |-
+                                  sources is the list of volume projections. Each entry in this list
+                                  handles one source.
+                                items:
+                                  description: |-
+                                    Projection that may be projected along with other supported volume types.
+                                    Exactly one of these fields must be set.
+                                  properties:
+                                    clusterTrustBundle:
+                                      description: |-
+                                        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                        of ClusterTrustBundle objects in an auto-updating file.
+
+                                        Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                        ClusterTrustBundle objects can either be selected by name, or by the
+                                        combination of signer name and a label selector.
+
+                                        Kubelet performs aggressive normalization of the PEM contents written
+                                        into the pod filesystem.  Esoteric PEM features such as inter-block
+                                        comments and block headers are stripped.  Certificates are deduplicated.
+                                        The ordering of certificates within the file is arbitrary, and Kubelet
+                                        may change the order over time.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            Select all ClusterTrustBundles that match this label selector.  Only has
+                                            effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                            interpreted as "match nothing".  If set but empty, interpreted as "match
+                                            everything".
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        name:
+                                          description: |-
+                                            Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                            with signerName and labelSelector.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                            aren't available.  If using name, then the named ClusterTrustBundle is
+                                            allowed not to exist.  If using signerName, then the combination of
+                                            signerName and labelSelector is allowed to match zero
+                                            ClusterTrustBundles.
+                                          type: boolean
+                                        path:
+                                          description: Relative path from the volume
+                                            root to write the bundle.
+                                          type: string
+                                        signerName:
+                                          description: |-
+                                            Select all ClusterTrustBundles that match this signer name.
+                                            Mutually-exclusive with name.  The contents of all selected
+                                            ClusterTrustBundles will be unified and deduplicated.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    configMap:
+                                      description: configMap information about the
+                                        configMap data to project
+                                      properties:
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    downwardAPI:
+                                      description: downwardAPI information about the
+                                        downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume
+                                            file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name, namespace and uid
+                                                  are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podCertificate:
+                                      description: |-
+                                        Projects an auto-rotating credential bundle (private key and certificate
+                                        chain) that the pod can use either as a TLS client or server.
+
+                                        Kubelet generates a private key and uses it to send a
+                                        PodCertificateRequest to the named signer.  Once the signer approves the
+                                        request and issues a certificate chain, Kubelet writes the key and
+                                        certificate chain to the pod filesystem.  The pod does not start until
+                                        certificates have been issued for each podCertificate projected volume
+                                        source in its spec.
+
+                                        Kubelet will begin trying to rotate the certificate at the time indicated
+                                        by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                        timestamp.
+
+                                        Kubelet can write a single file, indicated by the credentialBundlePath
+                                        field, or separate files, indicated by the keyPath and
+                                        certificateChainPath fields.
+
+                                        The credential bundle is a single file in PEM format.  The first PEM
+                                        entry is the private key (in PKCS#8 format), and the remaining PEM
+                                        entries are the certificate chain issued by the signer (typically,
+                                        signers will return their certificate chain in leaf-to-root order).
+
+                                        Prefer using the credential bundle format, since your application code
+                                        can read it atomically.  If you use keyPath and certificateChainPath,
+                                        your application must make two separate file reads. If these coincide
+                                        with a certificate rotation, it is possible that the private key and leaf
+                                        certificate you read may not correspond to each other.  Your application
+                                        will need to check for this condition, and re-read until they are
+                                        consistent.
+
+                                        The named signer controls chooses the format of the certificate it
+                                        issues; consult the signer implementation's documentation to learn how to
+                                        use the certificates it issues.
+                                      properties:
+                                        certificateChainPath:
+                                          description: |-
+                                            Write the certificate chain at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        credentialBundlePath:
+                                          description: |-
+                                            Write the credential bundle at this path in the projected volume.
+
+                                            The credential bundle is a single file that contains multiple PEM blocks.
+                                            The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                            key.
+
+                                            The remaining blocks are CERTIFICATE blocks, containing the issued
+                                            certificate chain from the signer (leaf and any intermediates).
+
+                                            Using credentialBundlePath lets your Pod's application code make a single
+                                            atomic read that retrieves a consistent key and certificate chain.  If you
+                                            project them to separate files, your application code will need to
+                                            additionally check that the leaf certificate was issued to the key.
+                                          type: string
+                                        keyPath:
+                                          description: |-
+                                            Write the key at this path in the projected volume.
+
+                                            Most applications should use credentialBundlePath.  When using keyPath
+                                            and certificateChainPath, your application needs to check that the key
+                                            and leaf certificate are consistent, because it is possible to read the
+                                            files mid-rotation.
+                                          type: string
+                                        keyType:
+                                          description: |-
+                                            The type of keypair Kubelet will generate for the pod.
+
+                                            Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                            "ECDSAP521", and "ED25519".
+                                          type: string
+                                        maxExpirationSeconds:
+                                          description: |-
+                                            maxExpirationSeconds is the maximum lifetime permitted for the
+                                            certificate.
+
+                                            Kubelet copies this value verbatim into the PodCertificateRequests it
+                                            generates for this projection.
+
+                                            If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                            will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                            value is 7862400 (91 days).
+
+                                            The signer implementation is then free to issue a certificate with any
+                                            lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                            seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                            `kubernetes.io` signers will never issue certificates with a lifetime
+                                            longer than 24 hours.
+                                          format: int32
+                                          type: integer
+                                        signerName:
+                                          description: Kubelet's generated CSRs will
+                                            be addressed to this signer.
+                                          type: string
+                                        userAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            userAnnotations allow pod authors to pass additional information to
+                                            the signer implementation.  Kubernetes does not restrict or validate this
+                                            metadata in any way.
+
+                                            These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                            the PodCertificateRequest objects that Kubelet creates.
+
+                                            Entries are subject to the same validation as object metadata annotations,
+                                            with the addition that all keys must be domain-prefixed. No restrictions
+                                            are placed on values, except an overall size limitation on the entire field.
+
+                                            Signers should document the keys and values they support. Signers should
+                                            deny requests that contain keys they do not recognize.
+                                          type: object
+                                      required:
+                                      - keyType
+                                      - signerName
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret
+                                        data to project
+                                      properties:
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information
+                                        about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: |-
+                                            audience is the intended audience of the token. A recipient of a token
+                                            must identify itself with an identifier specified in the audience of the
+                                            token, and otherwise should reject the token. The audience defaults to the
+                                            identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: |-
+                                            expirationSeconds is the requested duration of validity of the service
+                                            account token. As the token approaches expiration, the kubelet volume
+                                            plugin will proactively rotate the service account token. The kubelet will
+                                            start trying to rotate the token if the token is older than 80 percent of
+                                            its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                            and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the path relative to the mount point of the file to project the
+                                            token into.
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          quobyte:
+                            description: |-
+                              quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                              Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                            properties:
+                              group:
+                                description: |-
+                                  group to map volume access to
+                                  Default is no group
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                  Defaults to false.
+                                type: boolean
+                              registry:
+                                description: |-
+                                  registry represents a single or multiple Quobyte Registry services
+                                  specified as a string as host:port pair (multiple entries are separated with commas)
+                                  which acts as the central registry for volumes
+                                type: string
+                              tenant:
+                                description: |-
+                                  tenant owning the given Quobyte volume in the Backend
+                                  Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: |-
+                                  user to map volume access to
+                                  Defaults to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an
+                                  already created Quobyte volume by name.
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            description: |-
+                              rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                              Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type of the volume that you want to mount.
+                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                type: string
+                              image:
+                                description: |-
+                                  image is the rados image name.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              keyring:
+                                default: /etc/ceph/keyring
+                                description: |-
+                                  keyring is the path to key ring for RBDUser.
+                                  Default is /etc/ceph/keyring.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              monitors:
+                                description: |-
+                                  monitors is a collection of Ceph monitors.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              pool:
+                                default: rbd
+                                description: |-
+                                  pool is the rados pool name.
+                                  Default is rbd.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                  Defaults to false.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef is name of the authentication secret for RBDUser. If provided
+                                  overrides keyring.
+                                  Default is nil.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              user:
+                                default: admin
+                                description: |-
+                                  user is the rados user name.
+                                  Default is admin.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            description: |-
+                              scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                            properties:
+                              fsType:
+                                default: xfs
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs".
+                                  Default is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO
+                                  API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO
+                                  Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef references to the secret for ScaleIO user and other
+                                  sensitive information. If this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication
+                                  with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                default: ThinProvisioned
+                                description: |-
+                                  storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                  Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool
+                                  associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system
+                                  as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: |-
+                                  volumeName is the name of a volume already created in the ScaleIO system
+                                  that is associated with this volume source.
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          secret:
+                            description: |-
+                              secret represents a secret that should populate this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                            properties:
+                              defaultMode:
+                                description: |-
+                                  defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values
+                                  for mode bits. Defaults to 0644.
+                                  Directories within the path are not affected by this setting.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              items:
+                                description: |-
+                                  items If unspecified, each key-value pair in the Data field of the referenced
+                                  Secret will be projected into the volume as a file whose name is the
+                                  key and content is the value. If specified, the listed keys will be
+                                  projected into the specified paths, and unlisted keys will not be
+                                  present. If a key is specified which is not present in the Secret,
+                                  the volume setup will error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within
+                                    a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: |-
+                                        mode is Optional: mode bits used to set permissions on this file.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        If not specified, the volume defaultMode will be used.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: |-
+                                        path is the relative path of the file to map the key to.
+                                        May not be an absolute path.
+                                        May not contain the path element '..'.
+                                        May not start with the string '..'.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              optional:
+                                description: optional field specify whether the Secret
+                                  or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: |-
+                                  secretName is the name of the secret in the pod's namespace to use.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: string
+                            type: object
+                          storageos:
+                            description: |-
+                              storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is the filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                  the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: |-
+                                  secretRef specifies the secret to use for obtaining the StorageOS API
+                                  credentials.  If not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              volumeName:
+                                description: |-
+                                  volumeName is the human-readable name of the StorageOS volume.  Volume
+                                  names are only unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: |-
+                                  volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                  namespace is specified then the Pod's namespace will be used.  This allows the
+                                  Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                  Set VolumeName to any name to override the default behaviour.
+                                  Set to "default" if you are not using namespaces within StorageOS.
+                                  Namespaces that do not pre-exist within StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: |-
+                              vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                              Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                              are redirected to the csi.vsphere.vmware.com CSI driver.
+                            properties:
+                              fsType:
+                                description: |-
+                                  fsType is filesystem type to mount.
+                                  Must be a filesystem type supported by the host operating system.
+                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy
+                                  Based Management (SPBM) profile ID associated with
+                                  the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy
+                                  Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies
+                                  vSphere volume vmdk
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  type: object
+                description: Override the default configurations of the agents
+                type: object
+            type: object
+          status:
+            description: DatadogAgentStatus defines the observed state of DatadogAgent.
+            properties:
+              agent:
+                description: The combined actual state of all Agents as daemonsets
+                  or extended daemonsets.
+                properties:
+                  available:
+                    description: Number of available pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  current:
+                    description: Number of current pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the DaemonSet.
+                    type: string
+                  daemonsetName:
+                    description: DaemonsetName corresponds to the name of the created
+                      DaemonSet.
+                    type: string
+                  desired:
+                    description: Number of desired pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  ready:
+                    description: Number of ready pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the DaemonSet state.
+                    type: string
+                  status:
+                    description: Status corresponds to the DaemonSet computed status.
+                    type: string
+                  upToDate:
+                    description: Number of up to date pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                required:
+                - available
+                - current
+                - desired
+                - ready
+                - upToDate
+                type: object
+              agentList:
+                description: The actual state of the Agent as a daemonset or an extended
+                  daemonset.
+                items:
+                  description: DaemonSetStatus defines the observed state of Agent
+                    running as DaemonSet.
+                  properties:
+                    available:
+                      description: Number of available pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    current:
+                      description: Number of current pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    currentHash:
+                      description: CurrentHash is the stored hash of the DaemonSet.
+                      type: string
+                    daemonsetName:
+                      description: DaemonsetName corresponds to the name of the created
+                        DaemonSet.
+                      type: string
+                    desired:
+                      description: Number of desired pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    lastUpdate:
+                      description: LastUpdate is the last time the status was updated.
+                      format: date-time
+                      type: string
+                    ready:
+                      description: Number of ready pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                    state:
+                      description: State corresponds to the DaemonSet state.
+                      type: string
+                    status:
+                      description: Status corresponds to the DaemonSet computed status.
+                      type: string
+                    upToDate:
+                      description: Number of up to date pods in the DaemonSet.
+                      format: int32
+                      type: integer
+                  required:
+                  - available
+                  - current
+                  - desired
+                  - ready
+                  - upToDate
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              clusterAgent:
+                description: The actual state of the Cluster Agent as a deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the Deployment.
+                    type: string
+                  deploymentName:
+                    description: DeploymentName corresponds to the name of the Deployment.
+                    type: string
+                  generatedToken:
+                    description: |-
+                      GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is
+                      enabled.
+                    type: string
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  readyReplicas:
+                    description: Total number of ready pods targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the Deployment state.
+                    type: string
+                  status:
+                    description: Status corresponds to the Deployment computed status.
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this Deployment. This is the total number of
+                      pods that are still required for the Deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+              clusterChecksRunner:
+                description: The actual state of the Cluster Checks Runner as a deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the Deployment.
+                    type: string
+                  deploymentName:
+                    description: DeploymentName corresponds to the name of the Deployment.
+                    type: string
+                  generatedToken:
+                    description: |-
+                      GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is
+                      enabled.
+                    type: string
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  readyReplicas:
+                    description: Total number of ready pods targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the Deployment state.
+                    type: string
+                  status:
+                    description: Status corresponds to the Deployment computed status.
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this Deployment. This is the total number of
+                      pods that are still required for the Deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+              clusterProvider:
+                description: |-
+                  ClusterProvider is the detected (or user-specified) cluster provider used to
+                  apply provider-specific configuration (e.g. control plane monitoring). Empty
+                  means no provider was detected or configured.
+                type: string
+              conditions:
+                description: Conditions Represents the latest available observations
+                  of a DatadogAgent's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              experiment:
+                description: Experiment tracks the state of an active or recent Fleet
+                  Automation experiment.
+                properties:
+                  id:
+                    description: ID is the RC task ID that triggered this experiment
+                      state.
+                    type: string
+                  phase:
+                    description: Phase is the current state of the experiment.
+                    enum:
+                    - running
+                    - terminated
+                    - promoted
+                    - aborted
+                    type: string
+                  startTaskID:
+                    description: |-
+                      StartTaskID is the Fleet Automation task identifier that drove the
+                      transition into phase=Running. Captured from the daemon's pending
+                      annotations and preserved across daemon restarts. On local timeout
+                      the daemon uses it to report TaskState_ERROR for the original start
+                      task, so Fleet Automation gets an explicit terminal failure tied to
+                      the task it sent rather than inferring termination from a cleared
+                      experimentConfigVersion.
+                    type: string
+                  startedAt:
+                    description: |-
+                      StartedAt is the wall-clock time at which the experiment first
+                      transitioned to phase=Running. Used as the anchor for the
+                      experiment timeout. Decoupled from ControllerRevision metadata so
+                      the timeout decision does not depend on revision creation
+                      timestamps (which can be stale for re-used revisions).
+                    format: date-time
+                    type: string
+                  terminationReason:
+                    description: |-
+                      TerminationReason distinguishes why the experiment was terminated.
+                      Only set when Phase is "terminated".
+                    type: string
+                type: object
+              otelAgentGateway:
+                description: The actual state of the OTel Agent Gateway as a deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the Deployment.
+                    type: string
+                  deploymentName:
+                    description: DeploymentName corresponds to the name of the Deployment.
+                    type: string
+                  generatedToken:
+                    description: |-
+                      GeneratedToken corresponds to the generated token if any token was provided in the Credential configuration when ClusterAgent is
+                      enabled.
+                    type: string
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  readyReplicas:
+                    description: Total number of ready pods targeted by this Deployment.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the Deployment state.
+                    type: string
+                  status:
+                    description: Status corresponds to the Deployment computed status.
+                    type: string
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this Deployment. This is the total number of
+                      pods that are still required for the Deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      Deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+              remoteConfigConfiguration:
+                description: RemoteConfigConfiguration stores the configuration received
+                  from RemoteConfig.
+                properties:
+                  features:
+                    description: DatadogFeatures are features running on the Agent
+                      and Cluster Agent.
+                    properties:
+                      admissionController:
+                        description: AdmissionController configuration.
+                        properties:
+                          agentCommunicationMode:
+                            description: |-
+                              AgentCommunicationMode corresponds to the mode used by the Datadog application libraries to communicate with the Agent.
+                              It can be "hostip", "service", or "socket".
+                            type: string
+                          agentSidecarInjection:
+                            description: AgentSidecarInjection contains Agent sidecar
+                              injection configurations.
+                            properties:
+                              clusterAgentCommunicationEnabled:
+                                description: |-
+                                  ClusterAgentCommunicationEnabled enables communication between Agent sidecars and the Cluster Agent.
+                                  Default : true
+                                type: boolean
+                              clusterAgentTlsVerification:
+                                description: ClusterAgentTLSVerification configures
+                                  TLS verification for Agent sidecar to Cluster Agent
+                                  communication.
+                                properties:
+                                  copyCaConfigMap:
+                                    description: |-
+                                      CopyCaConfigMap enables automatic creation of a ConfigMap containing the Cluster Agent's CA certificate
+                                      in namespaces where sidecar injection occurs.
+                                      Default: false
+                                    type: boolean
+                                  enabled:
+                                    description: |-
+                                      Enabled enables TLS verification for agent sidecars communicating with the Cluster Agent.
+                                      Default: false
+                                    type: boolean
+                                type: object
+                              enabled:
+                                description: |-
+                                  Enabled enables Sidecar injections.
+                                  Default: false
+                                type: boolean
+                              image:
+                                description: Image overrides the default Agent image
+                                  name and tag for the Agent sidecar.
+                                properties:
+                                  jmxEnabled:
+                                    description: |-
+                                      Define whether the Agent image should support JMX.
+                                      To be used if the `Name` field does not correspond to a full image string.
+                                    type: boolean
+                                  name:
+                                    description: |-
+                                      Defines the Agent image name for the pod. You can provide this as:
+                                      * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                                      for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                                      * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                                      and `[key].image.jmxEnabled` are ignored.
+                                      * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                                        like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                                    type: string
+                                  pullPolicy:
+                                    description: |-
+                                      The Kubernetes pull policy:
+                                      Use `Always`, `Never`, or `IfNotPresent`.
+                                    type: string
+                                  pullSecrets:
+                                    description: |-
+                                      It is possible to specify Docker registry credentials.
+                                      See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                                    items:
+                                      description: |-
+                                        LocalObjectReference contains enough information to let you locate the
+                                        referenced object inside the same namespace.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                  tag:
+                                    description: |-
+                                      Define the image tag to use.
+                                      To be used if the `Name` field does not correspond to a full image string.
+                                    type: string
+                                type: object
+                              profiles:
+                                description: Profiles define the sidecar configuration
+                                  override. Only one profile is supported.
+                                items:
+                                  description: Profile defines a sidecar configuration
+                                    override.
+                                  properties:
+                                    env:
+                                      description: EnvVars specifies the environment
+                                        variables for the profile.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    resources:
+                                      description: ResourceRequirements specifies
+                                        the resource requirements for the profile.
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    securityContext:
+                                      description: SecurityContext specifies the security
+                                        context for the profile.
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              provider:
+                                description: |-
+                                  Provider is used to add infrastructure provider-specific configurations to the Agent sidecar.
+                                  Currently only "fargate" is supported.
+                                  To use the feature in other environments (including local testing) omit the config.
+                                  See also: https://docs.datadoghq.com/integrations/eks_fargate
+                                type: string
+                              registry:
+                                description: Registry overrides the default registry
+                                  for the sidecar Agent.
+                                type: string
+                              selectors:
+                                description: Selectors define the pod selector for
+                                  sidecar injection. Only one rule is supported.
+                                items:
+                                  description: Selectors define a pod selector for
+                                    sidecar injection.
+                                  properties:
+                                    namespaceSelector:
+                                      description: NamespaceSelector specifies the
+                                        label selector for namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    objectSelector:
+                                      description: ObjectSelector specifies the label
+                                        selector for objects.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          cwsInstrumentation:
+                            description: CWSInstrumentation holds the CWS Instrumentation
+                              endpoint configuration
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable the CWS Instrumentation admission controller endpoint.
+                                  Default: false
+                                type: boolean
+                              mode:
+                                description: |-
+                                  Mode defines the behavior of the CWS Instrumentation endpoint, and can be either "init_container" or "remote_copy".
+                                  Default: "remote_copy"
+                                type: string
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the Admission Controller.
+                              Default: true
+                            type: boolean
+                          failurePolicy:
+                            description: FailurePolicy determines how unrecognized
+                              and timeout errors are handled.
+                            type: string
+                          kubernetesAdmissionEvents:
+                            description: KubernetesAdmissionEvents holds the Kubernetes
+                              Admission Events configuration.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enable the Kubernetes Admission Events feature.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          mutateUnlabelled:
+                            description: |-
+                              MutateUnlabelled enables config injection without the need of pod label 'admission.datadoghq.com/enabled="true"'.
+                              Default: false
+                            type: boolean
+                          mutation:
+                            description: Mutation contains Admission Controller mutation
+                              configurations.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the Admission Controller mutation webhook.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          probe:
+                            description: Probe holds the admission controller connectivity
+                              probe configuration.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the admission controller connectivity probe.
+                                  The probe periodically sends dry-run ConfigMap creation requests to verify the
+                                  webhook is reachable from the API server. Requires Cluster Agent 7.78.0+.
+                                  Default: true
+                                type: boolean
+                              gracePeriod:
+                                description: |-
+                                  GracePeriod is the number of seconds to wait at startup before the first probe.
+                                  Default: 60
+                                format: int32
+                                type: integer
+                              interval:
+                                description: |-
+                                  Interval is the number of seconds between probe executions.
+                                  Default: 60
+                                format: int32
+                                type: integer
+                            type: object
+                          registry:
+                            description: Registry defines an image registry for the
+                              admission controller.
+                            type: string
+                          serviceName:
+                            description: ServiceName corresponds to the webhook service
+                              name.
+                            type: string
+                          validation:
+                            description: Validation contains Admission Controller
+                              validation configurations.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the Admission Controller validation webhook.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          webhookName:
+                            description: |-
+                              WebhookName is a custom name for the MutatingWebhookConfiguration.
+                              Default: "datadog-webhook"
+                            type: string
+                        type: object
+                      apm:
+                        description: APM (Application Performance Monitoring) configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Application Performance Monitoring.
+                              Default: true
+                            type: boolean
+                          errorTrackingStandalone:
+                            description: |-
+                              ErrorTrackingStandalone contains the configuration for the Error Tracking standalone feature.
+                              Feature is in preview.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enables Error Tracking for backend services.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          hostPortConfig:
+                            description: |-
+                              HostPortConfig contains host port configuration.
+                              Enabled Default: false
+                              Port Default: 8126
+                            properties:
+                              enabled:
+                                description: Enabled enables host port configuration
+                                type: boolean
+                              hostPort:
+                                description: |-
+                                  Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                  If HostNetwork is enabled, this value must match the ContainerPort.
+                                format: int32
+                                type: integer
+                            type: object
+                          instrumentation:
+                            description: |-
+                              SingleStepInstrumentation allows the agent to inject the Datadog APM libraries into all pods in the cluster.
+                              Feature is in beta.
+                              See also: https://docs.datadoghq.com/tracing/trace_collection/single-step-apm
+                              Enabled Default: false
+                            properties:
+                              disabledNamespaces:
+                                description: DisabledNamespaces disables injecting
+                                  the Datadog APM libraries into pods in specific
+                                  namespaces.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enabled enables injecting the Datadog APM libraries into all pods in the cluster.
+                                  Default: false
+                                type: boolean
+                              enabledNamespaces:
+                                description: EnabledNamespaces enables injecting the
+                                  Datadog APM libraries into pods in specific namespaces.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              injectionMode:
+                                description: |-
+                                  InjectionMode is the injection mode to use for libraries injection.
+                                  Valid values are: "auto", "init_container", "csi" (experimental, requires Cluster Agent 7.76.0+ and Datadog CSI Driver 1.2.0+), "image_volume" (experimental, requires Cluster Agent 7.77.0+).
+                                  Empty by default so the Cluster Agent can apply its own defaults.
+                                enum:
+                                - auto
+                                - init_container
+                                - csi
+                                - image_volume
+                                type: string
+                              injector:
+                                description: Injector configures the APM Injector.
+                                properties:
+                                  imageTag:
+                                    description: |-
+                                      Set the image tag to use for the APM Injector.
+                                      (Requires Cluster Agent 7.57.0+)
+                                    type: string
+                                type: object
+                              languageDetection:
+                                description: |-
+                                  LanguageDetection detects languages and adds them as annotations on Deployments, but does not use these languages for injecting libraries to workload pods.
+                                  (Requires Agent 7.52.0+ and Cluster Agent 7.52.0+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables Language Detection to automatically detect languages of user workloads (beta).
+                                      Requires SingleStepInstrumentation.Enabled to be true.
+                                      Default: true
+                                    type: boolean
+                                type: object
+                              libVersions:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  LibVersions configures injection of specific tracing library versions with Single Step Instrumentation.
+                                  <Library>: <Version>
+                                  ex: "java": "v1.18.0"
+                                type: object
+                              targets:
+                                description: |-
+                                  Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
+                                  used. If no target matches, the auto instrumentation will not be applied.
+                                  (Requires Cluster Agent 7.64.0+)
+                                items:
+                                  description: SSITarget is a rule to apply the auto
+                                    instrumentation to a specific workload using the
+                                    pod and namespace selectors.
+                                  properties:
+                                    ddTraceConfigs:
+                                      description: |-
+                                        TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+                                        as environment variables in addition to the injected tracer.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    ddTraceVersions:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
+                                        name and the value is the version to inject.
+                                      type: object
+                                    name:
+                                      description: Name is the name of the target.
+                                        It will be appended to the pod annotations
+                                        to identify the target that was used.
+                                      type: string
+                                    namespaceSelector:
+                                      description: |-
+                                        NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
+                                        be used in conjunction with the Selector to match the pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: |-
+                                            MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
+                                            expressions are ANDed. This cannot be used with MatchNames.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
+                                            ANDed. This cannot be used with MatchNames.
+                                          type: object
+                                        matchNames:
+                                          description: MatchNames is a list of namespace
+                                            names to match. If empty, all namespaces
+                                            are matched.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    podSelector:
+                                      description: |-
+                                        PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
+                                        conjunction with the NamespaceSelector to match the pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                            type: object
+                          unixDomainSocketConfig:
+                            description: |-
+                              UnixDomainSocketConfig contains socket configuration.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                              Enabled Default: true
+                              Path Default: `/var/run/datadog/apm.socket`
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Unix Domain Socket.
+                                  Default: true
+                                type: boolean
+                              path:
+                                description: Path defines the socket path used when
+                                  enabled.
+                                type: string
+                            type: object
+                        type: object
+                      asm:
+                        description: ASM (Application Security Management) configuration.
+                        properties:
+                          iast:
+                            description: |-
+                              IAST configures Interactive Application Security Testing.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Interactive Application Security Testing (IAST).
+                                  Default: false
+                                type: boolean
+                            type: object
+                          sca:
+                            description: |-
+                              SCA configures Software Composition Analysis.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Software Composition Analysis (SCA).
+                                  Default: false
+                                type: boolean
+                            type: object
+                          threats:
+                            description: |-
+                              Threats configures ASM App & API Protection.
+                              Enabled Default: false
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables ASM App & API Protection.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      autoscaling:
+                        description: Autoscaling configuration.
+                        properties:
+                          cluster:
+                            description: Cluster contains the configuration for the
+                              cluster autoscaling product.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the cluster autoscaling product.
+                                  (Requires Cluster Agent 7.74.0+)
+                                  Default: false
+                                type: boolean
+                              spot:
+                                description: |-
+                                  Spot contains the configuration for the spot instance scheduling sub-feature.
+                                  Requires cluster autoscaling to be enabled.
+                                  (Requires Cluster Agent 7.79.0+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables the cluster spot scheduling product.
+                                      (Requires Cluster Agent 7.79.0+)
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                          workload:
+                            description: Workload contains the configuration for the
+                              workload autoscaling product.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables the workload autoscaling product.
+                                  Default: false
+                                type: boolean
+                              inPlaceVerticalScaling:
+                                description: |-
+                                  InPlaceVerticalScaling contains the configuration for the in-place vertical scaling sub-feature.
+                                  Requires workload autoscaling to be enabled.
+                                  (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enabled enables in-place vertical scaling for workload autoscaling.
+                                      (Requires Cluster Agent 7.78.0+ and Kubernetes 1.33+)
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                        type: object
+                      clusterChecks:
+                        description: ClusterChecks configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables Cluster Checks scheduling in the Cluster Agent.
+                              Default: true
+                            type: boolean
+                          useClusterChecksRunners:
+                            description: |-
+                              Enabled enables Cluster Checks Runners to run all Cluster Checks.
+                              Default: false
+                            type: boolean
+                        type: object
+                      controlPlaneMonitoring:
+                        description: ControlPlaneMonitoring configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables control plane monitoring checks in the cluster agent.
+                              Default: true
+                            type: boolean
+                        type: object
+                      cspm:
+                        description: CSPM (Cloud Security Posture Management) configuration.
+                        properties:
+                          checkInterval:
+                            description: CheckInterval defines the check interval.
+                            type: string
+                          customBenchmarks:
+                            description: |-
+                              CustomBenchmarks contains CSPM benchmarks.
+                              The content of the ConfigMap will be merged with the benchmarks bundled with the agent.
+                              Any benchmarks with the same name as those existing in the agent will take precedence.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Security Posture Management, including Docker and Kubernetes benchmarks.
+                              Default: false
+                            type: boolean
+                          hostBenchmarks:
+                            description: HostBenchmarks contains configuration for
+                              host benchmarks.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Linux host benchmarks. Requires `features.cspm.enabled` to be set to `true`.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          runInSystemProbe:
+                            description: |-
+                              RunInSystemProbe configures CSPM to send payloads directly from the system-probe, without using the security-agent.
+                              This is an experimental feature. Contact support before using.
+                              Default: false
+                            type: boolean
+                        type: object
+                      cws:
+                        description: CWS (Cloud Workload Security) configuration.
+                        properties:
+                          customPolicies:
+                            description: |-
+                              CustomPolicies contains security policies.
+                              The content of the ConfigMap will be merged with the policies bundled with the agent.
+                              Any policies with the same name as those existing in the agent will take precedence.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          directSendFromSystemProbe:
+                            description: |-
+                              DirectSendFromSystemProbe configures CWS to send payloads directly from the system-probe, without using the security-agent.
+                              This is an experimental feature. Contact support before using.
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables Cloud Workload Security.
+                              Default: false
+                            type: boolean
+                          enforcement:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Enforcement for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          network:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Cloud Workload Security Network detections.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          remoteConfiguration:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Remote Configuration for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          securityProfiles:
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Security Profiles collection for Cloud Workload Security.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          syscallMonitorEnabled:
+                            description: |-
+                              SyscallMonitorEnabled enables Syscall Monitoring (recommended for troubleshooting only).
+                              Default: false
+                            type: boolean
+                        type: object
+                      dataPlane:
+                        description: |-
+                          DataPlane configuration for the Agent Data Plane.
+                          Agent Data Plane is a high-performance sidecar that handles data ingestion.
+                        properties:
+                          dogstatsd:
+                            description: Dogstatsd configures DogStatsD handling by
+                              the Data Plane.
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled configures the Data Plane to handle DogStatsD traffic.
+                                  When set to false, DogStatsD is handled by the Core Agent instead.
+                                  Default: true
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the Data Plane.
+                              Default: false
+                            type: boolean
+                        type: object
+                      dogstatsd:
+                        description: Dogstatsd configuration.
+                        properties:
+                          hostPortConfig:
+                            description: |-
+                              HostPortConfig contains host port configuration.
+                              Enabled Default: false
+                              Port Default: 8125
+                            properties:
+                              enabled:
+                                description: Enabled enables host port configuration
+                                type: boolean
+                              hostPort:
+                                description: |-
+                                  Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                  If HostNetwork is enabled, this value must match the ContainerPort.
+                                format: int32
+                                type: integer
+                            type: object
+                          mapperProfiles:
+                            description: |-
+                              Configure the Dogstasd Mapper Profiles.
+                              Can be passed as raw data or via a json encoded string in a config map.
+                              See also: https://docs.datadoghq.com/developers/dogstatsd/dogstatsd_mapper/
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          nonLocalTraffic:
+                            description: |-
+                              NonLocalTraffic enables non-local traffic for Dogstatsd.
+                              Default: true
+                            type: boolean
+                          originDetectionEnabled:
+                            description: |-
+                              OriginDetectionEnabled enables origin detection for container tagging.
+                              See also: https://docs.datadoghq.com/developers/dogstatsd/unix_socket/#using-origin-detection-for-container-tagging
+                            type: boolean
+                          tagCardinality:
+                            description: |-
+                              TagCardinality configures tag cardinality for the metrics collected using origin detection (`low`, `orchestrator` or `high`).
+                              This setting only applies when OriginDetectionEnabled is true.
+                              See also: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
+                              Cardinality default: low
+                            type: string
+                          unixDomainSocketConfig:
+                            description: |-
+                              UnixDomainSocketConfig contains socket configuration.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#agent-environment-variables
+                              Enabled Default: true
+                              Path Default: `/var/run/datadog/dsd.socket`
+                            properties:
+                              enabled:
+                                description: |-
+                                  Enabled enables Unix Domain Socket.
+                                  Default: true
+                                type: boolean
+                              path:
+                                description: Path defines the socket path used when
+                                  enabled.
+                                type: string
+                            type: object
+                        type: object
+                      dynamicInstrumentation:
+                        description: DynamicInstrumentation configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Dynamic Instrumentation system probe module.
+                              Default: false
+                            type: boolean
+                        type: object
+                      ebpfCheck:
+                        description: EBPFCheck configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the eBPF check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      eventCollection:
+                        description: EventCollection configuration.
+                        properties:
+                          collectKubernetesEvents:
+                            description: |-
+                              CollectKubernetesEvents enables Kubernetes event collection.
+                              Default: true
+                            type: boolean
+                          collectedEventTypes:
+                            description: |-
+                              CollectedEventTypes defines the list of events to collect when UnbundleEvents is enabled.
+                              Default:
+                              [
+                              {"kind":"Pod","reasons":["Failed","BackOff","Unhealthy","FailedScheduling","FailedMount","FailedAttachVolume"]},
+                              {"kind":"Node","reasons":["TerminatingEvictedPod","NodeNotReady","Rebooted","HostPortConflict"]},
+                              {"kind":"CronJob","reasons":["SawCompletedJob"]}
+                              ]
+                            items:
+                              description: EventTypes defines the kind and reasons
+                                of events to collect.
+                              properties:
+                                kind:
+                                  description: 'Kind is the kind of event to collect.
+                                    (ex: Pod, Node, CronJob)'
+                                  type: string
+                                reasons:
+                                  description: 'Reasons is a list of event reasons
+                                    to collect. (ex: Failed, BackOff, Unhealthy)'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - kind
+                              - reasons
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          unbundleEvents:
+                            description: |-
+                              UnbundleEvents enables collection of Kubernetes events as individual events.
+                              Default: false
+                            type: boolean
+                        type: object
+                      externalMetricsServer:
+                        description: ExternalMetricsServer configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the External Metrics Server.
+                              Default: false
+                            type: boolean
+                          endpoint:
+                            description: |-
+                              Override the API endpoint for the External Metrics Server.
+                              URL Default: "https://app.datadoghq.com".
+                            properties:
+                              credentials:
+                                description: Credentials defines the Datadog credentials
+                                  used to submit data to/query data from Datadog.
+                                properties:
+                                  apiKey:
+                                    description: |-
+                                      APIKey configures your Datadog API key.
+                                      See also: https://app.datadoghq.com/account/settings#agent/kubernetes
+                                    type: string
+                                  apiSecret:
+                                    description: |-
+                                      APISecret references an existing Secret which stores the API key instead of creating a new one.
+                                      If set, this parameter takes precedence over "APIKey".
+                                    properties:
+                                      keyName:
+                                        description: KeyName is the key of the secret
+                                          to use.
+                                        type: string
+                                      secretName:
+                                        description: SecretName is the name of the
+                                          secret.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                  appKey:
+                                    description: |-
+                                      AppKey configures your Datadog application key.
+                                      If you are using features.externalMetricsServer.enabled = true, you must set
+                                      a Datadog application key for read access to your metrics.
+                                    type: string
+                                  appSecret:
+                                    description: |-
+                                      AppSecret references an existing Secret which stores the application key instead of creating a new one.
+                                      If set, this parameter takes precedence over "AppKey".
+                                    properties:
+                                      keyName:
+                                        description: KeyName is the key of the secret
+                                          to use.
+                                        type: string
+                                      secretName:
+                                        description: SecretName is the name of the
+                                          secret.
+                                        type: string
+                                    required:
+                                    - secretName
+                                    type: object
+                                type: object
+                              url:
+                                description: URL defines the endpoint URL.
+                                type: string
+                            type: object
+                          port:
+                            description: |-
+                              Port specifies the metricsProvider External Metrics Server service port.
+                              Default: 8443
+                            format: int32
+                            type: integer
+                          registerAPIService:
+                            description: |-
+                              RegisterAPIService registers the External Metrics endpoint as an APIService
+                              Default: true
+                            type: boolean
+                          useDatadogMetrics:
+                            description: |-
+                              UseDatadogMetrics enables usage of the DatadogMetrics CRD (allowing one to scale on arbitrary Datadog metric queries).
+                              Default: true
+                            type: boolean
+                          wpaController:
+                            description: |-
+                              WPAController enables the informer and controller of the Watermark Pod Autoscaler.
+                              NOTE: The Watermark Pod Autoscaler controller needs to be installed.
+                              See also: https://github.com/DataDog/watermarkpodautoscaler.
+                              Default: false
+                            type: boolean
+                        type: object
+                      gpu:
+                        description: GPU monitoring
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables GPU monitoring core check.
+                              Default: false
+                            type: boolean
+                          patchCgroupPermissions:
+                            description: |-
+                              PatchCgroupPermissions enables the patch of cgroup permissions for GPU monitoring, in case
+                              the container runtime is not properly configured and the Agent containers lose access to GPU devices.
+                              Default: false
+                            type: boolean
+                          privilegedMode:
+                            description: |-
+                              PrivilegedMode enables GPU Probe module in System Probe.
+                              Default: false
+                            type: boolean
+                          requiredRuntimeClassName:
+                            description: |-
+                              PodRuntimeClassName specifies the runtime class name required for the GPU monitoring feature.
+                              If the value is an empty string, the runtime class is not set.
+                              Default: nvidia
+                            type: string
+                        type: object
+                      helmCheck:
+                        description: HelmCheck configuration.
+                        properties:
+                          collectEvents:
+                            description: |-
+                              CollectEvents set to `true` enables event collection in the Helm check
+                              (Requires Agent 7.36.0+ and Cluster Agent 1.20.0+)
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables the Helm check.
+                              Default: false
+                            type: boolean
+                          valuesAsTags:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ValuesAsTags collects Helm values from a release and uses them as tags
+                              (Requires Agent and Cluster Agent 7.40.0+).
+                              Default: {}
+                            type: object
+                        type: object
+                      kubeStateMetricsCore:
+                        description: KubeStateMetricsCore check configuration.
+                        properties:
+                          collectCrMetrics:
+                            description: |-
+                              `CollectCrMetrics` defines custom resources for the kube-state-metrics core check to collect.
+
+                              The datadog agent uses the same logic as upstream `kube-state-metrics`. So is its configuration.
+                              The exact structure and existing fields of each item in this list can be found in:
+                              https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+                            items:
+                              description: Resource configures a custom resource for
+                                metric generation.
+                              properties:
+                                commonLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: CommonLabels are added to all metrics.
+                                  type: object
+                                groupVersionKind:
+                                  description: GroupVersionKind of the custom resource
+                                    to be monitored.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  type: object
+                                labelsFromPath:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: LabelsFromPath adds additional labels
+                                    where the value is taken from a field in the resource.
+                                  type: object
+                                metricNamePrefix:
+                                  description: |-
+                                    MetricNamePrefix defines a prefix for all metrics of the resource.
+                                    If set to "", no prefix will be added.
+                                    Example: If set to "foo", MetricNamePrefix will be "foo_<metric>".
+                                  type: string
+                                metrics:
+                                  description: Metrics are the custom resource fields
+                                    to be collected.
+                                  items:
+                                    description: Generator describes a unique metric
+                                      name.
+                                    properties:
+                                      commonLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: CommonLabels are added to all
+                                          metrics.
+                                        type: object
+                                      each:
+                                        description: Each targets a value or values
+                                          from the resource.
+                                        properties:
+                                          gauge:
+                                            description: Gauge defines a gauge metric.
+                                            properties:
+                                              labelFromKey:
+                                                description: LabelFromKey adds a label
+                                                  with the given name if Path is an
+                                                  object. The label value will be
+                                                  the object key.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              nilIsZero:
+                                                description: NilIsZero indicates that
+                                                  if a value is nil it will be treated
+                                                  as zero value.
+                                                type: boolean
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              valueFrom:
+                                                description: ValueFrom is the path
+                                                  to a numeric field under Path that
+                                                  will be the metric value.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          info:
+                                            description: Info defines an info metric.
+                                            properties:
+                                              labelFromKey:
+                                                description: LabelFromKey adds a label
+                                                  with the given name if Path is an
+                                                  object. The label value will be
+                                                  the object key.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          stateSet:
+                                            description: StateSet defines a state
+                                              set metric.
+                                            properties:
+                                              labelName:
+                                                description: LabelName is the key
+                                                  of the label which is used for each
+                                                  entry in List to expose the value.
+                                                type: string
+                                              labelsFromPath:
+                                                additionalProperties:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                description: LabelsFromPath adds additional
+                                                  labels where the value of the label
+                                                  is taken from a field under Path.
+                                                type: object
+                                              list:
+                                                description: List is the list of values
+                                                  to expose a value for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              path:
+                                                description: Path is the path to to
+                                                  generate metric(s) for.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              valueFrom:
+                                                description: ValueFrom is the subpath
+                                                  to compare the list to.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - path
+                                            type: object
+                                          type:
+                                            description: Type defines the type of
+                                              the metric.
+                                            type: string
+                                        type: object
+                                      help:
+                                        description: Help text for the metric.
+                                        type: string
+                                      labelsFromPath:
+                                        additionalProperties:
+                                          items:
+                                            type: string
+                                          type: array
+                                        description: LabelsFromPath adds additional
+                                          labels where the value is taken from a field
+                                          in the resource.
+                                        type: object
+                                      name:
+                                        description: Name of the metric. Subject to
+                                          prefixing based on the configuration of
+                                          the Resource.
+                                        type: string
+                                    type: object
+                                  type: array
+                                resourcePlural:
+                                  description: ResourcePlural sets the plural name
+                                    of the resource. Defaults to the plural version
+                                    of the Kind according to flect.Pluralize.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables Kube State Metrics Core.
+                              Default: true
+                            type: boolean
+                        type: object
+                      kubernetesActions:
+                        description: KubernetesActions configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Kubernetes Actions feature on the Cluster Agent.
+                              Default: false
+                            type: boolean
+                        type: object
+                      liveContainerCollection:
+                        description: LiveContainerCollection configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables container collection for the Live Container View.
+                              Default: true
+                            type: boolean
+                        type: object
+                      liveProcessCollection:
+                        description: LiveProcessCollection configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Process monitoring.
+                              Default: false
+                            type: boolean
+                          scrubProcessArguments:
+                            description: |-
+                              ScrubProcessArguments enables scrubbing of sensitive data in process command-lines (passwords, tokens, etc. ).
+                              Default: true
+                            type: boolean
+                          stripProcessArguments:
+                            description: |-
+                              StripProcessArguments enables stripping of all process arguments.
+                              Default: false
+                            type: boolean
+                        type: object
+                      logCollection:
+                        description: LogCollection configuration.
+                        properties:
+                          autoMultiLineDetection:
+                            description: |-
+                              AutoMultiLineDetection allows the Agent to detect and aggregate common multi-line logs automatically.
+                              See also: https://docs.datadoghq.com/agent/logs/auto_multiline_detection/
+                            type: boolean
+                          containerCollectAll:
+                            description: |-
+                              ContainerCollectAll enables Log collection from all containers.
+                              Default: false
+                            type: boolean
+                          containerCollectUsingFiles:
+                            description: |-
+                              ContainerCollectUsingFiles enables log collection from files in `/var/log/pods instead` of using the container runtime API.
+                              Collecting logs from files is usually the most efficient way of collecting logs.
+                              See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                              Default: true
+                            type: boolean
+                          containerLogsPath:
+                            description: |-
+                              ContainerLogsPath allows log collection from the container log path.
+                              Set to a different path if you are not using the Docker runtime.
+                              See also: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#create-manifest
+                              Default: `/var/lib/docker/containers`
+                            type: string
+                          containerSymlinksPath:
+                            description: |-
+                              ContainerSymlinksPath allows log collection to use symbolic links in this directory to validate container ID -> pod.
+                              Default: `/var/log/containers`
+                            type: string
+                          enabled:
+                            description: |-
+                              Enabled enables Log collection.
+                              Default: false
+                            type: boolean
+                          openFilesLimit:
+                            description: |-
+                              OpenFilesLimit sets the maximum number of log files that the Datadog Agent tails.
+                              Increasing this limit can increase resource consumption of the Agent.
+                              See also: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#log-collection-setup
+                              Default: 100
+                            format: int32
+                            type: integer
+                          podLogsPath:
+                            description: |-
+                              PodLogsPath allows log collection from a pod log path.
+                              Default: `/var/log/pods`
+                            type: string
+                          tempStoragePath:
+                            description: |-
+                              TempStoragePath (always mounted from the host) is used by the Agent to store information about processed log files.
+                              If the Agent is restarted, it starts tailing the log files immediately.
+                              Default: `/var/lib/datadog-agent/logs`
+                            type: string
+                        type: object
+                      npm:
+                        description: NPM (Network Performance Monitoring) configuration.
+                        properties:
+                          collectDNSStats:
+                            description: |-
+                              CollectDNSStats enables DNS stat collection.
+                              Default: false
+                            type: boolean
+                          enableConntrack:
+                            description: |-
+                              EnableConntrack enables the system-probe agent to connect to the netlink/conntrack subsystem to add NAT information to connection data.
+                              See also: http://conntrack-tools.netfilter.org/
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enabled enables Network Performance Monitoring.
+                              Default: false
+                            type: boolean
+                        type: object
+                      oomKill:
+                        description: OOMKill configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the OOMKill eBPF-based check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      orchestratorExplorer:
+                        description: OrchestratorExplorer check configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Orchestrator Explorer check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          customResources:
+                            description: |-
+                              `CustomResources` defines custom resources for the orchestrator explorer to collect.
+                              Each item should follow the convention `group/version/kind`. For example, `datadoghq.com/v1alpha1/datadogmetrics`.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          ddUrl:
+                            description: |-
+                              Override the API endpoint for the Orchestrator Explorer.
+                              URL Default: "https://orchestrator.datadoghq.com".
+                            type: string
+                          enabled:
+                            description: |-
+                              Enabled enables the Orchestrator Explorer.
+                              Default: true
+                            type: boolean
+                          extraTags:
+                            description: |-
+                              Additional tags to associate with the collected data in the form of `a b c`.
+                              This is a Cluster Agent option distinct from DD_TAGS that is used in the Orchestrator Explorer.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          scrubContainers:
+                            description: |-
+                              ScrubContainers enables scrubbing of sensitive container data (passwords, tokens, etc. ).
+                              Default: true
+                            type: boolean
+                        type: object
+                      otelAgentGateway:
+                        description: OtelAgentGateway configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default OTel Agent Gateway.
+                              This must point to a ConfigMap containing a valid OTel collector configuration.
+                              When passing a configmap, file name *must* be otel-gateway-config.yaml.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the OTel Agent Gateway.
+                              Default: false
+                            type: boolean
+                          featureGates:
+                            description: |-
+                              FeatureGates are the feature gates to pass to the OTel collector as a comma-separated list.
+                              Example: "component.UseLocalHostAsDefaultHost,connector.datadogconnector.NativeIngest"
+                            type: string
+                          ports:
+                            description: |-
+                              Ports contains the ports that the OTel Collector is listening on.
+                              Defaults: otel-grpc:4317 / otel-http:4318.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      otelCollector:
+                        description: OtelCollector configuration.
+                        properties:
+                          conf:
+                            description: |-
+                              Conf overrides the configuration for the default Kubernetes State Metrics Core check.
+                              This must point to a ConfigMap containing a valid cluster check configuration.
+                              When passing a configmap, file name *must* be otel-config.yaml.
+                            properties:
+                              configData:
+                                description: ConfigData corresponds to the configuration
+                                  file content.
+                                type: string
+                              configMap:
+                                description: ConfigMap references an existing ConfigMap
+                                  with the configuration file content.
+                                properties:
+                                  items:
+                                    description: Items maps a ConfigMap data `key`
+                                      to a file `path` mount.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - key
+                                    x-kubernetes-list-type: map
+                                  name:
+                                    description: Name is the name of the ConfigMap.
+                                    type: string
+                                type: object
+                            type: object
+                          coreConfig:
+                            description: OTelCollector Config Relevant to the Core
+                              agent
+                            properties:
+                              enabled:
+                                description: Enabled marks otelcollector as enabled
+                                  in core agent.
+                                type: boolean
+                              extensionTimeout:
+                                description: |-
+                                  Extension URL provides the timout of the ddflareextension to
+                                  the core agent.
+                                type: integer
+                              extensionURL:
+                                description: |-
+                                  Extension URL provides the URL of the ddflareextension to
+                                  the core agent.
+                                type: string
+                            type: object
+                          enabled:
+                            description: |-
+                              Enabled enables the OTel Agent.
+                              Default: false
+                            type: boolean
+                          ports:
+                            description: |-
+                              Ports contains the ports for the otel-agent.
+                              Defaults: otel-grpc:4317 / otel-http:4318. Note: setting 4317
+                              or 4318 manually is *only* supported if name match default names (otel-grpc, otel-http).
+                              If not, this will lead to a port conflict.
+                              This limitation will be lifted once annotations support is removed.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: |-
+                                    Number of port to expose on the pod's IP address.
+                                    This must be a valid port number, 0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: |-
+                                    Number of port to expose on the host.
+                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                    If HostNetwork is specified, this must match ContainerPort.
+                                    Most containers do not need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: |-
+                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                    named port in a pod must have a unique name. Name for the port that can be
+                                    referred to by services.
+                                  type: string
+                                protocol:
+                                  default: TCP
+                                  description: |-
+                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                    Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      otlp:
+                        description: OTLP ingest configuration
+                        properties:
+                          receiver:
+                            description: Receiver contains configuration for the OTLP
+                              ingest receiver.
+                            properties:
+                              protocols:
+                                description: Protocols contains configuration for
+                                  the OTLP ingest receiver protocols.
+                                properties:
+                                  grpc:
+                                    description: GRPC contains configuration for the
+                                      OTLP ingest OTLP/gRPC receiver.
+                                    properties:
+                                      enabled:
+                                        description: Enable the OTLP/gRPC endpoint.
+                                          Host port is enabled by default and can
+                                          be disabled.
+                                        type: boolean
+                                      endpoint:
+                                        description: |-
+                                          Endpoint for OTLP/gRPC.
+                                          gRPC supports several naming schemes: https://github.com/grpc/grpc/blob/master/doc/naming.md
+                                          The Datadog Operator supports only 'host:port' (usually `0.0.0.0:port`).
+                                          Default: `0.0.0.0:4317`.
+                                        type: string
+                                      hostPortConfig:
+                                        description: |-
+                                          Enable hostPort for OTLP/gRPC
+                                          Default: true
+                                        properties:
+                                          enabled:
+                                            description: Enabled enables host port
+                                              configuration
+                                            type: boolean
+                                          hostPort:
+                                            description: |-
+                                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                              If HostNetwork is enabled, this value must match the ContainerPort.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                  http:
+                                    description: HTTP contains configuration for the
+                                      OTLP ingest OTLP/HTTP receiver.
+                                    properties:
+                                      enabled:
+                                        description: Enable the OTLP/HTTP endpoint.
+                                          Host port is enabled by default and can
+                                          be disabled.
+                                        type: boolean
+                                      endpoint:
+                                        description: |-
+                                          Endpoint for OTLP/HTTP.
+                                          Default: '0.0.0.0:4318'.
+                                        type: string
+                                      hostPortConfig:
+                                        description: |-
+                                          Enable hostPorts for OTLP/HTTP
+                                          Default: true
+                                        properties:
+                                          enabled:
+                                            description: Enabled enables host port
+                                              configuration
+                                            type: boolean
+                                          hostPort:
+                                            description: |-
+                                              Port takes a port number (0 < x < 65536) to expose on the host. (Most containers do not need this.)
+                                              If HostNetwork is enabled, this value must match the ContainerPort.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      processDiscovery:
+                        description: ProcessDiscovery configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables the Process Discovery check in the Agent.
+                              Default: true
+                            type: boolean
+                        type: object
+                      prometheusScrape:
+                        description: PrometheusScrape configuration.
+                        properties:
+                          additionalConfigs:
+                            description: AdditionalConfigs allows adding advanced
+                              Prometheus check configurations with custom discovery
+                              rules.
+                            type: string
+                          enableServiceEndpoints:
+                            description: |-
+                              EnableServiceEndpoints enables generating dedicated checks for service endpoints.
+                              Default: false
+                            type: boolean
+                          enabled:
+                            description: |-
+                              Enable autodiscovery of pods and services exposing Prometheus metrics.
+                              Default: false
+                            type: boolean
+                          version:
+                            description: |-
+                              Version specifies the version of the OpenMetrics check.
+                              Default: 2
+                            type: integer
+                        type: object
+                      remoteConfiguration:
+                        description: Remote Configuration configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enable this option to activate Remote Configuration.
+                              Default: true
+                            type: boolean
+                        type: object
+                      sbom:
+                        description: SBOM collection configuration.
+                        properties:
+                          containerImage:
+                            description: SBOMTypeConfig contains configuration for
+                              a SBOM collection type.
+                            properties:
+                              analyzers:
+                                description: Analyzers to use for SBOM collection.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM collection.
+                                  Default: false
+                                type: boolean
+                              overlayFSDirectScan:
+                                description: |-
+                                  Enable this option to enable experimental overlayFS direct scan.
+                                  Default: false
+                                type: boolean
+                              uncompressedLayersSupport:
+                                description: |-
+                                  Enable this option to enable support for uncompressed layers.
+                                  Default: false
+                                type: boolean
+                            type: object
+                          enabled:
+                            description: |-
+                              Enable this option to activate SBOM collection.
+                              Default: false
+                            type: boolean
+                          enrichment:
+                            description: SBOMEnrichmentConfig contains SBOM enrichment
+                              configuration.
+                            properties:
+                              usage:
+                                description: Usage contains configuration for the
+                                  "package in use" enrichment.
+                                properties:
+                                  enabled:
+                                    description: |-
+                                      Enable this option to activate SBOM enrichment with runtime "package in use" detection.
+                                      Requires system-probe for eBPF-based file access tracking.
+                                      Default: false
+                                    type: boolean
+                                type: object
+                            type: object
+                          host:
+                            description: SBOMTypeConfig contains configuration for
+                              a SBOM collection type.
+                            properties:
+                              analyzers:
+                                description: Analyzers to use for SBOM collection.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              enabled:
+                                description: |-
+                                  Enable this option to activate SBOM collection.
+                                  Default: false
+                                type: boolean
+                            type: object
+                        type: object
+                      serviceDiscovery:
+                        description: ServiceDiscovery
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the service discovery check.
+                              Default: true when omitted and the node Agent image is >= 7.78.0. Otherwise false.
+                              If the image version cannot be determined, it is treated as latest.
+                            type: boolean
+                        type: object
+                      tcpQueueLength:
+                        description: TCPQueueLength configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enables the TCP queue length eBPF-based check.
+                              Default: false
+                            type: boolean
+                        type: object
+                      usm:
+                        description: USM (Universal Service Monitoring) configuration.
+                        properties:
+                          enabled:
+                            description: |-
+                              Enabled enables Universal Service Monitoring.
+                              Default: false
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogcsidrivers.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogcsidrivers.yaml
@@ -1,0 +1,4744 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogcsidrivers.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogCSIDriver
+    listKind: DatadogCSIDriverList
+    plural: datadogcsidrivers
+    shortNames:
+    - ddcsi
+    singular: datadogcsidriver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.daemonSet.status
+      name: status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogCSIDriver is the Schema for the datadogcsidrivers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogCSIDriverSpec defines the desired state of DatadogCSIDriver
+            properties:
+              apm:
+                description: APM configures APM/Single Step Instrumentation support
+                  for the CSI driver.
+                properties:
+                  enabled:
+                    description: |-
+                      Enabled enables APM/Single Step Instrumentation support for the CSI driver.
+                      Default: true
+                    type: boolean
+                type: object
+              apmSocketPath:
+                description: |-
+                  APMSocketPath is the host path to the APM socket.
+                  Default: /var/run/datadog/apm.socket
+                type: string
+              commonLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CommonLabels are propagated from spec.global.commonLabels on the parent
+                  DatadogAgent and are applied to all resources managed by the CSI
+                  controller (DaemonSet ObjectMeta, pod template, and cluster-scoped
+                  CSIDriver object). This field is managed by the operator; do not set it
+                  manually.
+                type: object
+                x-kubernetes-map-type: granular
+              csiDriverImage:
+                description: CSIDriverImage is the image configuration for the main
+                  CSI node driver container.
+                properties:
+                  jmxEnabled:
+                    description: |-
+                      Define whether the Agent image should support JMX.
+                      To be used if the `Name` field does not correspond to a full image string.
+                    type: boolean
+                  name:
+                    description: |-
+                      Defines the Agent image name for the pod. You can provide this as:
+                      * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                      for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                      * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                      and `[key].image.jmxEnabled` are ignored.
+                      * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                        like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                    type: string
+                  pullPolicy:
+                    description: |-
+                      The Kubernetes pull policy:
+                      Use `Always`, `Never`, or `IfNotPresent`.
+                    type: string
+                  pullSecrets:
+                    description: |-
+                      It is possible to specify Docker registry credentials.
+                      See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  tag:
+                    description: |-
+                      Define the image tag to use.
+                      To be used if the `Name` field does not correspond to a full image string.
+                    type: string
+                type: object
+              dsdSocketPath:
+                description: |-
+                  DSDSocketPath is the host path to the DogStatsD socket.
+                  Default: /var/run/datadog/dsd.socket
+                type: string
+              override:
+                description: Override allows customization of the CSI driver DaemonSet
+                  pod template.
+                properties:
+                  affinity:
+                    description: Affinity specifies the pod's scheduling constraints.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations provides annotations that are added to
+                      the CSI driver DaemonSet pods.
+                    type: object
+                  containers:
+                    additionalProperties:
+                      description: DatadogAgentGenericContainer is the generic structure
+                        describing any container's common configuration.
+                      properties:
+                        appArmorProfileName:
+                          description: AppArmorProfileName specifies an apparmor profile.
+                          type: string
+                        args:
+                          description: Args allows the specification of extra args
+                            to the `Command` parameter
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          description: Command allows the specification of a custom
+                            entrypoint for container
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        env:
+                          description: |-
+                            Specify additional environment variables in the container.
+                            See also: https://docs.datadoghq.com/agent/kubernetes/?tab=helm#environment-variables
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount
+                                          containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        healthPort:
+                          description: |-
+                            HealthPort of the container for the internal liveness probe.
+                            Must be the same as the Liveness/Readiness probes.
+                          format: int32
+                          type: integer
+                        livenessProbe:
+                          description: Configure the Liveness Probe of the container
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in
+                                the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        logLevel:
+                          description: |-
+                            LogLevel sets logging verbosity (overrides global setting).
+                            Valid log levels are: trace, debug, info, warn, error, critical, and off.
+                            Default: 'info'
+                          type: string
+                        name:
+                          description: Name of the container that is overridden
+                          type: string
+                        ports:
+                          description: |-
+                            Specify additional ports to be exposed by the container. Not specifying a port here
+                            DOES NOT prevent that port from being exposed.
+                            See https://pkg.go.dev/k8s.io/api/core/v1#Container documentation for more details.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: |-
+                                  Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: |-
+                                  Number of port to expose on the host.
+                                  If specified, this must be a valid port number, 0 < x < 65536.
+                                  If HostNetwork is specified, this must match ContainerPort.
+                                  Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: |-
+                                  If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                  named port in a pod must have a unique name. Name for the port that can be
+                                  referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP.
+                                  Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        readinessProbe:
+                          description: Configure the Readiness Probe of the container
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in
+                                the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: |-
+                            Specify the Request and Limits of the pods
+                            To get guaranteed QoS class, specify requests and limits equal.
+                            See also: http://kubernetes.io/docs/user-guide/compute-resources/
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This field depends on the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        seccompConfig:
+                          description: |-
+                            Seccomp configurations to override Operator actions. For all other Seccomp Profile manipulation,
+                            use SecurityContext.
+                          properties:
+                            customProfile:
+                              description: |-
+                                CustomProfile specifies a ConfigMap containing a custom Seccomp Profile.
+                                ConfigMap data must either have the key `system-probe-seccomp.json` or CustomProfile.Items
+                                must include a corev1.KeytoPath that maps the key to the path `system-probe-seccomp.json`.
+                              properties:
+                                configData:
+                                  description: ConfigData corresponds to the configuration
+                                    file content.
+                                  type: string
+                                configMap:
+                                  description: ConfigMap references an existing ConfigMap
+                                    with the configuration file content.
+                                  properties:
+                                    items:
+                                      description: Items maps a ConfigMap data `key`
+                                        to a file `path` mount.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - key
+                                      x-kubernetes-list-type: map
+                                    name:
+                                      description: Name is the name of the ConfigMap.
+                                      type: string
+                                  type: object
+                              type: object
+                            customRootPath:
+                              description: CustomRootPath specifies a custom Seccomp
+                                Profile root location.
+                              type: string
+                          type: object
+                        securityContext:
+                          description: Container-level SecurityContext.
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: |-
+                                AllowPrivilegeEscalation controls whether a process can gain more
+                                privileges than its parent process. This bool directly controls if
+                                the no_new_privs flag will be set on the container process.
+                                AllowPrivilegeEscalation is true always when the container is:
+                                1) run as Privileged
+                                2) has CAP_SYS_ADMIN
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                overrides the pod's appArmorProfile.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            capabilities:
+                              description: |-
+                                The capabilities to add/drop when running containers.
+                                Defaults to the default set of capabilities granted by the container runtime.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            privileged:
+                              description: |-
+                                Run container in privileged mode.
+                                Processes in privileged containers are essentially equivalent to root on the host.
+                                Defaults to false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: |-
+                                procMount denotes the type of proc mount to use for the containers.
+                                The default value is Default which uses the container runtime defaults for
+                                readonly paths and masked paths.
+                                This requires the ProcMountType feature flag to be enabled.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: |-
+                                Whether this container has a read-only root filesystem.
+                                Default is false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: |-
+                                The GID to run the entrypoint of the container process.
+                                Uses runtime default if unset.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: |-
+                                Indicates that the container must run as a non-root user.
+                                If true, the Kubelet will validate the image at runtime to ensure that it
+                                does not run as UID 0 (root) and fail to start the container if it does.
+                                If unset or false, no such validation will be performed.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: |-
+                                The UID to run the entrypoint of the container process.
+                                Defaults to user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: |-
+                                The SELinux context to be applied to the container.
+                                If unspecified, the container runtime will allocate a random SELinux context for each
+                                container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: |-
+                                The seccomp options to use by this container. If seccomp options are
+                                provided at both the pod & container level, the container options
+                                override the pod options.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied.
+                                    Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used.
+                                    RuntimeDefault - the container runtime default profile should be used.
+                                    Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: |-
+                                The Windows specific settings applied to all containers.
+                                If unspecified, the options from the PodSecurityContext will be used.
+                                If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: |-
+                                    GMSACredentialSpec is where the GMSA admission webhook
+                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: |-
+                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                    All of a Pod's containers must have the same effective HostProcess value
+                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: |-
+                                    The UserName in Windows to run the entrypoint of the container process.
+                                    Defaults to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: Configure the Startup Probe of the container
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in
+                                the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP
+                                port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Specify additional volume mounts in the container.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: |-
+                                  mountPropagation determines how mounts are propagated from the host
+                                  to container and the other way around.
+                                  When not set, MountPropagationNone is used.
+                                  This field is beta in 1.10.
+                                  When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                  (which defaults to None).
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  Mounted read-only if true, read-write otherwise (false or unspecified).
+                                  Defaults to false.
+                                type: boolean
+                              recursiveReadOnly:
+                                description: |-
+                                  RecursiveReadOnly specifies whether read-only mounts should be handled
+                                  recursively.
+
+                                  If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                  If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                  recursively read-only.  If this field is set to IfPossible, the mount is made
+                                  recursively read-only, if it is supported by the container runtime.  If this
+                                  field is set to Enabled, the mount is made recursively read-only if it is
+                                  supported by the container runtime, otherwise the pod will not be started and
+                                  an error will be generated to indicate the reason.
+
+                                  If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                  None (or be unspecified, which defaults to None).
+
+                                  If this field is not specified, it is treated as an equivalent of Disabled.
+                                type: string
+                              subPath:
+                                description: |-
+                                  Path within the volume from which the container's volume should be mounted.
+                                  Defaults to "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: |-
+                                  Expanded path within the volume from which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root).
+                                  SubPathExpr and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          - mountPath
+                          x-kubernetes-list-type: map
+                      type: object
+                    description: |-
+                      Containers allows overriding container-level configuration for the CSI driver containers.
+                      Valid keys are: "csi-node-driver" and "csi-node-driver-registrar".
+                    type: object
+                  env:
+                    description: Env specifies additional environment variables for
+                      all containers.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: AdditionalLabels provides labels that are added to
+                      the CSI driver DaemonSet pods.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is a map of key-value pairs. For the CSI driver pod to run on a
+                      specific node, the node must have these key-value pairs as labels.
+                    type: object
+                  priorityClassName:
+                    description: PriorityClassName indicates the pod's priority.
+                    type: string
+                  securityContext:
+                    description: SecurityContext holds pod-level security attributes.
+                    properties:
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      fsGroup:
+                        description: |-
+                          A special supplemental group that applies to all containers in a pod.
+                          Some volume types allow the Kubelet to change the ownership of that volume
+                          to be owned by the pod:
+
+                          1. The owning GID will be the FSGroup
+                          2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw----
+
+                          If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod. This field will only apply to
+                          volume types which support fsGroup based ownership(and permissions).
+                          It will have no effect on ephemeral volume types such as: secret, configmaps
+                          and emptydir.
+                          Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence
+                          for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxChangePolicy:
+                        description: |-
+                          seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                          It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                          Valid values are "MountOption" and "Recursive".
+
+                          "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                          This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                          "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                          This requires all Pods that share the same volume to use the same SELinux label.
+                          It is not possible to share the same volume among privileged and unprivileged Pods.
+                          Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                          whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                          CSIDriver instance. Other volumes are always re-labelled recursively.
+                          "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                          If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                          If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                          and "Recursive" for all other volumes.
+
+                          This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                          All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in SecurityContext.  If set in
+                          both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and fsGroup (if specified).  If
+                          the SupplementalGroupsPolicy feature is enabled, the
+                          supplementalGroupsPolicy field determines whether these are in addition
+                          to or instead of any group memberships defined in the container image.
+                          If unspecified, no additional groups are added, though group memberships
+                          defined in the container image may still be used, depending on the
+                          supplementalGroupsPolicy field.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                          (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                          and the container runtime must implement support for this feature.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      sysctls:
+                        description: |-
+                          Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                          sysctls (by the container runtime) might fail to launch.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: ServiceAccountName sets the ServiceAccount used by
+                      the CSI driver DaemonSet.
+                    type: string
+                  tolerations:
+                    description: Tolerations configure the CSI driver DaemonSet pod
+                      tolerations.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  updateStrategy:
+                    description: UpdateStrategy is the DaemonSet update strategy configuration.
+                    properties:
+                      rollingUpdate:
+                        description: Configure the rolling update strategy of the
+                          Deployment or DaemonSet.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              MaxSurge behaves differently based on the Kubernetes resource. Refer to the
+                              Kubernetes API documentation for additional details.
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be unavailable during the update.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              Refer to the Kubernetes API documentation for additional details..
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: |-
+                          Type can be "RollingUpdate" or "OnDelete" for DaemonSets and "RollingUpdate"
+                          or "Recreate" for Deployments
+                        type: string
+                    type: object
+                  volumes:
+                    description: Volumes specifies additional volumes to add to the
+                      CSI driver DaemonSet pods.
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: |-
+                            awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                            awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly value true will force the readOnly setting in VolumeMounts.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: boolean
+                            volumeID:
+                              description: |-
+                                volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: |-
+                            azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                            are redirected to the disk.csi.azure.com CSI driver.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              default: ext4
+                              description: |-
+                                fsType is Filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              default: false
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: |-
+                            azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                            are redirected to the file.csi.azure.com CSI driver.
+                          properties:
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: |-
+                            cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                            Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                          properties:
+                            monitors:
+                              description: |-
+                                monitors is Required: Monitors is a collection of Ceph monitors
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: boolean
+                            secretFile:
+                              description: |-
+                                secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              description: |-
+                                user is optional: User is the rados user name, default is admin
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: |-
+                            cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                            are redirected to the cinder.csi.openstack.org CSI driver.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is optional: points to a secret object containing parameters used to connect
+                                to OpenStack.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeID:
+                              description: |-
+                                volumeID used to identify the volume in cinder.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers.
+                          properties:
+                            driver:
+                              description: |-
+                                driver is the name of the CSI driver that handles this volume.
+                                Consult with your admin for the correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the associated CSI driver
+                                which will determine the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: |-
+                                nodePublishSecretRef is a reference to the secret object containing
+                                sensitive information to pass to the CSI driver to complete the CSI
+                                NodePublishVolume and NodeUnpublishVolume calls.
+                                This field is optional, and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret references are passed.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly specifies a read-only configuration for the volume.
+                                Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                volumeAttributes stores driver-specific properties that are passed to the CSI
+                                driver. Consult your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                Optional: mode bits to use on created files by default. Must be a
+                                Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name, namespace
+                                      and uid are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        emptyDir:
+                          description: |-
+                            emptyDir represents a temporary directory that shares a pod's lifetime.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          properties:
+                            medium:
+                              description: |-
+                                medium represents what type of storage medium should back this directory.
+                                The default is "" which means to use the node's default medium.
+                                Must be an empty string (default) or Memory.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                The size limit is also applicable for memory medium.
+                                The maximum usage on memory medium EmptyDir would be the minimum value between
+                                the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                The default is nil which means that the limit is undefined.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver.
+                            The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                            and deleted when the pod is removed.
+
+                            Use this if:
+                            a) the volume is only needed while the pod runs,
+                            b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and
+                            d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific
+                            APIs for volumes that persist for longer than the lifecycle
+                            of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                            be used that way - see the documentation of the driver for
+                            more information.
+
+                            A pod can use both types of ephemeral volumes and
+                            persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume.
+                                The pod in which this EphemeralVolumeSource is embedded will be the
+                                owner of the PVC, i.e. the PVC will be deleted together with the
+                                pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                `<volume name>` is the name from the `PodSpec.Volumes` array
+                                entry. Pod validation will reject the pod if the concatenated name
+                                is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod
+                                will *not* be used for the pod to avoid using an unrelated
+                                volume by mistake. Starting the pod is then blocked until
+                                the unrelated PVC is removed. If such a pre-created PVC is
+                                meant to be used by the pod, the PVC has to updated with an
+                                owner reference to the pod once the pod exists. Normally
+                                this should not be necessary, but it may be useful when
+                                manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes
+                                to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    May contain labels and annotations that will be copied into the PVC
+                                    when creating it. No other fields are allowed and will be rejected during
+                                    validation.
+                                  type: object
+                                spec:
+                                  description: |-
+                                    The specification for the PersistentVolumeClaim. The entire content is
+                                    copied unchanged into the PVC that gets created from this
+                                    template. The same fields as in a PersistentVolumeClaim
+                                    are also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: |-
+                                        accessModes contains the desired access modes the volume should have.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    dataSource:
+                                      description: |-
+                                        dataSource field can be used to specify either:
+                                        * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller can support the specified data source,
+                                        it will create a new volume based on the contents of the specified data source.
+                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                        volume is desired. This may be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding will only succeed if the type of
+                                        the specified object matches some installed volume populator or dynamic
+                                        provisioner.
+                                        This field will replace the functionality of the dataSource field and as such
+                                        if both fields are non-empty, they must have the same value. For backwards
+                                        compatibility, when namespace isn't specified in dataSourceRef,
+                                        both fields (dataSource and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty and the other is non-empty.
+                                        When namespace is specified in dataSourceRef,
+                                        dataSource isn't set to the same value and must be empty.
+                                        There are three important differences between dataSource and dataSourceRef:
+                                        * While dataSource only allows two specific types of objects, dataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        * While dataSource only allows local objects, dataSourceRef allows objects
+                                          in any namespaces.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of resource being referenced
+                                            Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                            (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: |-
+                                        resources represents the minimum resources the volume should have.
+                                        Users are allowed to specify resource requirements
+                                        that are lower than previous value but must still be higher than capacity recorded in the
+                                        status field of the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
+                                      description: |-
+                                        storageClassName is the name of the StorageClass required by the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: |-
+                                        volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                        If specified, the CSI driver will create or update the volume with the attributes defined
+                                        in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created. An empty string or nil value indicates that no
+                                        VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                        this field can be reset to its previous value (including nil) to cancel the modification.
+                                        If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                        set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                        exists.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                      type: string
+                                    volumeMode:
+                                      description: |-
+                                        volumeMode defines what type of volume is required by the claim.
+                                        Value of Filesystem is implied when not included in claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            wwids:
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        flexVolume:
+                          description: |-
+                            flexVolume represents a generic volume resource that is
+                            provisioned/attached using an exec based plugin.
+                            Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: secretRef is reference to the secret object containing
+                                sensitive information to pass to the plugin scripts. This may be
+                                empty if no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed to the plugin
+                                scripts.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: |-
+                            flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                            Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                          properties:
+                            datasetName:
+                              description: |-
+                                datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                should be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: |-
+                            gcePersistentDisk represents a GCE Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                            gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: |-
+                                pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: |-
+                            gitRepo represents a git repository at a particular revision.
+                            Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                            EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                            into the Pod's container.
+                          properties:
+                            directory:
+                              description: |-
+                                directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: |-
+                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                            Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                          properties:
+                            endpoints:
+                              description: endpoints is the endpoint name that details
+                                Glusterfs topology.
+                              type: string
+                            path:
+                              description: |-
+                                path is the Glusterfs volume path.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: |-
+                            hostPath represents a pre-existing file or directory on the host
+                            machine that is directly exposed to the container. This is generally
+                            used for system agents or other privileged things that are allowed
+                            to see the host machine. Most containers will NOT need this.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          properties:
+                            path:
+                              description: |-
+                                path of the directory on the host.
+                                If the path is a symlink, it will follow the link to the real path.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                            type:
+                              description: |-
+                                type for HostPath Volume
+                                Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        image:
+                          description: |-
+                            image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                            The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                            - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                            The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                            A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                            The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                            The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                            The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                                Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                          type: object
+                        iscsi:
+                          description: |-
+                            iscsi represents an ISCSI Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              type: string
+                            initiatorName:
+                              description: |-
+                                initiatorName is the custom iSCSI Initiator Name.
+                                If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                <target portal>:<volume name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              default: default
+                              description: |-
+                                iscsiInterface is the interface Name that uses an iSCSI transport.
+                                Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: |-
+                                portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            targetPortal:
+                              description: |-
+                                targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          description: |-
+                            name of the volume.
+                            Must be a DNS_LABEL and unique within the pod.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        nfs:
+                          description: |-
+                            nfs represents an NFS mount on the host that shares a pod's lifetime
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          properties:
+                            path:
+                              description: |-
+                                path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the NFS export to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: boolean
+                            server:
+                              description: |-
+                                server is the hostname or IP address of the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          description: |-
+                            persistentVolumeClaimVolumeSource represents a reference to a
+                            PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          properties:
+                            claimName:
+                              description: |-
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: |-
+                            photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                            Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: |-
+                            portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                            Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                            is on.
+                          properties:
+                            fsType:
+                              description: |-
+                                fSType represents the filesystem type to mount
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode are the mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: |-
+                                sources is the list of volume projections. Each entry in this list
+                                handles one source.
+                              items:
+                                description: |-
+                                  Projection that may be projected along with other supported volume types.
+                                  Exactly one of these fields must be set.
+                                properties:
+                                  clusterTrustBundle:
+                                    description: |-
+                                      ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                      of ClusterTrustBundle objects in an auto-updating file.
+
+                                      Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                      ClusterTrustBundle objects can either be selected by name, or by the
+                                      combination of signer name and a label selector.
+
+                                      Kubelet performs aggressive normalization of the PEM contents written
+                                      into the pod filesystem.  Esoteric PEM features such as inter-block
+                                      comments and block headers are stripped.  Certificates are deduplicated.
+                                      The ordering of certificates within the file is arbitrary, and Kubelet
+                                      may change the order over time.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                          interpreted as "match nothing".  If set but empty, interpreted as "match
+                                          everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: |-
+                                          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                          with signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the named ClusterTrustBundle is
+                                          allowed not to exist.  If using signerName, then the combination of
+                                          signerName and labelSelector is allowed to match zero
+                                          ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this signer name.
+                                          Mutually-exclusive with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate
+                                      chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a
+                                      PodCertificateRequest to the named signer.  Once the signer approves the
+                                      request and issues a certificate chain, Kubelet writes the key and
+                                      certificate chain to the pod filesystem.  The pod does not start until
+                                      certificates have been issued for each podCertificate projected volume
+                                      source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated
+                                      by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                      timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath
+                                      field, or separate files, indicated by the keyPath and
+                                      certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM
+                                      entry is the private key (in PKCS#8 format), and the remaining PEM
+                                      entries are the certificate chain issued by the signer (typically,
+                                      signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code
+                                      can read it atomically.  If you use keyPath and certificateChainPath,
+                                      your application must make two separate file reads. If these coincide
+                                      with a certificate rotation, it is possible that the private key and leaf
+                                      certificate you read may not correspond to each other.  Your application
+                                      will need to check for this condition, and re-read until they are
+                                      consistent.
+
+                                      The named signer controls chooses the format of the certificate it
+                                      issues; consult the signer implementation's documentation to learn how to
+                                      use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks.
+                                          The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                          key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued
+                                          certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single
+                                          atomic read that retrieves a consistent key and certificate chain.  If you
+                                          project them to separate files, your application code will need to
+                                          additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath
+                                          and certificateChainPath, your application needs to check that the key
+                                          and leaf certificate are consistent, because it is possible to read the
+                                          files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                          "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the
+                                          certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it
+                                          generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                          will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                          value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any
+                                          lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                          seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                          `kubernetes.io` signers will never issue certificates with a lifetime
+                                          longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will
+                                          be addressed to this signer.
+                                        type: string
+                                      userAnnotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          userAnnotations allow pod authors to pass additional information to
+                                          the signer implementation.  Kubernetes does not restrict or validate this
+                                          metadata in any way.
+
+                                          These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                          the PodCertificateRequest objects that Kubelet creates.
+
+                                          Entries are subject to the same validation as object metadata annotations,
+                                          with the addition that all keys must be domain-prefixed. No restrictions
+                                          are placed on values, except an overall size limitation on the entire field.
+
+                                          Signers should document the keys and values they support. Signers should
+                                          deny requests that contain keys they do not recognize.
+                                        type: object
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: |-
+                                          audience is the intended audience of the token. A recipient of a token
+                                          must identify itself with an identifier specified in the audience of the
+                                          token, and otherwise should reject the token. The audience defaults to the
+                                          identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: |-
+                                          expirationSeconds is the requested duration of validity of the service
+                                          account token. As the token approaches expiration, the kubelet volume
+                                          plugin will proactively rotate the service account token. The kubelet will
+                                          start trying to rotate the token if the token is older than 80 percent of
+                                          its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                          and must be at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the path relative to the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        quobyte:
+                          description: |-
+                            quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                            Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                          properties:
+                            group:
+                              description: |-
+                                group to map volume access to
+                                Default is no group
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                Defaults to false.
+                              type: boolean
+                            registry:
+                              description: |-
+                                registry represents a single or multiple Quobyte Registry services
+                                specified as a string as host:port pair (multiple entries are separated with commas)
+                                which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: |-
+                                tenant owning the given Quobyte volume in the Backend
+                                Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: |-
+                                user to map volume access to
+                                Defaults to serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: |-
+                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                            Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              type: string
+                            image:
+                              description: |-
+                                image is the rados image name.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            keyring:
+                              default: /etc/ceph/keyring
+                              description: |-
+                                keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            monitors:
+                              description: |-
+                                monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            pool:
+                              default: rbd
+                              description: |-
+                                pool is the rados pool name.
+                                Default is rbd.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is name of the authentication secret for RBDUser. If provided
+                                overrides keyring.
+                                Default is nil.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              default: admin
+                              description: |-
+                                user is the rados user name.
+                                Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          description: |-
+                            scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                          properties:
+                            fsType:
+                              default: xfs
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs".
+                                Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef references to the secret for ScaleIO user and other
+                                sensitive information. If this is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              default: ThinProvisioned
+                              description: |-
+                                storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: |-
+                                volumeName is the name of a volume already created in the ScaleIO system
+                                that is associated with this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          description: |-
+                            secret represents a secret that should populate this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values
+                                for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items If unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: |-
+                                secretName is the name of the secret in the pod's namespace to use.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              type: string
+                          type: object
+                        storageos:
+                          description: |-
+                            storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef specifies the secret to use for obtaining the StorageOS API
+                                credentials.  If not specified, default values will be attempted.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeName:
+                              description: |-
+                                volumeName is the human-readable name of the StorageOS volume.  Volume
+                                names are only unique within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: |-
+                                volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                namespace is specified then the Pod's namespace will be used.  This allows the
+                                Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                Set VolumeName to any name to override the default behaviour.
+                                Set to "default" if you are not using namespaces within StorageOS.
+                                Namespaces that do not pre-exist within StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: |-
+                            vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                            Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                            are redirected to the csi.vsphere.vmware.com CSI driver.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+              registrarImage:
+                description: RegistrarImage is the image configuration for the CSI
+                  node driver registrar sidecar.
+                properties:
+                  jmxEnabled:
+                    description: |-
+                      Define whether the Agent image should support JMX.
+                      To be used if the `Name` field does not correspond to a full image string.
+                    type: boolean
+                  name:
+                    description: |-
+                      Defines the Agent image name for the pod. You can provide this as:
+                      * `<NAME>` - Use `agent` for the Datadog Agent, `cluster-agent` for the Datadog Cluster Agent, or `dogstatsd`
+                      for DogStatsD. The full image string is derived from `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled`.
+                      * `<NAME>:<TAG>` - For example, `agent:latest`. The registry is derived from `global.registry`. `[key].image.tag`
+                      and `[key].image.jmxEnabled` are ignored.
+                      * `<REGISTRY>/<NAME>:<TAG>` - For example, `gcr.io/datadoghq/agent:latest`. If the full image string is specified
+                        like this, then `global.registry`, `[key].image.tag`, and `[key].image.jmxEnabled` are ignored.
+                    type: string
+                  pullPolicy:
+                    description: |-
+                      The Kubernetes pull policy:
+                      Use `Always`, `Never`, or `IfNotPresent`.
+                    type: string
+                  pullSecrets:
+                    description: |-
+                      It is possible to specify Docker registry credentials.
+                      See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  tag:
+                    description: |-
+                      Define the image tag to use.
+                      To be used if the `Name` field does not correspond to a full image string.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DatadogCSIDriverStatus defines the observed state of DatadogCSIDriver
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the DatadogCSIDriver's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              csiDriverName:
+                description: CSIDriverName is the name of the managed CSIDriver Kubernetes
+                  object.
+                type: string
+              daemonSet:
+                description: DaemonSet tracks the status of the CSI driver DaemonSet.
+                properties:
+                  available:
+                    description: Number of available pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  current:
+                    description: Number of current pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  currentHash:
+                    description: CurrentHash is the stored hash of the DaemonSet.
+                    type: string
+                  daemonsetName:
+                    description: DaemonsetName corresponds to the name of the created
+                      DaemonSet.
+                    type: string
+                  desired:
+                    description: Number of desired pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  lastUpdate:
+                    description: LastUpdate is the last time the status was updated.
+                    format: date-time
+                    type: string
+                  ready:
+                    description: Number of ready pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                  state:
+                    description: State corresponds to the DaemonSet state.
+                    type: string
+                  status:
+                    description: Status corresponds to the DaemonSet computed status.
+                    type: string
+                  upToDate:
+                    description: Number of up to date pods in the DaemonSet.
+                    format: int32
+                    type: integer
+                required:
+                - available
+                - current
+                - desired
+                - ready
+                - upToDate
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this resource.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogdashboards.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogdashboards.yaml
@@ -1,0 +1,271 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogdashboards.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogDashboard
+    listKind: DatadogDashboardList
+    plural: datadogdashboards
+    shortNames:
+    - ddd
+    singular: datadogdashboard
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: id
+      type: string
+    - jsonPath: .status.syncStatus
+      name: sync status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogDashboard is the Schema for the datadogdashboards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogDashboardSpec defines the desired state of DatadogDashboard
+            properties:
+              description:
+                description: Description is the description of the dashboard.
+                type: string
+              layoutType:
+                description: LayoutType is the layout type of the dashboard.
+                enum:
+                - ordered
+                - free
+                type: string
+              notifyList:
+                description: NotifyList is the list of handles of users to notify
+                  when changes are made to this dashboard.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              reflowType:
+                description: |-
+                  Reflowtype is the reflow type for a 'new dashboard layout' dashboard. Set this only when layout type is 'ordered'.
+                  If set to 'fixed', the dashboard expects all widgets to have a layout, and if it's set to 'auto',
+                  widgets should not have layouts.
+                type: string
+              tags:
+                description: Tags is a list of team names representing ownership of
+                  a dashboard.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              templateVariablePresets:
+                description: TemplateVariablePresets is an array of template variables
+                  saved views.
+                items:
+                  description: DashboardTemplateVariablePreset Template variables
+                    saved views.
+                  properties:
+                    name:
+                      description: The name of the variable.
+                      type: string
+                    templateVariables:
+                      description: List of variables.
+                      items:
+                        description: DashboardTemplateVariablePresetValue Template
+                          variables saved views.
+                        properties:
+                          name:
+                            description: The name of the variable.
+                            type: string
+                          values:
+                            description: One or many template variable values within
+                              the saved view, which will be unioned together using
+                              `OR` if more than one is specified. Cannot be used in
+                              conjunction with `value`.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              templateVariables:
+                description: TemplateVariables is a list of template variables for
+                  this dashboard.
+                items:
+                  description: DashboardTemplateVariable Template variable.
+                  properties:
+                    availableValues:
+                      description: The list of values that the template variable drop-down
+                        is limited to.
+                      items:
+                        type: string
+                      type: array
+                    defaults:
+                      description: One or many default values for template variables
+                        on load. If more than one default is specified, they will
+                        be unioned together with `OR`. Cannot be used in conjunction
+                        with `default`.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    name:
+                      description: The name of the variable.
+                      type: string
+                    prefix:
+                      description: The tag prefix associated with the variable. Only
+                        tags with this prefix appear in the variable drop-down.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              title:
+                description: Title is the title of the dashboard.
+                minLength: 1
+                type: string
+              widgets:
+                description: Widgets is a JSON string representation of a list of
+                  Datadog API Widgets
+                type: string
+            required:
+            - layoutType
+            - title
+            type: object
+          status:
+            description: DatadogDashboardStatus defines the observed state of DatadogDashboard
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the state of a DatadogDashboard.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              created:
+                description: Created is the time the dashboard was created.
+                format: date-time
+                type: string
+              creator:
+                description: Creator is the identity of the dashboard creator.
+                type: string
+              currentHash:
+                description: |-
+                  CurrentHash tracks the hash of the current DatadogDashboardSpec to know
+                  if the Spec has changed and needs an update.
+                type: string
+              id:
+                description: ID is the dashboard ID generated in Datadog.
+                type: string
+              lastForceSyncTime:
+                description: LastForceSyncTime is the last time the API dashboard
+                  was last force synced with the DatadogDashboard resource
+                format: date-time
+                type: string
+              syncStatus:
+                description: SyncStatus shows the health of syncing the dashboard
+                  state to Datadog.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadoggenericresources.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadoggenericresources.yaml
@@ -1,0 +1,199 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadoggenericresources.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogGenericResource
+    listKind: DatadogGenericResourceList
+    plural: datadoggenericresources
+    shortNames:
+    - ddgr
+    singular: datadoggenericresource
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: id
+      type: string
+    - jsonPath: .status.syncStatus
+      name: sync status
+      type: string
+    - jsonPath: .status.state
+      name: state
+      type: string
+    - format: date
+      jsonPath: .status.stateLastUpdateTime
+      name: last state sync
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogGenericResource is the Schema for the DatadogGenericResources
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogGenericResourceSpec defines the desired state of DatadogGenericResource
+            properties:
+              jsonSpec:
+                description: JsonSpec is the specification of the API object
+                minLength: 1
+                type: string
+              type:
+                description: Type is the type of the API object
+                enum:
+                - dashboard
+                - downtime
+                - monitor
+                - notebook
+                - slo
+                - synthetics_api_test
+                - synthetics_browser_test
+                type: string
+            required:
+            - jsonSpec
+            - type
+            type: object
+          status:
+            description: DatadogGenericResourceStatus defines the observed state of
+              DatadogGenericResource
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the state of a DatadogGenericResource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              created:
+                description: Created is the time the object was created.
+                format: date-time
+                type: string
+              creator:
+                description: Creator is the identity of the creator.
+                type: string
+              currentHash:
+                description: |-
+                  CurrentHash tracks the hash of the current DatadogGenericResourceSpec to know
+                  if the JsonSpec has changed and needs an update.
+                type: string
+              id:
+                description: Id is the object unique identifier generated in Datadog.
+                type: string
+              lastForceSyncTime:
+                description: LastForceSyncTime is the last time the API object was
+                  last force synced with the custom resource
+                format: date-time
+                type: string
+              state:
+                description: |-
+                  State is the live Datadog-side state of the underlying resource as last
+                  fetched from the Datadog API. Values are resource-type dependent — for
+                  Monitors: OK, Alert, Warn, No Data, Skipped, Ignored, Unknown. For SLOs:
+                  breached, warning, ok, no_data. Only populated for resource types that
+                  expose live state.
+                type: string
+              stateLastTransitionTime:
+                description: StateLastTransitionTime is the last time State changed
+                  value.
+                format: date-time
+                type: string
+              stateLastUpdateTime:
+                description: StateLastUpdateTime is the last time State was successfully
+                  refreshed from Datadog.
+                format: date-time
+                type: string
+              syncStatus:
+                description: SyncStatus shows the health of syncing the object state
+                  to Datadog.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadoginstrumentations.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadoginstrumentations.yaml
@@ -1,0 +1,282 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadoginstrumentations.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogInstrumentation
+    listKind: DatadogInstrumentationList
+    plural: datadoginstrumentations
+    shortNames:
+    - ddi
+    singular: datadoginstrumentation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.targetRef.kind
+      name: Target Kind
+      type: string
+    - jsonPath: .spec.targetRef.name
+      name: Target Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='ChecksReady')].status
+      name: Checks Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogInstrumentation is the Schema for the datadoginstrumentations
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogInstrumentationSpec defines the desired state of DatadogInstrumentation.
+            properties:
+              config:
+                description: Config defines the Datadog instrumentation configuration
+                  to apply to the target workload.
+                properties:
+                  checks:
+                    description: Checks configures Datadog Agent Autodiscovery checks
+                      for the target workload.
+                    items:
+                      description: DatadogInstrumentationCheckConfig defines an Autodiscovery
+                        check configuration.
+                      properties:
+                        containerName:
+                          description: ContainerName identifies the container name
+                            this check applies to.
+                          type: string
+                        initConfig:
+                          description: InitConfig is the integration-specific Autodiscovery
+                            init_config payload.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        instances:
+                          description: Instances contains integration-specific Autodiscovery
+                            instances payloads.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        integration:
+                          description: Integration is the Datadog integration name,
+                            for example redisdb.
+                          type: string
+                      required:
+                      - integration
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  logs:
+                    description: Logs configures Datadog Agent log collection for
+                      the target workload.
+                    items:
+                      description: DatadogInstrumentationLogConfig defines Agent log
+                        collection configuration fields.
+                      properties:
+                        channel_path:
+                          description: ChannelPath is the Windows event channel path
+                            when type is windows_event.
+                          type: string
+                        containerName:
+                          description: ContainerName identifies the container name
+                            this log configuration applies to.
+                          type: string
+                        encoding:
+                          description: |-
+                            Encoding sets the file encoding when type is file.
+                            Common values include utf-16-le, utf-16-be, and shift-jis.
+                          type: string
+                        exclude_paths:
+                          description: ExcludePaths lists matching files to exclude
+                            when type is file and path contains a wildcard.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        exclude_units:
+                          description: ExcludeUnits lists journald units to exclude
+                            when type is journald.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        include_units:
+                          description: IncludeUnits lists journald units to include
+                            when type is journald.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        log_processing_rules:
+                          description: LogProcessingRules contains Agent log processing
+                            rules for this log source.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: Path is the file path for gathering logs when
+                            type is file or journald.
+                          type: string
+                        port:
+                          description: Port is the port for listening to logs when
+                            type is tcp or udp.
+                          format: int32
+                          type: integer
+                        service:
+                          description: Service sets the log service name.
+                          type: string
+                        source:
+                          description: Source sets the log source name.
+                          type: string
+                        sourcecategory:
+                          description: SourceCategory sets the source category attribute.
+                          type: string
+                        start_position:
+                          description: |-
+                            StartPosition sets where the Agent starts reading for file and journald tailers.
+                            Common values include beginning, end, forceBeginning, and forceEnd.
+                          type: string
+                        tags:
+                          description: Tags sets additional tags on collected logs.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        type:
+                          description: Type is the type of log input source. Common
+                            values include tcp, udp, file, windows_event, docker,
+                            and journald.
+                          type: string
+                      required:
+                      - containerName
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              targetRef:
+                description: TargetRef is the reference to the workload resource to
+                  instrument.
+                properties:
+                  apiVersion:
+                    description: apiVersion is the API version of the referent
+                    type: string
+                  kind:
+                    description: 'kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - config
+            - targetRef
+            type: object
+          status:
+            description: DatadogInstrumentationStatus defines the observed state of
+              DatadogInstrumentation.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the instrumentation handlers.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogmetrics.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogmetrics.yaml
@@ -1,0 +1,133 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogmetrics.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMetric
+    listKind: DatadogMetricList
+    plural: datadogmetrics
+    singular: datadogmetric
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Active')].status
+      name: active
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: valid
+      type: string
+    - jsonPath: .status.currentValue
+      name: value
+      type: string
+    - jsonPath: .status.autoscalerReferences
+      name: references
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Updated')].lastUpdateTime
+      name: update time
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogMetric allows autoscaling on arbitrary Datadog query
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogMetricSpec defines the desired state of DatadogMetric
+            properties:
+              externalMetricName:
+                description: ExternalMetricName is reserved for internal use
+                type: string
+              maxAge:
+                description: |-
+                  MaxAge provides the max age for the metric query (overrides the default setting
+                  `external_metrics_provider.max_age`)
+                type: string
+              query:
+                description: Query is the raw datadog query
+                type: string
+              timeWindow:
+                description: TimeWindow provides the time window for the metric query,
+                  defaults to MaxAge.
+                type: string
+            type: object
+          status:
+            description: DatadogMetricStatus defines the observed state of DatadogMetric
+            properties:
+              autoscalerReferences:
+                description: List of autoscalers currently using this DatadogMetric
+                type: string
+              conditions:
+                description: Conditions Represents the latest available observations
+                  of a DatadogMetric's current state.
+                items:
+                  description: DatadogMetricCondition describes the state of a DatadogMetric
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of DatadogMetric condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentValue:
+                description: Value is the latest value of the metric
+                type: string
+            required:
+            - currentValue
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogmonitors.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogmonitors.yaml
@@ -1,0 +1,454 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogmonitors.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogMonitor
+    listKind: DatadogMonitorList
+    plural: datadogmonitors
+    singular: datadogmonitor
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: id
+      type: string
+    - jsonPath: .status.monitorState
+      name: monitor state
+      type: string
+    - jsonPath: .status.monitorStateLastTransitionTime
+      name: last state transition
+      type: string
+    - format: date
+      jsonPath: .status.monitorStateLastUpdateTime
+      name: last state sync
+      type: string
+    - jsonPath: .status.monitorStateSyncStatus
+      name: sync status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogMonitor allows to define and manage Monitors from your
+          Kubernetes Cluster
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogMonitorSpec defines the desired state of DatadogMonitor
+            properties:
+              controllerOptions:
+                description: ControllerOptions are the optional parameters in the
+                  DatadogMonitor controller
+                properties:
+                  disableRequiredTags:
+                    description: DisableRequiredTags disables the automatic addition
+                      of required tags to monitors.
+                    type: boolean
+                type: object
+              message:
+                description: Message is a message to include with notifications for
+                  this monitor
+                minLength: 1
+                type: string
+              name:
+                description: Name is the monitor name
+                minLength: 1
+                type: string
+              options:
+                description: Options are the optional parameters associated with your
+                  monitor
+                properties:
+                  enableLogsSample:
+                    description: A Boolean indicating whether to send a log sample
+                      when the log monitor triggers.
+                    type: boolean
+                  escalationMessage:
+                    description: A message to include with a re-notification.
+                    type: string
+                  evaluationDelay:
+                    description: |-
+                      Time (in seconds) to delay evaluation, as a non-negative integer. For example, if the value is set to 300 (5min),
+                      the timeframe is set to last_5m and the time is 7:00, the monitor evaluates data from 6:50 to 6:55.
+                      This is useful for AWS CloudWatch and other backfilled metrics to ensure the monitor always has data during evaluation.
+                    format: int64
+                    type: integer
+                  groupRetentionDuration:
+                    description: |-
+                      The time span after which groups with missing data are dropped from the monitor state.
+                      The minimum value is one hour, and the maximum value is 72 hours.
+                      Example values are: "60m", "1h", and "2d".
+                      This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors.
+                    type: string
+                  groupbySimpleMonitor:
+                    description: A Boolean indicating whether the log alert monitor
+                      triggers a single alert or multiple alerts when any group breaches
+                      a threshold.
+                    type: boolean
+                  includeTags:
+                    description: A Boolean indicating whether notifications from this
+                      monitor automatically inserts its triggering tags into the title.
+                    type: boolean
+                  locked:
+                    description: 'DEPRECATED: Whether or not the monitor is locked
+                      (only editable by creator and admins). Use `restricted_roles`
+                      instead.'
+                    type: boolean
+                  newGroupDelay:
+                    description: |-
+                      Time (in seconds) to allow a host to boot and applications to fully start before starting the evaluation of
+                      monitor results. Should be a non negative integer.
+                    format: int64
+                    type: integer
+                  noDataTimeframe:
+                    description: |-
+                      The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the
+                      monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe
+                      is used for metric alerts, and 24 hours is used for service checks.
+                    format: int64
+                    type: integer
+                  notificationPresetName:
+                    description: An enum that toggles the display of additional content
+                      sent in the monitor notification.
+                    type: string
+                  notifyAudit:
+                    description: A Boolean indicating whether tagged users are notified
+                      on changes to this monitor.
+                    type: boolean
+                  notifyBy:
+                    description: |-
+                      A string indicating the granularity a monitor alerts on. Only available for monitors with groupings.
+                      For instance, a monitor grouped by cluster, namespace, and pod can be configured to only notify on each new
+                      cluster violating the alert conditions by setting notify_by to ["cluster"]. Tags mentioned in notify_by must
+                      be a subset of the grouping tags in the query. For example, a query grouped by cluster and namespace cannot
+                      notify on region. Setting notify_by to [*] configures the monitor to notify as a simple-alert.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  notifyNoData:
+                    description: A Boolean indicating whether this monitor notifies
+                      when data stops reporting.
+                    type: boolean
+                  onMissingData:
+                    description: |-
+                      An enum that controls how groups or monitors are treated if an evaluation does not return data points.
+                      The default option results in different behavior depending on the monitor query type.
+                      For monitors using Count queries, an empty monitor evaluation is treated as 0 and is compared to the threshold conditions.
+                      For monitors using any query type other than Count, for example Gauge, Measure, or Rate, the monitor shows the last known status.
+                      This option is only available for APM Trace Analytics, Audit Trail, CI, Error Tracking, Event, Logs, and RUM monitors
+                    type: string
+                  renotifyInterval:
+                    description: |-
+                      The number of minutes after the last notification before a monitor re-notifies on the current status.
+                      It only re-notifies if it’s not resolved.
+                    format: int64
+                    type: integer
+                  renotifyOccurrences:
+                    description: The number of times re-notification messages should
+                      be sent on the current status at the provided re-notification
+                      interval.
+                    format: int64
+                    type: integer
+                  renotifyStatuses:
+                    description: The types of statuses for which re-notification messages
+                      should be sent. Valid values are alert, warn, no data.
+                    items:
+                      description: MonitorRenotifyStatusType The different statuses
+                        for which renotification is supported.
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  requireFullWindow:
+                    description: |-
+                      A Boolean indicating whether this monitor needs a full window of data before it’s evaluated. We highly
+                      recommend you set this to false for sparse metrics, otherwise some evaluations are skipped. Default is false.
+                    type: boolean
+                  schedulingOptions:
+                    description: Configuration options for scheduling.
+                    properties:
+                      customSchedule:
+                        description: Configuration options for the custom schedule.
+                          If start is omitted, the monitor creation time will be used.
+                        properties:
+                          recurrence:
+                            description: DatadogMonitorOptionsSchedulingOptionsCustomScheduleRecurrence
+                              is a struct of the recurrence definition
+                            properties:
+                              rrule:
+                                description: The recurrence rule in iCalendar format.
+                                  For example, `FREQ=MONTHLY;BYMONTHDAY=28,29,30,31;BYSETPOS=-1`.
+                                type: string
+                              start:
+                                description: |-
+                                  The start date of the recurrence rule defined in `YYYY-MM-DDThh:mm:ss` format.
+                                  If omitted, the monitor creation time will be used.
+                                type: string
+                              timezone:
+                                description: The timezone in `tz database` format,
+                                  in which the recurrence rule is defined. For example,
+                                  `America/New_York` or `UTC`.
+                                type: string
+                            type: object
+                        type: object
+                      evaluationWindow:
+                        description: |-
+                          Configuration options for the evaluation window. If hour_starts is set, no other fields may be set.
+                          Otherwise, day_starts and month_starts must be set together.
+                        properties:
+                          dayStarts:
+                            description: The time of the day at which a one day cumulative
+                              evaluation window starts. Must be defined in UTC time
+                              in HH:mm format.
+                            type: string
+                          hourStarts:
+                            description: The minute of the hour at which a one hour
+                              cumulative evaluation window starts.
+                            format: int32
+                            type: integer
+                          monthStarts:
+                            description: The day of the month at which a one month
+                              cumulative evaluation window starts.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  thresholdWindows:
+                    description: A struct of the alerting time window options.
+                    properties:
+                      recoveryWindow:
+                        description: Describes how long an anomalous metric must be
+                          normal before the alert recovers.
+                        type: string
+                      triggerWindow:
+                        description: Describes how long a metric must be anomalous
+                          before an alert triggers.
+                        type: string
+                    type: object
+                  thresholds:
+                    description: A struct of the different monitor threshold values.
+                    properties:
+                      critical:
+                        description: The monitor CRITICAL threshold.
+                        type: string
+                      criticalRecovery:
+                        description: The monitor CRITICAL recovery threshold.
+                        type: string
+                      ok:
+                        description: The monitor OK threshold.
+                        type: string
+                      unknown:
+                        description: The monitor UNKNOWN threshold.
+                        type: string
+                      warning:
+                        description: The monitor WARNING threshold.
+                        type: string
+                      warningRecovery:
+                        description: The monitor WARNING recovery threshold.
+                        type: string
+                    type: object
+                  timeoutH:
+                    description: The number of hours of the monitor not reporting
+                      data before it automatically resolves from a triggered state.
+                    format: int64
+                    type: integer
+                type: object
+              priority:
+                description: Priority is an integer from 1 (high) to 5 (low) indicating
+                  alert severity
+                format: int64
+                type: integer
+              query:
+                description: Query is the Datadog monitor query
+                minLength: 1
+                type: string
+              restrictedRoles:
+                description: |-
+                  RestrictedRoles is a list of unique role identifiers to define which roles are allowed to edit the monitor.
+                  `restricted_roles` is the successor of `locked`. For more information about `locked` and `restricted_roles`,
+                  see the [monitor options docs](https://docs.datadoghq.com/monitors/guide/monitor_api_options/#permissions-options).
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              tags:
+                description: Tags is the monitor tags associated with your monitor
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              type:
+                description: Type is the monitor type
+                enum:
+                - metric alert
+                - query alert
+                - service check
+                - event alert
+                - log alert
+                - process alert
+                - rum alert
+                - trace-analytics alert
+                - slo alert
+                - event-v2 alert
+                - audit alert
+                - composite
+                - error-tracking alert
+                type: string
+            required:
+            - message
+            - name
+            - query
+            - type
+            type: object
+          status:
+            description: DatadogMonitorStatus defines the observed state of DatadogMonitor
+            properties:
+              conditions:
+                description: Conditions Represents the latest available observations
+                  of a DatadogMonitor's current state.
+                items:
+                  description: DatadogMonitorCondition describes the current state
+                    of a DatadogMonitor
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of DatadogMonitor condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              created:
+                description: Created is the time the monitor was created
+                format: date-time
+                type: string
+              creator:
+                description: Creator is the identify of the monitor creator
+                type: string
+              currentHash:
+                description: |-
+                  CurrentHash tracks the hash of the current DatadogMonitorSpec to know
+                  if the Spec has changed and needs an update
+                type: string
+              downtimeStatus:
+                description: DowntimeStatus defines whether the monitor is downtimed
+                properties:
+                  downtimeID:
+                    description: DowntimeID is the downtime ID.
+                    type: integer
+                  isDowntimed:
+                    description: IsDowntimed shows the downtime status of the monitor.
+                    type: boolean
+                type: object
+              id:
+                description: ID is the monitor ID generated in Datadog
+                type: integer
+              monitorLastForceSyncTime:
+                description: MonitorLastForceSyncTime is the last time the API monitor
+                  was last force synced with the DatadogMonitor resource
+                format: date-time
+                type: string
+              monitorState:
+                description: MonitorState is the overall state of monitor
+                type: string
+              monitorStateLastTransitionTime:
+                description: MonitorStateLastTransitionTime is the last time the monitor
+                  state changed
+                format: date-time
+                type: string
+              monitorStateLastUpdateTime:
+                description: MonitorStateLastUpdateTime is the last time the monitor
+                  state updated
+                format: date-time
+                type: string
+              monitorStateSyncStatus:
+                description: MonitorStateSyncStatus shows the health of syncing the
+                  monitor state to Datadog
+                type: string
+              primary:
+                description: |-
+                  Primary defines whether the monitor is managed by the Kubernetes custom
+                  resource (true) or outside Kubernetes (false)
+                type: boolean
+              triggeredState:
+                description: TriggeredState only includes details for monitor groups
+                  that are triggering
+                items:
+                  description: |-
+                    DatadogMonitorTriggeredState represents the details of a triggering DatadogMonitor
+                    The DatadogMonitor is triggering if one of its groups is in Alert, Warn, or No Data
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    monitorGroup:
+                      description: MonitorGroup is the name of the triggering group
+                      type: string
+                    state:
+                      description: DatadogMonitorState represents the overall DatadogMonitor
+                        state
+                      type: string
+                  required:
+                  - monitorGroup
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - monitorGroup
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogpodautoscalerclusterprofiles.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogpodautoscalerclusterprofiles.yaml
@@ -1,0 +1,1029 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogpodautoscalerclusterprofiles.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogPodAutoscalerClusterProfile
+    listKind: DatadogPodAutoscalerClusterProfileList
+    plural: datadogpodautoscalerclusterprofiles
+    shortNames:
+    - dpacp
+    singular: datadogpodautoscalerclusterprofile
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Valid')].status
+      name: Valid
+      type: string
+    - jsonPath: .status.controlledAutoscalers
+      name: Controlled Autoscalers
+      type: integer
+    - jsonPath: .spec.template.applyPolicy.mode
+      name: Apply Mode
+      type: string
+    - jsonPath: .spec.template.constraints.minReplicas
+      name: Min Replicas
+      type: integer
+    - jsonPath: .spec.template.constraints.maxReplicas
+      name: Max Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: DatadogPodAutoscalerClusterProfile is the Schema for the datadogpodautoscalerclusterprofiles
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogPodAutoscalerProfileSpec defines the desired state
+              of DatadogPodAutoscalerProfile.
+            properties:
+              template:
+                description: Template contains the autoscaling behavior configuration
+                  to apply to managed DatadogPodAutoscalers.
+                properties:
+                  applyPolicy:
+                    default: {}
+                    description: ApplyPolicy defines how recommendations should be
+                      applied.
+                    properties:
+                      mode:
+                        default: Apply
+                        description: |-
+                          Mode determines recommendations that should be applied by the controller:
+                          - Apply: Apply all recommendations.
+                          - Preview: Recommendations are received and visible through .Status, but the controller does not apply them.
+                          It's also possible to selectively deactivate upscale, downscale or update actions thanks to the `ScaleUp`, `ScaleDown` and `Update` fields.
+                        enum:
+                        - Apply
+                        - Preview
+                        type: string
+                      scaleDown:
+                        description: ScaleDown defines the policy to scale down the
+                          target resource.
+                        properties:
+                          rules:
+                            description: |-
+                              Rules is a list of potential scaling polices which can be used during scaling.
+                              At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                            items:
+                              description: DatadogPodAutoscalerScalingRule defines
+                                rules for horizontal scaling that should be true for
+                                a certain amount of time.
+                              properties:
+                                periodSeconds:
+                                  description: |-
+                                    PeriodSeconds specifies the window of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                                  format: int32
+                                  maximum: 3600
+                                  minimum: 1
+                                  type: integer
+                                type:
+                                  description: Type is used to specify the scaling
+                                    policy.
+                                  enum:
+                                  - Pods
+                                  - Percent
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value contains the amount of change which is permitted by the policy.
+                                    Setting it to 0 will prevent any scaling in this direction.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - periodSeconds
+                              - type
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          stabilizationWindowSeconds:
+                            description: |-
+                              StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                              before deciding to apply a new one. Defaults to 0.
+                            format: int32
+                            maximum: 3600
+                            minimum: 0
+                            type: integer
+                          strategy:
+                            description: |-
+                              Strategy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
+                            enum:
+                            - Max
+                            - Min
+                            - Disabled
+                            type: string
+                        type: object
+                      scaleUp:
+                        description: ScaleUp defines the policy to scale up the target
+                          resource.
+                        properties:
+                          rules:
+                            description: |-
+                              Rules is a list of potential scaling polices which can be used during scaling.
+                              At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                            items:
+                              description: DatadogPodAutoscalerScalingRule defines
+                                rules for horizontal scaling that should be true for
+                                a certain amount of time.
+                              properties:
+                                periodSeconds:
+                                  description: |-
+                                    PeriodSeconds specifies the window of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                                  format: int32
+                                  maximum: 3600
+                                  minimum: 1
+                                  type: integer
+                                type:
+                                  description: Type is used to specify the scaling
+                                    policy.
+                                  enum:
+                                  - Pods
+                                  - Percent
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value contains the amount of change which is permitted by the policy.
+                                    Setting it to 0 will prevent any scaling in this direction.
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - periodSeconds
+                              - type
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          stabilizationWindowSeconds:
+                            description: |-
+                              StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                              before deciding to apply a new one. Defaults to 0.
+                            format: int32
+                            maximum: 3600
+                            minimum: 0
+                            type: integer
+                          strategy:
+                            description: |-
+                              Strategy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
+                            enum:
+                            - Max
+                            - Min
+                            - Disabled
+                            type: string
+                        type: object
+                      update:
+                        description: Update defines the policy for updating the target
+                          resource.
+                        properties:
+                          resizePendingPeriod:
+                            description: |-
+                              Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                              Must be greater than 0 and less than or equal to 3600 (1 hour).
+                            format: int32
+                            maximum: 3600
+                            minimum: 1
+                            type: integer
+                          rolloutFallbackDelay:
+                            description: |-
+                              Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                              Must be greater than 0 and less than or equal to 3600 (1 hour).
+                            format: int32
+                            maximum: 3600
+                            minimum: 1
+                            type: integer
+                          strategy:
+                            description: Strategy defines the mode of the update policy.
+                            enum:
+                            - Auto
+                            - Disabled
+                            - TriggerRollout
+                            type: string
+                        type: object
+                    type: object
+                  constraints:
+                    description: Constraints defines constraints that should always
+                      be respected.
+                    properties:
+                      containers:
+                        description: Containers defines constraints for the containers.
+                        items:
+                          description: |-
+                            DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
+                            If no constraints are set, it enables resource scaling for all containers without any constraints.
+                          properties:
+                            controlledResources:
+                              description: |-
+                                Specifies the resources for which recommendations will be computed.
+                                If not specified, it defaults to CPU and Memory.
+                                If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                              items:
+                                description: ResourceName is the name identifying
+                                  various resources in a ResourceList.
+                                type: string
+                              type: array
+                            controlledValues:
+                              description: |-
+                                Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                                The default is "RequestsAndLimits".
+                              enum:
+                              - RequestsAndLimits
+                              - RequestsOnly
+                              - CPURequestsRemoveLimitsMemoryRequestsAndLimits
+                              type: string
+                            enabled:
+                              description: Enabled, if false, allows one to disable
+                                resource autoscaling for the container. Defaults to
+                                true.
+                              type: boolean
+                            maxAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: MaxAllowed is the upper limit for the requests
+                                of the container.
+                              type: object
+                            minAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: MinAllowed is the lower limit for the requests
+                                of the container.
+                              type: object
+                            name:
+                              description: Name is the name of the container. Can
+                                be "*" to apply to all containers.
+                              type: string
+                            requests:
+                              description: |-
+                                Requests defines the constraints for the requests of the container.
+                                WARNING: Deprecated
+                              properties:
+                                maxAllowed:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: MaxAllowed is the upper limit for the
+                                    requests of the container.
+                                  type: object
+                                minAllowed:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: MinAllowed is the lower limit for the
+                                    requests of the container.
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      maxReplicas:
+                        description: MaxReplicas is the upper limit for the number
+                          of POD replicas. Needs to be >= minReplicas.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      minReplicas:
+                        description: MinReplicas is the lower limit for the number
+                          of pod replicas. Needs to be >= 1. Defaults to 1.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  fallback:
+                    default: {}
+                    description: Fallback defines how recommendations should be applied
+                      when in fallback mode.
+                    properties:
+                      horizontal:
+                        default: {}
+                        description: Horizontal configures the behavior during horizontal
+                          fallback mode.
+                        properties:
+                          direction:
+                            default: ScaleUp
+                            description: Direction determines the direction that recommendations
+                              should be applied.
+                            enum:
+                            - ScaleUp
+                            - ScaleDown
+                            - All
+                            type: string
+                          enabled:
+                            default: true
+                            description: 'Enabled determines whether recommendations
+                              should be applied by the controller:'
+                            type: boolean
+                          objectives:
+                            description: |-
+                              Objectives are the objectives to reach and maintain for the target resource in fallback mode.
+                              If not set, the regular objectives will be used.
+                            items:
+                              description: DatadogPodAutoscalerObjective defines the
+                                objectives to reach and maintain for the target workload.
+                              properties:
+                                containerResource:
+                                  description: ContainerResource allows to set a container-level
+                                    resource objective.
+                                  properties:
+                                    container:
+                                      description: Container is the name of the container.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the resource.
+                                      enum:
+                                      - cpu
+                                      - memory
+                                      type: string
+                                    value:
+                                      description: Value is the value of the objective
+                                      properties:
+                                        absoluteValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                            Use a plain number (e.g., "11" or "11.5").
+                                            Represented as a resource.Quantity to avoid floating point in CRDs.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: 'Type specifies how the value
+                                            is expressed (possible values: Utilization,
+                                            AbsoluteValue).'
+                                          enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                          type: string
+                                        utilization:
+                                          description: Utilization defines a percentage
+                                            of the target compared to requested workload
+                                          format: int32
+                                          maximum: 100
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - container
+                                  - name
+                                  - value
+                                  type: object
+                                customQuery:
+                                  description: CustomQuery allows to set a controller-level
+                                    objective.
+                                  properties:
+                                    request:
+                                      description: Request is the timeseries query
+                                        to use for the objective.
+                                      properties:
+                                        formula:
+                                          description: Formula to compute (optional).
+                                          type: string
+                                        queries:
+                                          description: |-
+                                            Queries is a list of timeseries queries to use for the objective.
+                                            At least one query must be specified
+                                          items:
+                                            description: TimeseriesQuery is a discriminated
+                                              union. Only Metrics and APMMetrics are
+                                              supported for autoscaling.
+                                            properties:
+                                              apmMetrics:
+                                                description: ApmMetrics is allows
+                                                  to query APM metrics.
+                                                properties:
+                                                  groupBy:
+                                                    description: GroupBy is the list
+                                                      of tags to group by.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  operationName:
+                                                    description: OperationName is
+                                                      the name of the operation to
+                                                      query.
+                                                    type: string
+                                                  queryFilter:
+                                                    description: QueryFilter is the
+                                                      filter to apply to the query.
+                                                    type: string
+                                                  resourceHash:
+                                                    description: ResourceHash is a
+                                                      fingerprint of the resource
+                                                      name that can be used to identify
+                                                      the resource instead of the
+                                                      resource name.
+                                                    type: string
+                                                  resourceName:
+                                                    description: ResourceName is the
+                                                      name of the resource to query.
+                                                    type: string
+                                                  service:
+                                                    description: Service is the name
+                                                      of the service to query.
+                                                    type: string
+                                                  spanKind:
+                                                    description: SpanKind is the kind
+                                                      of span to query.
+                                                    type: string
+                                                  stat:
+                                                    description: Stat defines the
+                                                      statistic to compute for the
+                                                      APM metrics query.
+                                                    enum:
+                                                    - error_rate
+                                                    - errors
+                                                    - errors_per_second
+                                                    - hits
+                                                    - hits_per_second
+                                                    - apdex
+                                                    - latency_avg
+                                                    - latency_max
+                                                    - latency_p50
+                                                    - latency_p75
+                                                    - latency_p90
+                                                    - latency_p95
+                                                    - latency_p99
+                                                    - latency_p999
+                                                    - latency_distribution
+                                                    - total_time
+                                                    type: string
+                                                required:
+                                                - stat
+                                                type: object
+                                              metrics:
+                                                description: Metrics is a standard
+                                                  Datadog metrics query.
+                                                properties:
+                                                  query:
+                                                    description: Classic Datadog metrics
+                                                      query, e.g. "avg:system.cpu.user{*}
+                                                      by {env}".
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - query
+                                                type: object
+                                              name:
+                                                description: Optional variable name
+                                                  ("a", "b", etc.) to reference in
+                                                  formulas.
+                                                type: string
+                                              source:
+                                                description: Source defines the source
+                                                  of the timeseries query.
+                                                enum:
+                                                - Metrics
+                                                - ApmMetrics
+                                                type: string
+                                            required:
+                                            - source
+                                            type: object
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - queries
+                                      type: object
+                                    value:
+                                      description: Value is the value of the objective
+                                      properties:
+                                        absoluteValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                            Use a plain number (e.g., "11" or "11.5").
+                                            Represented as a resource.Quantity to avoid floating point in CRDs.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: 'Type specifies how the value
+                                            is expressed (possible values: Utilization,
+                                            AbsoluteValue).'
+                                          enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                          type: string
+                                        utilization:
+                                          description: Utilization defines a percentage
+                                            of the target compared to requested workload
+                                          format: int32
+                                          maximum: 100
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - type
+                                      type: object
+                                    window:
+                                      description: Window is the time duration over
+                                        which the query is computed. It should contain
+                                        at least one full sample.
+                                      type: string
+                                  required:
+                                  - request
+                                  - value
+                                  - window
+                                  type: object
+                                podResource:
+                                  description: PodResource allows to set a pod-level
+                                    resource objective.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the resource.
+                                      enum:
+                                      - cpu
+                                      - memory
+                                      type: string
+                                    value:
+                                      description: Value is the value of the objective.
+                                      properties:
+                                        absoluteValue:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                            Use a plain number (e.g., "11" or "11.5").
+                                            Represented as a resource.Quantity to avoid floating point in CRDs.
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type:
+                                          description: 'Type specifies how the value
+                                            is expressed (possible values: Utilization,
+                                            AbsoluteValue).'
+                                          enum:
+                                          - Utilization
+                                          - AbsoluteValue
+                                          type: string
+                                        utilization:
+                                          description: Utilization defines a percentage
+                                            of the target compared to requested workload
+                                          format: int32
+                                          maximum: 100
+                                          minimum: 0
+                                          type: integer
+                                      required:
+                                      - type
+                                      type: object
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type:
+                                  description: Type sets the type of the objective.
+                                  enum:
+                                  - PodResource
+                                  - ContainerResource
+                                  - CustomQuery
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          triggers:
+                            default: {}
+                            description: Triggers defines the triggers that will generate
+                              recommendations.
+                            properties:
+                              staleRecommendationThresholdSeconds:
+                                default: 600
+                                description: StaleRecommendationThresholdSeconds defines
+                                  the time window the controller will wait after detecting
+                                  an error before applying recommendations.
+                                format: int32
+                                maximum: 3600
+                                minimum: 100
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  objectives:
+                    description: |-
+                      Objectives are the objectives to reach and maintain for the target resource.
+                      Default to a single objective to maintain 80% POD CPU utilization.
+                    items:
+                      description: DatadogPodAutoscalerObjective defines the objectives
+                        to reach and maintain for the target workload.
+                      properties:
+                        containerResource:
+                          description: ContainerResource allows to set a container-level
+                            resource objective.
+                          properties:
+                            container:
+                              description: Container is the name of the container.
+                              type: string
+                            name:
+                              description: Name is the name of the resource.
+                              enum:
+                              - cpu
+                              - memory
+                              type: string
+                            value:
+                              description: Value is the value of the objective
+                              properties:
+                                absoluteValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                    Use a plain number (e.g., "11" or "11.5").
+                                    Represented as a resource.Quantity to avoid floating point in CRDs.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: 'Type specifies how the value is expressed
+                                    (possible values: Utilization, AbsoluteValue).'
+                                  enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                  type: string
+                                utilization:
+                                  description: Utilization defines a percentage of
+                                    the target compared to requested workload
+                                  format: int32
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - container
+                          - name
+                          - value
+                          type: object
+                        customQuery:
+                          description: CustomQuery allows to set a controller-level
+                            objective.
+                          properties:
+                            request:
+                              description: Request is the timeseries query to use
+                                for the objective.
+                              properties:
+                                formula:
+                                  description: Formula to compute (optional).
+                                  type: string
+                                queries:
+                                  description: |-
+                                    Queries is a list of timeseries queries to use for the objective.
+                                    At least one query must be specified
+                                  items:
+                                    description: TimeseriesQuery is a discriminated
+                                      union. Only Metrics and APMMetrics are supported
+                                      for autoscaling.
+                                    properties:
+                                      apmMetrics:
+                                        description: ApmMetrics is allows to query
+                                          APM metrics.
+                                        properties:
+                                          groupBy:
+                                            description: GroupBy is the list of tags
+                                              to group by.
+                                            items:
+                                              type: string
+                                            type: array
+                                          operationName:
+                                            description: OperationName is the name
+                                              of the operation to query.
+                                            type: string
+                                          queryFilter:
+                                            description: QueryFilter is the filter
+                                              to apply to the query.
+                                            type: string
+                                          resourceHash:
+                                            description: ResourceHash is a fingerprint
+                                              of the resource name that can be used
+                                              to identify the resource instead of
+                                              the resource name.
+                                            type: string
+                                          resourceName:
+                                            description: ResourceName is the name
+                                              of the resource to query.
+                                            type: string
+                                          service:
+                                            description: Service is the name of the
+                                              service to query.
+                                            type: string
+                                          spanKind:
+                                            description: SpanKind is the kind of span
+                                              to query.
+                                            type: string
+                                          stat:
+                                            description: Stat defines the statistic
+                                              to compute for the APM metrics query.
+                                            enum:
+                                            - error_rate
+                                            - errors
+                                            - errors_per_second
+                                            - hits
+                                            - hits_per_second
+                                            - apdex
+                                            - latency_avg
+                                            - latency_max
+                                            - latency_p50
+                                            - latency_p75
+                                            - latency_p90
+                                            - latency_p95
+                                            - latency_p99
+                                            - latency_p999
+                                            - latency_distribution
+                                            - total_time
+                                            type: string
+                                        required:
+                                        - stat
+                                        type: object
+                                      metrics:
+                                        description: Metrics is a standard Datadog
+                                          metrics query.
+                                        properties:
+                                          query:
+                                            description: Classic Datadog metrics query,
+                                              e.g. "avg:system.cpu.user{*} by {env}".
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - query
+                                        type: object
+                                      name:
+                                        description: Optional variable name ("a",
+                                          "b", etc.) to reference in formulas.
+                                        type: string
+                                      source:
+                                        description: Source defines the source of
+                                          the timeseries query.
+                                        enum:
+                                        - Metrics
+                                        - ApmMetrics
+                                        type: string
+                                    required:
+                                    - source
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - queries
+                              type: object
+                            value:
+                              description: Value is the value of the objective
+                              properties:
+                                absoluteValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                    Use a plain number (e.g., "11" or "11.5").
+                                    Represented as a resource.Quantity to avoid floating point in CRDs.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: 'Type specifies how the value is expressed
+                                    (possible values: Utilization, AbsoluteValue).'
+                                  enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                  type: string
+                                utilization:
+                                  description: Utilization defines a percentage of
+                                    the target compared to requested workload
+                                  format: int32
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - type
+                              type: object
+                            window:
+                              description: Window is the time duration over which
+                                the query is computed. It should contain at least
+                                one full sample.
+                              type: string
+                          required:
+                          - request
+                          - value
+                          - window
+                          type: object
+                        podResource:
+                          description: PodResource allows to set a pod-level resource
+                            objective.
+                          properties:
+                            name:
+                              description: Name is the name of the resource.
+                              enum:
+                              - cpu
+                              - memory
+                              type: string
+                            value:
+                              description: Value is the value of the objective.
+                              properties:
+                                absoluteValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                    Use a plain number (e.g., "11" or "11.5").
+                                    Represented as a resource.Quantity to avoid floating point in CRDs.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: 'Type specifies how the value is expressed
+                                    (possible values: Utilization, AbsoluteValue).'
+                                  enum:
+                                  - Utilization
+                                  - AbsoluteValue
+                                  type: string
+                                utilization:
+                                  description: Utilization defines a percentage of
+                                    the target compared to requested workload
+                                  format: int32
+                                  maximum: 100
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type:
+                          description: Type sets the type of the objective.
+                          enum:
+                          - PodResource
+                          - ContainerResource
+                          - CustomQuery
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  options:
+                    description: Options defines optional behavior modifications for
+                      the autoscaler.
+                    properties:
+                      burstable:
+                        description: |-
+                          Burstable, if true, removes CPU limits from containers while keeping CPU request recommendations,
+                          granting the pod a Burstable QoS class and allowing it to consume idle node CPU capacity beyond its requests.
+                          If not set, the default value is determined by the Cluster Agent setting autoscaling.workload.options.burstable.
+                        type: boolean
+                      outOfMemory:
+                        description: OutOfMemory configures behavior when OOM events
+                          are detected.
+                        properties:
+                          bumpUpRatio:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              BumpUpRatio defines the ratio to multiply memory by when OOM is detected.
+                              For example, "1.2" means increase memory by 20%.
+                              Represented as a resource.Quantity to avoid floating point in CRDs.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: DatadogPodAutoscalerProfileStatus defines the observed state
+              of DatadogPodAutoscalerProfile.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the profile's current state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              controlledAutoscalers:
+                description: ControlledAutoscalers is the number of DatadogPodAutoscaler
+                  objects managed by this profile.
+                format: int32
+                type: integer
+              templateHash:
+                description: TemplateHash is the stored hash of the DatadogPodAutoscalerProfile
+                  template.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogpodautoscalers.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogpodautoscalers.yaml
@@ -1,0 +1,2104 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogpodautoscalers.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogPodAutoscaler
+    listKind: DatadogPodAutoscalerList
+    plural: datadogpodautoscalers
+    shortNames:
+    - dpa
+    singular: datadogpodautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.policy.applyMode
+      name: Apply Mode
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Active')].status
+      name: Active
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Error')].status
+      name: In Error
+      type: string
+    - jsonPath: .status.horizontal.target.desiredReplicas
+      name: Desired Replicas
+      type: integer
+    - jsonPath: .status.horizontal.target.generatedAt
+      name: Generated
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='HorizontalAbleToScale')].status
+      name: Able to Scale
+      type: string
+    - jsonPath: .status.horizontal.lastAction.time
+      name: Last Scale
+      type: date
+    - jsonPath: .status.vertical.target.podCPURequest
+      name: Target CPU Req
+      type: string
+    - jsonPath: .status.vertical.target.podMemoryRequest
+      name: Target Memory Req
+      type: string
+    - jsonPath: .status.vertical.target.generatedAt
+      name: Generated
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='VerticalAbleToApply')].status
+      name: Able to Apply
+      type: string
+    - jsonPath: .status.vertical.lastAction.time
+      name: Last Trigger
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogPodAutoscaler is the Schema for the datadogpodautoscalers
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogPodAutoscalerSpec defines the desired state of DatadogPodAutoscaler
+            properties:
+              constraints:
+                description: Constraints defines constraints that should always be
+                  respected.
+                properties:
+                  containers:
+                    description: Containers defines constraints for the containers.
+                    items:
+                      description: |-
+                        DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
+                        If no constraints are set, it enables resource scaling for all containers without any constraints.
+                      properties:
+                        controlledResources:
+                          description: |-
+                            Specifies the resources for which recommendations will be computed.
+                            If not specified, it defaults to CPU and Memory.
+                            If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                        controlledValues:
+                          description: |-
+                            Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                            The default is "RequestsAndLimits".
+                          enum:
+                          - RequestsAndLimits
+                          - RequestsOnly
+                          - CPURequestsRemoveLimitsMemoryRequestsAndLimits
+                          type: string
+                        enabled:
+                          description: Enabled, if false, allows one to disable resource
+                            autoscaling for the container. Defaults to true.
+                          type: boolean
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: MaxAllowed is the upper limit for the requests
+                            of the container.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: MinAllowed is the lower limit for the requests
+                            of the container.
+                          type: object
+                        name:
+                          description: Name is the name of the container. Can be "*"
+                            to apply to all containers.
+                          type: string
+                        requests:
+                          description: |-
+                            Requests defines the constraints for the requests of the container.
+                            WARNING: Deprecated
+                          properties:
+                            maxAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: MaxAllowed is the upper limit for the requests
+                                of the container.
+                              type: object
+                            minAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: MinAllowed is the lower limit for the requests
+                                of the container.
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  maxReplicas:
+                    description: MaxReplicas is the upper limit for the number of
+                      POD replicas. Needs to be >= minReplicas.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  minReplicas:
+                    description: MinReplicas is the lower limit for the number of
+                      pod replicas. Needs to be >= 1. Defaults to 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              owner:
+                description: |-
+                  Owner defines the source of truth for this object (local or remote)
+                  Value needs to be set when a DatadogPodAutoscaler object is created.
+                enum:
+                - Local
+                - Remote
+                type: string
+              policy:
+                default: {}
+                description: Policy defines how recommendations should be applied.
+                properties:
+                  applyMode:
+                    default: All
+                    description: |-
+                      ApplyMode determines recommendations that should be applied by the controller:
+                      - All: Apply all recommendations (regular and manual).
+                      - Manual: Apply only manual recommendations (recommendations manually validated by user in the Datadog app).
+                      - None: Prevent the controller to apply any recommendations.
+                      It's also possible to selectively deactivate upscale, downscale or update actions thanks to the `Upscale`, `Downscale` and `Update` fields.
+                    enum:
+                    - All
+                    - Manual
+                    - None
+                    type: string
+                  downscale:
+                    description: Downscale defines the policy to scale down the target
+                      resource.
+                    properties:
+                      rules:
+                        description: |-
+                          Rules is a list of potential scaling polices which can be used during scaling.
+                          At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                        items:
+                          description: DatadogPodAutoscalerScalingRule defines rules
+                            for horizontal scaling that should be true for a certain
+                            amount of time.
+                          properties:
+                            periodSeconds:
+                              description: |-
+                                PeriodSeconds specifies the window of time for which the policy should hold true.
+                                PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            type:
+                              description: Type is used to specify the scaling policy.
+                              enum:
+                              - Pods
+                              - Percent
+                              type: string
+                            value:
+                              description: |-
+                                Value contains the amount of change which is permitted by the policy.
+                                Setting it to 0 will prevent any scaling in this direction.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          required:
+                          - periodSeconds
+                          - type
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      stabilizationWindowSeconds:
+                        description: |-
+                          StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                          before deciding to apply a new one. Defaults to 0.
+                        format: int32
+                        maximum: 3600
+                        minimum: 0
+                        type: integer
+                      strategy:
+                        description: |-
+                          Strategy is used to specify which policy should be used.
+                          If not set, the default value Max is used.
+                        enum:
+                        - Max
+                        - Min
+                        - Disabled
+                        type: string
+                    type: object
+                  update:
+                    description: Update defines the policy to update target resource.
+                    properties:
+                      resizePendingPeriod:
+                        description: |-
+                          Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                          Must be greater than 0 and less than or equal to 3600 (1 hour).
+                        format: int32
+                        maximum: 3600
+                        minimum: 1
+                        type: integer
+                      rolloutFallbackDelay:
+                        description: |-
+                          Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                          Must be greater than 0 and less than or equal to 3600 (1 hour).
+                        format: int32
+                        maximum: 3600
+                        minimum: 1
+                        type: integer
+                      strategy:
+                        description: Strategy defines the mode of the update policy.
+                        enum:
+                        - Auto
+                        - Disabled
+                        - TriggerRollout
+                        type: string
+                    type: object
+                  upscale:
+                    description: Upscale defines the policy to scale up the target
+                      resource.
+                    properties:
+                      rules:
+                        description: |-
+                          Rules is a list of potential scaling polices which can be used during scaling.
+                          At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                        items:
+                          description: DatadogPodAutoscalerScalingRule defines rules
+                            for horizontal scaling that should be true for a certain
+                            amount of time.
+                          properties:
+                            periodSeconds:
+                              description: |-
+                                PeriodSeconds specifies the window of time for which the policy should hold true.
+                                PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            type:
+                              description: Type is used to specify the scaling policy.
+                              enum:
+                              - Pods
+                              - Percent
+                              type: string
+                            value:
+                              description: |-
+                                Value contains the amount of change which is permitted by the policy.
+                                Setting it to 0 will prevent any scaling in this direction.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          required:
+                          - periodSeconds
+                          - type
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      stabilizationWindowSeconds:
+                        description: |-
+                          StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                          before deciding to apply a new one. Defaults to 0.
+                        format: int32
+                        maximum: 3600
+                        minimum: 0
+                        type: integer
+                      strategy:
+                        description: |-
+                          Strategy is used to specify which policy should be used.
+                          If not set, the default value Max is used.
+                        enum:
+                        - Max
+                        - Min
+                        - Disabled
+                        type: string
+                    type: object
+                type: object
+              remoteVersion:
+                description: |-
+                  RemoteVersion is the version of the .Spec currently store in this object.
+                  Only set if the owner is Remote.
+                format: int64
+                type: integer
+              targetRef:
+                description: TargetRef is the reference to the resource to scale.
+                properties:
+                  apiVersion:
+                    description: apiVersion is the API version of the referent
+                    type: string
+                  kind:
+                    description: 'kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              targets:
+                description: |-
+                  Targets are objectives to reach and maintain for the target resource.
+                  Default to a single target to maintain 80% POD CPU utilization.
+                items:
+                  description: DatadogPodAutoscalerObjective defines the objectives
+                    to reach and maintain for the target workload.
+                  properties:
+                    containerResource:
+                      description: ContainerResource allows to set a container-level
+                        resource objective.
+                      properties:
+                        container:
+                          description: Container is the name of the container.
+                          type: string
+                        name:
+                          description: Name is the name of the resource.
+                          enum:
+                          - cpu
+                          - memory
+                          type: string
+                        value:
+                          description: Value is the value of the objective
+                          properties:
+                            absoluteValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                Use a plain number (e.g., "11" or "11.5").
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: 'Type specifies how the value is expressed
+                                (possible values: Utilization, AbsoluteValue).'
+                              enum:
+                              - Utilization
+                              - AbsoluteValue
+                              type: string
+                            utilization:
+                              description: Utilization defines a percentage of the
+                                target compared to requested workload
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - container
+                      - name
+                      - value
+                      type: object
+                    customQuery:
+                      description: CustomQuery allows to set a controller-level objective.
+                      properties:
+                        request:
+                          description: Request is the timeseries query to use for
+                            the objective.
+                          properties:
+                            formula:
+                              description: Formula to compute (optional).
+                              type: string
+                            queries:
+                              description: |-
+                                Queries is a list of timeseries queries to use for the objective.
+                                At least one query must be specified
+                              items:
+                                description: TimeseriesQuery is a discriminated union.
+                                  Only Metrics and APMMetrics are supported for autoscaling.
+                                properties:
+                                  apmMetrics:
+                                    description: ApmMetrics is allows to query APM
+                                      metrics.
+                                    properties:
+                                      groupBy:
+                                        description: GroupBy is the list of tags to
+                                          group by.
+                                        items:
+                                          type: string
+                                        type: array
+                                      operationName:
+                                        description: OperationName is the name of
+                                          the operation to query.
+                                        type: string
+                                      queryFilter:
+                                        description: QueryFilter is the filter to
+                                          apply to the query.
+                                        type: string
+                                      resourceHash:
+                                        description: ResourceHash is a fingerprint
+                                          of the resource name that can be used to
+                                          identify the resource instead of the resource
+                                          name.
+                                        type: string
+                                      resourceName:
+                                        description: ResourceName is the name of the
+                                          resource to query.
+                                        type: string
+                                      service:
+                                        description: Service is the name of the service
+                                          to query.
+                                        type: string
+                                      spanKind:
+                                        description: SpanKind is the kind of span
+                                          to query.
+                                        type: string
+                                      stat:
+                                        description: Stat defines the statistic to
+                                          compute for the APM metrics query.
+                                        enum:
+                                        - error_rate
+                                        - errors
+                                        - errors_per_second
+                                        - hits
+                                        - hits_per_second
+                                        - apdex
+                                        - latency_avg
+                                        - latency_max
+                                        - latency_p50
+                                        - latency_p75
+                                        - latency_p90
+                                        - latency_p95
+                                        - latency_p99
+                                        - latency_p999
+                                        - latency_distribution
+                                        - total_time
+                                        type: string
+                                    required:
+                                    - stat
+                                    type: object
+                                  metrics:
+                                    description: Metrics is a standard Datadog metrics
+                                      query.
+                                    properties:
+                                      query:
+                                        description: Classic Datadog metrics query,
+                                          e.g. "avg:system.cpu.user{*} by {env}".
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - query
+                                    type: object
+                                  name:
+                                    description: Optional variable name ("a", "b",
+                                      etc.) to reference in formulas.
+                                    type: string
+                                  source:
+                                    description: Source defines the source of the
+                                      timeseries query.
+                                    enum:
+                                    - Metrics
+                                    - ApmMetrics
+                                    type: string
+                                required:
+                                - source
+                                type: object
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - queries
+                          type: object
+                        value:
+                          description: Value is the value of the objective
+                          properties:
+                            absoluteValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                Use a plain number (e.g., "11" or "11.5").
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: 'Type specifies how the value is expressed
+                                (possible values: Utilization, AbsoluteValue).'
+                              enum:
+                              - Utilization
+                              - AbsoluteValue
+                              type: string
+                            utilization:
+                              description: Utilization defines a percentage of the
+                                target compared to requested workload
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                          required:
+                          - type
+                          type: object
+                        window:
+                          description: Window is the time duration over which the
+                            query is computed. It should contain at least one full
+                            sample.
+                          type: string
+                      required:
+                      - request
+                      - value
+                      - window
+                      type: object
+                    podResource:
+                      description: PodResource allows to set a pod-level resource
+                        objective.
+                      properties:
+                        name:
+                          description: Name is the name of the resource.
+                          enum:
+                          - cpu
+                          - memory
+                          type: string
+                        value:
+                          description: Value is the value of the objective.
+                          properties:
+                            absoluteValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                Use a plain number (e.g., "11" or "11.5").
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: 'Type specifies how the value is expressed
+                                (possible values: Utilization, AbsoluteValue).'
+                              enum:
+                              - Utilization
+                              - AbsoluteValue
+                              type: string
+                            utilization:
+                              description: Utilization defines a percentage of the
+                                target compared to requested workload
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type:
+                      description: Type sets the type of the objective.
+                      enum:
+                      - PodResource
+                      - ContainerResource
+                      - CustomQuery
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - owner
+            - targetRef
+            type: object
+          status:
+            description: DatadogPodAutoscalerStatus defines the observed state of
+              DatadogPodAutoscaler
+            properties:
+              conditions:
+                description: Conditions describe the current state of the DatadogPodAutoscaler
+                  operations.
+                items:
+                  description: DatadogPodAutoscalerCondition describes the state of
+                    DatadogPodAutoscaler.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: DatadogPodAutoscalerConditionType is the type of
+                        DatadogPodAutoscaler condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentReplicas:
+                description: CurrentReplicas is the current number of pods for the
+                  targetRef observed by the controller.
+                format: int32
+                type: integer
+              horizontal:
+                description: Horizontal is the status of the horizontal scaling, if
+                  activated.
+                properties:
+                  lastActions:
+                    description: LastActions are the last successful actions done
+                      by the controller
+                    items:
+                      description: DatadogPodAutoscalerHorizontalAction represents
+                        a horizontal action done by the controller
+                      properties:
+                        limitedReason:
+                          description: LimitedReason is the reason why the action
+                            was limited (that is ToReplicas != RecommendedReplicas)
+                          type: string
+                        recommendedReplicas:
+                          description: RecommendedReplicas is the original number
+                            of replicas recommended by Datadog
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: FromReplicas is the number of replicas before
+                            the action
+                          format: int32
+                          type: integer
+                        time:
+                          description: Time is the timestamp of the action
+                          format: date-time
+                          type: string
+                        toReplicas:
+                          description: ToReplicas is the effective number of replicas
+                            after the action
+                          format: int32
+                          type: integer
+                      required:
+                      - replicas
+                      - time
+                      - toReplicas
+                      type: object
+                    type: array
+                  lastRecommendations:
+                    description: LastRecommendations stores the most recent recommendations
+                    items:
+                      description: DatadogPodAutoscalerHorizontalRecommendation defines
+                        a horizontal scaling recommendation
+                      properties:
+                        desiredReplicas:
+                          description: Replicas is the recommended number of replicas
+                            for the workload
+                          format: int32
+                          type: integer
+                        generatedAt:
+                          description: GeneratedAt is the timestamp at which the recommendation
+                            was generated
+                          format: date-time
+                          type: string
+                        source:
+                          description: Source is the source of the value used to scale
+                            the target workload
+                          type: string
+                      required:
+                      - desiredReplicas
+                      type: object
+                    type: array
+                  target:
+                    description: Target is the current target of the horizontal scaling
+                    properties:
+                      desiredReplicas:
+                        description: Replicas is the recommended number of replicas
+                          for the workload
+                        format: int32
+                        type: integer
+                      generatedAt:
+                        description: GeneratedAt is the timestamp at which the recommendation
+                          was generated
+                        format: date-time
+                        type: string
+                      source:
+                        description: Source is the source of the value used to scale
+                          the target workload
+                        type: string
+                    required:
+                    - desiredReplicas
+                    type: object
+                type: object
+              options:
+                description: Options reflects the effective options applied by the
+                  autoscaler.
+                properties:
+                  burstable:
+                    description: |-
+                      Burstable is the effective value of the burstable setting applied by the autoscaler.
+                      When not set in the spec, this reflects the default determined by the Cluster Agent
+                      setting autoscaling.workload.options.burstable.
+                    type: boolean
+                type: object
+              vertical:
+                description: Vertical is the status of the vertical scaling, if activated.
+                properties:
+                  lastAction:
+                    description: LastAction is the last successful action done by
+                      the controller
+                    properties:
+                      time:
+                        description: Time is the timestamp of the action
+                        format: date-time
+                        type: string
+                      type:
+                        description: Type is the type of action
+                        type: string
+                      version:
+                        description: Version is the version of the recommendation
+                          used for the action
+                        type: string
+                    required:
+                    - time
+                    - type
+                    - version
+                    type: object
+                  target:
+                    description: Target is the current target of the vertical scaling
+                    properties:
+                      desiredResources:
+                        description: DesiredResources is the desired resources for
+                          containers
+                        items:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Limits describes the maximum amount of
+                                compute resources allowed.
+                              type: object
+                            name:
+                              description: Name is the name of the container
+                              type: string
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the requested amount
+                                of compute resources.
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      evicted:
+                        description: |-
+                          Evicted is the number of pods evicted as an in-place resize fallback during the
+                          current recommendation cycle. Resets when the recommendation changes.
+                        format: int32
+                        type: integer
+                      generatedAt:
+                        description: GeneratedAt is the timestamp at which the recommendation
+                          was generated
+                        format: date-time
+                        type: string
+                      podCPURequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: PodCPURequest is the sum of CPU requests for
+                          all containers (used for display)
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      podMemoryRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: PodMemoryRequest is the sum of memory requests
+                          for all containers (used for display)
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      scaled:
+                        description: Scaled is the current number of pods having desired
+                          resources
+                        format: int32
+                        type: integer
+                      source:
+                        description: Source is the source of the value used to scale
+                          the target resource
+                        type: string
+                      version:
+                        description: Version is the current version of the received
+                          recommendation
+                        type: string
+                    required:
+                    - desiredResources
+                    - podCPURequest
+                    - podMemoryRequest
+                    - source
+                    - version
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.applyPolicy.mode
+      name: Apply Mode
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Active')].status
+      name: Active
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Error')].status
+      name: In Error
+      type: string
+    - jsonPath: .status.horizontal.target.desiredReplicas
+      name: Desired Replicas
+      type: integer
+    - jsonPath: .status.horizontal.target.generatedAt
+      name: Generated
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='HorizontalAbleToScale')].status
+      name: Able to Scale
+      type: string
+    - jsonPath: .status.horizontal.lastAction.time
+      name: Last Scale
+      type: date
+    - jsonPath: .status.vertical.target.podCPURequest
+      name: Target CPU Req
+      type: string
+    - jsonPath: .status.vertical.target.podMemoryRequest
+      name: Target Memory Req
+      type: string
+    - jsonPath: .status.vertical.target.generatedAt
+      name: Generated
+      type: date
+    - jsonPath: .status.conditions[?(@.type=='VerticalAbleToApply')].status
+      name: Able to Apply
+      type: string
+    - jsonPath: .status.vertical.lastAction.time
+      name: Last Trigger
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: DatadogPodAutoscaler is the Schema for the datadogpodautoscalers
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatadogPodAutoscalerSpec defines the desired state of DatadogPodAutoscaler
+            properties:
+              applyPolicy:
+                default: {}
+                description: ApplyPolicy defines how recommendations should be applied.
+                properties:
+                  mode:
+                    default: Apply
+                    description: |-
+                      Mode determines recommendations that should be applied by the controller:
+                      - Apply: Apply all recommendations.
+                      - Preview: Recommendations are received and visible through .Status, but the controller does not apply them.
+                      It's also possible to selectively deactivate upscale, downscale or update actions thanks to the `ScaleUp`, `ScaleDown` and `Update` fields.
+                    enum:
+                    - Apply
+                    - Preview
+                    type: string
+                  scaleDown:
+                    description: ScaleDown defines the policy to scale down the target
+                      resource.
+                    properties:
+                      rules:
+                        description: |-
+                          Rules is a list of potential scaling polices which can be used during scaling.
+                          At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                        items:
+                          description: DatadogPodAutoscalerScalingRule defines rules
+                            for horizontal scaling that should be true for a certain
+                            amount of time.
+                          properties:
+                            periodSeconds:
+                              description: |-
+                                PeriodSeconds specifies the window of time for which the policy should hold true.
+                                PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            type:
+                              description: Type is used to specify the scaling policy.
+                              enum:
+                              - Pods
+                              - Percent
+                              type: string
+                            value:
+                              description: |-
+                                Value contains the amount of change which is permitted by the policy.
+                                Setting it to 0 will prevent any scaling in this direction.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          required:
+                          - periodSeconds
+                          - type
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      stabilizationWindowSeconds:
+                        description: |-
+                          StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                          before deciding to apply a new one. Defaults to 0.
+                        format: int32
+                        maximum: 3600
+                        minimum: 0
+                        type: integer
+                      strategy:
+                        description: |-
+                          Strategy is used to specify which policy should be used.
+                          If not set, the default value Max is used.
+                        enum:
+                        - Max
+                        - Min
+                        - Disabled
+                        type: string
+                    type: object
+                  scaleUp:
+                    description: ScaleUp defines the policy to scale up the target
+                      resource.
+                    properties:
+                      rules:
+                        description: |-
+                          Rules is a list of potential scaling polices which can be used during scaling.
+                          At least one policy must be specified, otherwise the DatadogPodAutoscalerScalingPolicy will be discarded as invalid
+                        items:
+                          description: DatadogPodAutoscalerScalingRule defines rules
+                            for horizontal scaling that should be true for a certain
+                            amount of time.
+                          properties:
+                            periodSeconds:
+                              description: |-
+                                PeriodSeconds specifies the window of time for which the policy should hold true.
+                                PeriodSeconds must be greater than zero and less than or equal to 3600 (1 hour).
+                              format: int32
+                              maximum: 3600
+                              minimum: 1
+                              type: integer
+                            type:
+                              description: Type is used to specify the scaling policy.
+                              enum:
+                              - Pods
+                              - Percent
+                              type: string
+                            value:
+                              description: |-
+                                Value contains the amount of change which is permitted by the policy.
+                                Setting it to 0 will prevent any scaling in this direction.
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          required:
+                          - periodSeconds
+                          - type
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      stabilizationWindowSeconds:
+                        description: |-
+                          StabilizationWindowSeconds is the number of seconds the controller should lookback at previous recommendations
+                          before deciding to apply a new one. Defaults to 0.
+                        format: int32
+                        maximum: 3600
+                        minimum: 0
+                        type: integer
+                      strategy:
+                        description: |-
+                          Strategy is used to specify which policy should be used.
+                          If not set, the default value Max is used.
+                        enum:
+                        - Max
+                        - Min
+                        - Disabled
+                        type: string
+                    type: object
+                  update:
+                    description: Update defines the policy for updating the target
+                      resource.
+                    properties:
+                      resizePendingPeriod:
+                        description: |-
+                          Controls how long we wait before forcing an eviction when the kubelet reports a resize as pending.
+                          Must be greater than 0 and less than or equal to 3600 (1 hour).
+                        format: int32
+                        maximum: 3600
+                        minimum: 1
+                        type: integer
+                      rolloutFallbackDelay:
+                        description: |-
+                          Controls how long we wait before falling back to a full rollout when evictions are blocked.
+                          Must be greater than 0 and less than or equal to 3600 (1 hour).
+                        format: int32
+                        maximum: 3600
+                        minimum: 1
+                        type: integer
+                      strategy:
+                        description: Strategy defines the mode of the update policy.
+                        enum:
+                        - Auto
+                        - Disabled
+                        - TriggerRollout
+                        type: string
+                    type: object
+                type: object
+              constraints:
+                description: Constraints defines constraints that should always be
+                  respected.
+                properties:
+                  containers:
+                    description: Containers defines constraints for the containers.
+                    items:
+                      description: |-
+                        DatadogPodAutoscalerContainerConstraints defines constraints that should always be respected for a container.
+                        If no constraints are set, it enables resource scaling for all containers without any constraints.
+                      properties:
+                        controlledResources:
+                          description: |-
+                            Specifies the resources for which recommendations will be computed.
+                            If not specified, it defaults to CPU and Memory.
+                            If an empty list is provided, no resource will be controlled (equivalent to Enabled=false).
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                        controlledValues:
+                          description: |-
+                            Specifies whether recommendations are made to Requests and Limits (RequestsAndLimits) or Requests only (RequestsOnly).
+                            The default is "RequestsAndLimits".
+                          enum:
+                          - RequestsAndLimits
+                          - RequestsOnly
+                          - CPURequestsRemoveLimitsMemoryRequestsAndLimits
+                          type: string
+                        enabled:
+                          description: Enabled, if false, allows one to disable resource
+                            autoscaling for the container. Defaults to true.
+                          type: boolean
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: MaxAllowed is the upper limit for the requests
+                            of the container.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: MinAllowed is the lower limit for the requests
+                            of the container.
+                          type: object
+                        name:
+                          description: Name is the name of the container. Can be "*"
+                            to apply to all containers.
+                          type: string
+                        requests:
+                          description: |-
+                            Requests defines the constraints for the requests of the container.
+                            WARNING: Deprecated
+                          properties:
+                            maxAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: MaxAllowed is the upper limit for the requests
+                                of the container.
+                              type: object
+                            minAllowed:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: MinAllowed is the lower limit for the requests
+                                of the container.
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  maxReplicas:
+                    description: MaxReplicas is the upper limit for the number of
+                      POD replicas. Needs to be >= minReplicas.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  minReplicas:
+                    description: MinReplicas is the lower limit for the number of
+                      pod replicas. Needs to be >= 1. Defaults to 1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+              fallback:
+                default: {}
+                description: Fallback defines how recommendations should be applied
+                  when in fallback mode.
+                properties:
+                  horizontal:
+                    default: {}
+                    description: Horizontal configures the behavior during horizontal
+                      fallback mode.
+                    properties:
+                      direction:
+                        default: ScaleUp
+                        description: Direction determines the direction that recommendations
+                          should be applied.
+                        enum:
+                        - ScaleUp
+                        - ScaleDown
+                        - All
+                        type: string
+                      enabled:
+                        default: true
+                        description: 'Enabled determines whether recommendations should
+                          be applied by the controller:'
+                        type: boolean
+                      objectives:
+                        description: |-
+                          Objectives are the objectives to reach and maintain for the target resource in fallback mode.
+                          If not set, the regular objectives will be used.
+                        items:
+                          description: DatadogPodAutoscalerObjective defines the objectives
+                            to reach and maintain for the target workload.
+                          properties:
+                            containerResource:
+                              description: ContainerResource allows to set a container-level
+                                resource objective.
+                              properties:
+                                container:
+                                  description: Container is the name of the container.
+                                  type: string
+                                name:
+                                  description: Name is the name of the resource.
+                                  enum:
+                                  - cpu
+                                  - memory
+                                  type: string
+                                value:
+                                  description: Value is the value of the objective
+                                  properties:
+                                    absoluteValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                        Use a plain number (e.g., "11" or "11.5").
+                                        Represented as a resource.Quantity to avoid floating point in CRDs.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: 'Type specifies how the value is
+                                        expressed (possible values: Utilization, AbsoluteValue).'
+                                      enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                      type: string
+                                    utilization:
+                                      description: Utilization defines a percentage
+                                        of the target compared to requested workload
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - container
+                              - name
+                              - value
+                              type: object
+                            customQuery:
+                              description: CustomQuery allows to set a controller-level
+                                objective.
+                              properties:
+                                request:
+                                  description: Request is the timeseries query to
+                                    use for the objective.
+                                  properties:
+                                    formula:
+                                      description: Formula to compute (optional).
+                                      type: string
+                                    queries:
+                                      description: |-
+                                        Queries is a list of timeseries queries to use for the objective.
+                                        At least one query must be specified
+                                      items:
+                                        description: TimeseriesQuery is a discriminated
+                                          union. Only Metrics and APMMetrics are supported
+                                          for autoscaling.
+                                        properties:
+                                          apmMetrics:
+                                            description: ApmMetrics is allows to query
+                                              APM metrics.
+                                            properties:
+                                              groupBy:
+                                                description: GroupBy is the list of
+                                                  tags to group by.
+                                                items:
+                                                  type: string
+                                                type: array
+                                              operationName:
+                                                description: OperationName is the
+                                                  name of the operation to query.
+                                                type: string
+                                              queryFilter:
+                                                description: QueryFilter is the filter
+                                                  to apply to the query.
+                                                type: string
+                                              resourceHash:
+                                                description: ResourceHash is a fingerprint
+                                                  of the resource name that can be
+                                                  used to identify the resource instead
+                                                  of the resource name.
+                                                type: string
+                                              resourceName:
+                                                description: ResourceName is the name
+                                                  of the resource to query.
+                                                type: string
+                                              service:
+                                                description: Service is the name of
+                                                  the service to query.
+                                                type: string
+                                              spanKind:
+                                                description: SpanKind is the kind
+                                                  of span to query.
+                                                type: string
+                                              stat:
+                                                description: Stat defines the statistic
+                                                  to compute for the APM metrics query.
+                                                enum:
+                                                - error_rate
+                                                - errors
+                                                - errors_per_second
+                                                - hits
+                                                - hits_per_second
+                                                - apdex
+                                                - latency_avg
+                                                - latency_max
+                                                - latency_p50
+                                                - latency_p75
+                                                - latency_p90
+                                                - latency_p95
+                                                - latency_p99
+                                                - latency_p999
+                                                - latency_distribution
+                                                - total_time
+                                                type: string
+                                            required:
+                                            - stat
+                                            type: object
+                                          metrics:
+                                            description: Metrics is a standard Datadog
+                                              metrics query.
+                                            properties:
+                                              query:
+                                                description: Classic Datadog metrics
+                                                  query, e.g. "avg:system.cpu.user{*}
+                                                  by {env}".
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - query
+                                            type: object
+                                          name:
+                                            description: Optional variable name ("a",
+                                              "b", etc.) to reference in formulas.
+                                            type: string
+                                          source:
+                                            description: Source defines the source
+                                              of the timeseries query.
+                                            enum:
+                                            - Metrics
+                                            - ApmMetrics
+                                            type: string
+                                        required:
+                                        - source
+                                        type: object
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - queries
+                                  type: object
+                                value:
+                                  description: Value is the value of the objective
+                                  properties:
+                                    absoluteValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                        Use a plain number (e.g., "11" or "11.5").
+                                        Represented as a resource.Quantity to avoid floating point in CRDs.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: 'Type specifies how the value is
+                                        expressed (possible values: Utilization, AbsoluteValue).'
+                                      enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                      type: string
+                                    utilization:
+                                      description: Utilization defines a percentage
+                                        of the target compared to requested workload
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - type
+                                  type: object
+                                window:
+                                  description: Window is the time duration over which
+                                    the query is computed. It should contain at least
+                                    one full sample.
+                                  type: string
+                              required:
+                              - request
+                              - value
+                              - window
+                              type: object
+                            podResource:
+                              description: PodResource allows to set a pod-level resource
+                                objective.
+                              properties:
+                                name:
+                                  description: Name is the name of the resource.
+                                  enum:
+                                  - cpu
+                                  - memory
+                                  type: string
+                                value:
+                                  description: Value is the value of the objective.
+                                  properties:
+                                    absoluteValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                        Use a plain number (e.g., "11" or "11.5").
+                                        Represented as a resource.Quantity to avoid floating point in CRDs.
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: 'Type specifies how the value is
+                                        expressed (possible values: Utilization, AbsoluteValue).'
+                                      enum:
+                                      - Utilization
+                                      - AbsoluteValue
+                                      type: string
+                                    utilization:
+                                      description: Utilization defines a percentage
+                                        of the target compared to requested workload
+                                      format: int32
+                                      maximum: 100
+                                      minimum: 0
+                                      type: integer
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type:
+                              description: Type sets the type of the objective.
+                              enum:
+                              - PodResource
+                              - ContainerResource
+                              - CustomQuery
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      triggers:
+                        default: {}
+                        description: Triggers defines the triggers that will generate
+                          recommendations.
+                        properties:
+                          staleRecommendationThresholdSeconds:
+                            default: 600
+                            description: StaleRecommendationThresholdSeconds defines
+                              the time window the controller will wait after detecting
+                              an error before applying recommendations.
+                            format: int32
+                            maximum: 3600
+                            minimum: 100
+                            type: integer
+                        type: object
+                    type: object
+                type: object
+              objectives:
+                description: |-
+                  Objectives are the objectives to reach and maintain for the target resource.
+                  Default to a single objective to maintain 80% POD CPU utilization.
+                items:
+                  description: DatadogPodAutoscalerObjective defines the objectives
+                    to reach and maintain for the target workload.
+                  properties:
+                    containerResource:
+                      description: ContainerResource allows to set a container-level
+                        resource objective.
+                      properties:
+                        container:
+                          description: Container is the name of the container.
+                          type: string
+                        name:
+                          description: Name is the name of the resource.
+                          enum:
+                          - cpu
+                          - memory
+                          type: string
+                        value:
+                          description: Value is the value of the objective
+                          properties:
+                            absoluteValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                Use a plain number (e.g., "11" or "11.5").
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: 'Type specifies how the value is expressed
+                                (possible values: Utilization, AbsoluteValue).'
+                              enum:
+                              - Utilization
+                              - AbsoluteValue
+                              type: string
+                            utilization:
+                              description: Utilization defines a percentage of the
+                                target compared to requested workload
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - container
+                      - name
+                      - value
+                      type: object
+                    customQuery:
+                      description: CustomQuery allows to set a controller-level objective.
+                      properties:
+                        request:
+                          description: Request is the timeseries query to use for
+                            the objective.
+                          properties:
+                            formula:
+                              description: Formula to compute (optional).
+                              type: string
+                            queries:
+                              description: |-
+                                Queries is a list of timeseries queries to use for the objective.
+                                At least one query must be specified
+                              items:
+                                description: TimeseriesQuery is a discriminated union.
+                                  Only Metrics and APMMetrics are supported for autoscaling.
+                                properties:
+                                  apmMetrics:
+                                    description: ApmMetrics is allows to query APM
+                                      metrics.
+                                    properties:
+                                      groupBy:
+                                        description: GroupBy is the list of tags to
+                                          group by.
+                                        items:
+                                          type: string
+                                        type: array
+                                      operationName:
+                                        description: OperationName is the name of
+                                          the operation to query.
+                                        type: string
+                                      queryFilter:
+                                        description: QueryFilter is the filter to
+                                          apply to the query.
+                                        type: string
+                                      resourceHash:
+                                        description: ResourceHash is a fingerprint
+                                          of the resource name that can be used to
+                                          identify the resource instead of the resource
+                                          name.
+                                        type: string
+                                      resourceName:
+                                        description: ResourceName is the name of the
+                                          resource to query.
+                                        type: string
+                                      service:
+                                        description: Service is the name of the service
+                                          to query.
+                                        type: string
+                                      spanKind:
+                                        description: SpanKind is the kind of span
+                                          to query.
+                                        type: string
+                                      stat:
+                                        description: Stat defines the statistic to
+                                          compute for the APM metrics query.
+                                        enum:
+                                        - error_rate
+                                        - errors
+                                        - errors_per_second
+                                        - hits
+                                        - hits_per_second
+                                        - apdex
+                                        - latency_avg
+                                        - latency_max
+                                        - latency_p50
+                                        - latency_p75
+                                        - latency_p90
+                                        - latency_p95
+                                        - latency_p99
+                                        - latency_p999
+                                        - latency_distribution
+                                        - total_time
+                                        type: string
+                                    required:
+                                    - stat
+                                    type: object
+                                  metrics:
+                                    description: Metrics is a standard Datadog metrics
+                                      query.
+                                    properties:
+                                      query:
+                                        description: Classic Datadog metrics query,
+                                          e.g. "avg:system.cpu.user{*} by {env}".
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - query
+                                    type: object
+                                  name:
+                                    description: Optional variable name ("a", "b",
+                                      etc.) to reference in formulas.
+                                    type: string
+                                  source:
+                                    description: Source defines the source of the
+                                      timeseries query.
+                                    enum:
+                                    - Metrics
+                                    - ApmMetrics
+                                    type: string
+                                required:
+                                - source
+                                type: object
+                              minItems: 1
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - queries
+                          type: object
+                        value:
+                          description: Value is the value of the objective
+                          properties:
+                            absoluteValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                Use a plain number (e.g., "11" or "11.5").
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: 'Type specifies how the value is expressed
+                                (possible values: Utilization, AbsoluteValue).'
+                              enum:
+                              - Utilization
+                              - AbsoluteValue
+                              type: string
+                            utilization:
+                              description: Utilization defines a percentage of the
+                                target compared to requested workload
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                          required:
+                          - type
+                          type: object
+                        window:
+                          description: Window is the time duration over which the
+                            query is computed. It should contain at least one full
+                            sample.
+                          type: string
+                      required:
+                      - request
+                      - value
+                      - window
+                      type: object
+                    podResource:
+                      description: PodResource allows to set a pod-level resource
+                        objective.
+                      properties:
+                        name:
+                          description: Name is the name of the resource.
+                          enum:
+                          - cpu
+                          - memory
+                          type: string
+                        value:
+                          description: Value is the value of the objective.
+                          properties:
+                            absoluteValue:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                AbsoluteValue defines a target as an absolute value divided by the number of running pods.
+                                Use a plain number (e.g., "11" or "11.5").
+                                Represented as a resource.Quantity to avoid floating point in CRDs.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            type:
+                              description: 'Type specifies how the value is expressed
+                                (possible values: Utilization, AbsoluteValue).'
+                              enum:
+                              - Utilization
+                              - AbsoluteValue
+                              type: string
+                            utilization:
+                              description: Utilization defines a percentage of the
+                                target compared to requested workload
+                              format: int32
+                              maximum: 100
+                              minimum: 0
+                              type: integer
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type:
+                      description: Type sets the type of the objective.
+                      enum:
+                      - PodResource
+                      - ContainerResource
+                      - CustomQuery
+                      type: string
+                  required:
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              options:
+                description: Options defines optional behavior modifications for the
+                  autoscaler.
+                properties:
+                  burstable:
+                    description: |-
+                      Burstable, if true, removes CPU limits from containers while keeping CPU request recommendations,
+                      granting the pod a Burstable QoS class and allowing it to consume idle node CPU capacity beyond its requests.
+                      If not set, the default value is determined by the Cluster Agent setting autoscaling.workload.options.burstable.
+                    type: boolean
+                  outOfMemory:
+                    description: OutOfMemory configures behavior when OOM events are
+                      detected.
+                    properties:
+                      bumpUpRatio:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          BumpUpRatio defines the ratio to multiply memory by when OOM is detected.
+                          For example, "1.2" means increase memory by 20%.
+                          Represented as a resource.Quantity to avoid floating point in CRDs.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                type: object
+              owner:
+                description: |-
+                  Owner defines the source of truth for this object (local or remote).
+                  Value must be set when a DatadogPodAutoscaler object is created.
+                enum:
+                - Local
+                - Remote
+                type: string
+              remoteVersion:
+                description: |-
+                  RemoteVersion is the version of the .Spec currently stored in this object.
+                  This is only set if the owner is Remote.
+                format: int64
+                type: integer
+              targetRef:
+                description: TargetRef is the reference to the resource to scale.
+                properties:
+                  apiVersion:
+                    description: apiVersion is the API version of the referent
+                    type: string
+                  kind:
+                    description: 'kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+            required:
+            - owner
+            - targetRef
+            type: object
+          status:
+            description: DatadogPodAutoscalerStatus defines the observed state of
+              DatadogPodAutoscaler
+            properties:
+              conditions:
+                description: Conditions describe the current state of the DatadogPodAutoscaler
+                  operations.
+                items:
+                  description: DatadogPodAutoscalerCondition describes the state of
+                    DatadogPodAutoscaler.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: DatadogPodAutoscalerConditionType is the type of
+                        DatadogPodAutoscaler condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentReplicas:
+                description: CurrentReplicas is the current number of pods for the
+                  targetRef observed by the controller.
+                format: int32
+                type: integer
+              horizontal:
+                description: Horizontal is the status of the horizontal scaling, if
+                  activated.
+                properties:
+                  lastActions:
+                    description: LastActions are the last successful actions done
+                      by the controller
+                    items:
+                      description: DatadogPodAutoscalerHorizontalAction represents
+                        a horizontal action done by the controller
+                      properties:
+                        limitedReason:
+                          description: LimitedReason is the reason why the action
+                            was limited (that is ToReplicas != RecommendedReplicas)
+                          type: string
+                        recommendedReplicas:
+                          description: RecommendedReplicas is the original number
+                            of replicas recommended by Datadog
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: FromReplicas is the number of replicas before
+                            the action
+                          format: int32
+                          type: integer
+                        time:
+                          description: Time is the timestamp of the action
+                          format: date-time
+                          type: string
+                        toReplicas:
+                          description: ToReplicas is the effective number of replicas
+                            after the action
+                          format: int32
+                          type: integer
+                      required:
+                      - replicas
+                      - time
+                      - toReplicas
+                      type: object
+                    type: array
+                  lastRecommendations:
+                    description: LastRecommendations stores the most recent recommendations
+                    items:
+                      description: DatadogPodAutoscalerHorizontalRecommendation defines
+                        a horizontal scaling recommendation
+                      properties:
+                        desiredReplicas:
+                          description: Replicas is the recommended number of replicas
+                            for the workload
+                          format: int32
+                          type: integer
+                        generatedAt:
+                          description: GeneratedAt is the timestamp at which the recommendation
+                            was generated
+                          format: date-time
+                          type: string
+                        source:
+                          description: Source is the source of the value used to scale
+                            the target workload
+                          type: string
+                      required:
+                      - desiredReplicas
+                      type: object
+                    type: array
+                  target:
+                    description: Target is the current target of the horizontal scaling
+                    properties:
+                      desiredReplicas:
+                        description: Replicas is the recommended number of replicas
+                          for the workload
+                        format: int32
+                        type: integer
+                      generatedAt:
+                        description: GeneratedAt is the timestamp at which the recommendation
+                          was generated
+                        format: date-time
+                        type: string
+                      source:
+                        description: Source is the source of the value used to scale
+                          the target workload
+                        type: string
+                    required:
+                    - desiredReplicas
+                    type: object
+                type: object
+              options:
+                description: Options reflects the effective options applied by the
+                  autoscaler.
+                properties:
+                  burstable:
+                    description: |-
+                      Burstable is the effective value of the burstable setting applied by the autoscaler.
+                      When not set in the spec, this reflects the default determined by the Cluster Agent
+                      setting autoscaling.workload.options.burstable.
+                    type: boolean
+                type: object
+              vertical:
+                description: Vertical is the status of the vertical scaling, if activated.
+                properties:
+                  lastAction:
+                    description: LastAction is the last successful action done by
+                      the controller
+                    properties:
+                      time:
+                        description: Time is the timestamp of the action
+                        format: date-time
+                        type: string
+                      type:
+                        description: Type is the type of action
+                        type: string
+                      version:
+                        description: Version is the version of the recommendation
+                          used for the action
+                        type: string
+                    required:
+                    - time
+                    - type
+                    - version
+                    type: object
+                  target:
+                    description: Target is the current target of the vertical scaling
+                    properties:
+                      desiredResources:
+                        description: DesiredResources is the desired resources for
+                          containers
+                        items:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Limits describes the maximum amount of
+                                compute resources allowed.
+                              type: object
+                            name:
+                              description: Name is the name of the container
+                              type: string
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Requests describes the requested amount
+                                of compute resources.
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      evicted:
+                        description: |-
+                          Evicted is the number of pods evicted as an in-place resize fallback during the
+                          current recommendation cycle. Resets when the recommendation changes.
+                        format: int32
+                        type: integer
+                      generatedAt:
+                        description: GeneratedAt is the timestamp at which the recommendation
+                          was generated
+                        format: date-time
+                        type: string
+                      podCPURequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: PodCPURequest is the sum of CPU requests for
+                          all containers (used for display)
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      podMemoryRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: PodMemoryRequest is the sum of memory requests
+                          for all containers (used for display)
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      scaled:
+                        description: Scaled is the current number of pods having desired
+                          resources
+                        format: int32
+                        type: integer
+                      source:
+                        description: Source is the source of the value used to scale
+                          the target resource
+                        type: string
+                      version:
+                        description: Version is the current version of the received
+                          recommendation
+                        type: string
+                    required:
+                    - desiredResources
+                    - podCPURequest
+                    - podMemoryRequest
+                    - source
+                    - version
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogslos.yaml
+++ b/operators/datadog-operator/1.29.0/manifests/datadoghq.com_datadogslos.yaml
@@ -1,0 +1,283 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  creationTimestamp: null
+  name: datadogslos.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: DatadogSLO
+    listKind: DatadogSLOList
+    plural: datadogslos
+    shortNames:
+    - ddslo
+    singular: datadogslo
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.id
+      name: id
+      type: string
+    - jsonPath: .status.syncStatus
+      name: sync status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DatadogSLO allows a user to define and manage datadog SLOs from
+          Kubernetes cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              controllerOptions:
+                description: ControllerOptions are the optional parameters in the
+                  DatadogSLO controller
+                properties:
+                  disableRequiredTags:
+                    description: DisableRequiredTags disables the automatic addition
+                      of required tags to SLOs.
+                    type: boolean
+                type: object
+              description:
+                description: |-
+                  Description is a user-defined description of the service level objective.
+                  Always included in service level objective responses (but may be null). Optional in create/update requests.
+                type: string
+              groups:
+                description: |-
+                  Groups is a list of (up to 100) monitor groups that narrow the scope of a monitor service level objective.
+                  Included in service level objective responses if it is not empty.
+                  Optional in create/update requests for monitor service level objectives, but may only be used when the length of the monitor_ids field is one.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              monitorIDs:
+                description: MonitorIDs is a list of monitor IDs that defines the
+                  scope of a monitor service level objective. Required if type is
+                  monitor.
+                items:
+                  format: int64
+                  type: integer
+                type: array
+                x-kubernetes-list-type: set
+              name:
+                description: Name is the name of the service level objective.
+                type: string
+              query:
+                description: |-
+                  Query is the query for a metric-based SLO. Required if type is metric.
+                  Note that only the `sum by` aggregator is allowed, which sums all request counts. `Average`, `max`, nor `min` request aggregators are not supported.
+                properties:
+                  denominator:
+                    description: Denominator is a Datadog metric query for total (valid)
+                      events.
+                    type: string
+                  numerator:
+                    description: Numerator is a Datadog metric query for good events.
+                    type: string
+                required:
+                - denominator
+                - numerator
+                type: object
+              tags:
+                description: |-
+                  Tags is a list of tags to associate with your service level objective.
+                  This can help you categorize and filter service level objectives in the service level objectives page of the UI.
+                  Note: it's not currently possible to filter by these tags when querying via the API.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              targetThreshold:
+                anyOf:
+                - type: integer
+                - type: string
+                description: TargetThreshold is the target threshold such that when
+                  the service level indicator is above this threshold over the given
+                  timeframe, the objective is being met.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              timeSlice:
+                description: |-
+                  TimeSlice defines the SLI specification for a time_slice SLO. Required if type is time_slice.
+                  It specifies a metric query and a comparator/threshold that determines what counts as good uptime.
+                properties:
+                  comparator:
+                    allOf:
+                    - enum:
+                      - '>'
+                      - '>='
+                      - <
+                      - <=
+                    - enum:
+                      - '>'
+                      - '>='
+                      - <
+                      - <=
+                    description: Comparator is the comparison operator used to compare
+                      the SLI value to the threshold.
+                    type: string
+                  query:
+                    description: Query is a Datadog metric query string that produces
+                      the SLI value.
+                    type: string
+                  threshold:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      Threshold is the value against which the SLI is compared using the comparator to determine
+                      if a time slice is good or bad.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                required:
+                - comparator
+                - query
+                - threshold
+                type: object
+              timeframe:
+                description: The SLO time window options.
+                type: string
+              type:
+                description: Type is the type of the service level objective.
+                type: string
+              warningThreshold:
+                anyOf:
+                - type: integer
+                - type: string
+                description: WarningThreshold is a optional warning threshold such
+                  that when the service level indicator is below this value for the
+                  given threshold, but above the target threshold, the objective appears
+                  in a "warning" state. This value must be greater than the target
+                  threshold.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+            required:
+            - name
+            - targetThreshold
+            - timeframe
+            - type
+            type: object
+          status:
+            description: DatadogSLOStatus defines the observed state of a DatadogSLO.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of the state of a DatadogSLO.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              created:
+                description: Created is the time the SLO was created.
+                format: date-time
+                type: string
+              creator:
+                description: Creator is the identity of the SLO creator.
+                type: string
+              currentHash:
+                description: |-
+                  CurrentHash tracks the hash of the current DatadogSLOSpec to know
+                  if the Spec has changed and needs an update.
+                type: string
+              id:
+                description: ID is the SLO ID generated in Datadog.
+                type: string
+              lastForceSyncTime:
+                description: LastForceSyncTime is the last time the API SLO was last
+                  force synced with the DatadogSLO resource.
+                format: date-time
+                type: string
+              syncStatus:
+                description: SyncStatus shows the health of syncing the SLO state
+                  to Datadog.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/datadog-operator/1.29.0/metadata/annotations.yaml
+++ b/operators/datadog-operator/1.29.0/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: datadog-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.6

--- a/operators/datadog-operator/1.29.0/tests/scorecard/config.yaml
+++ b/operators/datadog-operator/1.29.0/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Update operator datadog-operator (1.29.0).

Bundle taken from the [`v1.29.0` release tag](https://github.com/DataDog/datadog-operator/releases/tag/v1.29.0) of DataDog/datadog-operator.

Pull request created by minyi.zhu@datadoghq.com.