### PR TITLE
chore(ISV-7504): pin CI actions to SHA hash

### DIFF
--- a/.github/workflows/pr-label-command.yml
+++ b/.github/workflows/pr-label-command.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   comment-handler:
-    uses: redhat-openshift-ecosystem/github-workflows/.github/workflows/label-command.yml@main
+    uses: redhat-openshift-ecosystem/github-workflows/.github/workflows/label-command.yml@10ccef93d0efbbecf3bc9916512f6dcf5f0670c1  # main

--- a/.github/workflows/stale_issues.yaml
+++ b/.github/workflows/stale_issues.yaml
@@ -13,7 +13,7 @@ jobs:
   close-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93  # v11.0.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 30


### PR DESCRIPTION
Signed-off-by: Brian Lindner <blindner@redhat.com>
