### PR TITLE
operator dotvirt-operator (0.0.36)

### DIFF
--- a/operators/dotvirt-operator/0.0.36/manifests/dotvirt-argocd-apply_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/dotvirt-operator/0.0.36/manifests/dotvirt-argocd-apply_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,135 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: dotvirt-operator
+    app.kubernetes.io/name: dotvirt
+  name: dotvirt-argocd-apply
+rules:
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - userdefinednetworks
+  - clusteruserdefinednetworks
+  - egressfirewalls
+  - egressips
+  - adminpolicybasedexternalroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - policy.networking.k8s.io
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkconfigurationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - operatorgroups
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - kubedeschedulers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/operators/dotvirt-operator/0.0.36/manifests/dotvirt-operator.clusterserviceversion.yaml
+++ b/operators/dotvirt-operator/0.0.36/manifests/dotvirt-operator.clusterserviceversion.yaml
@@ -1,0 +1,449 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "dotvirt.io/v1alpha1",
+          "kind": "Dotvirt",
+          "metadata": {
+            "name": "dotvirt",
+            "namespace": "dotvirt"
+          },
+          "spec": {
+            "forge": {
+              "managed": true
+            },
+            "ingress": {
+              "type": "auto"
+            },
+            "metrics": {
+              "url": "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Developer Tools, Modernization & Migration
+    containerImage: quay.io/epheo/dotvirt-operator@sha256:72d240459ebb6afe36a208198462332013a0974d1c8e57d2b8203cd3fe02b4b8
+    createdAt: "2026-09-04T14:30:44Z"
+    description: Installs dotvirt, a GitOps web console for KubeVirt with a point-and-click workflow familiar to virtualization admins, plus its platform/tenant tier.
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "dotvirt.io/v1alpha1",
+        "kind": "Dotvirt",
+        "metadata": {
+          "name": "dotvirt",
+          "namespace": "dotvirt-operator"
+        },
+        "spec": {
+          "forge": {
+            "managed": true
+          },
+          "ingress": {
+            "type": "auto"
+          },
+          "metrics": {
+            "url": "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091"
+          }
+        }
+      }
+    operatorframework.io/suggested-namespace: dotvirt-operator
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/epheo/dotvirt
+    support: https://github.com/epheo/dotvirt/issues
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+  name: dotvirt-operator.v0.0.36
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: 'A dotvirt install: the workload and Route/Ingress, RBAC, the ArgoCD AppProject tier and ApplicationSet, the platform git repo, and (optionally) a self-hosted Forgejo.'
+        displayName: dotvirt
+        kind: Dotvirt
+        name: dotvirts.dotvirt.io
+        resources:
+          - kind: Deployment
+            name: ""
+            version: v1
+          - kind: Service
+            name: ""
+            version: v1
+          - kind: Route
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: dotvirt app image to deploy. Defaults to the operator's pinned digest, so an operator upgrade rolls the app; set only to override.
+            displayName: App Image
+            path: image
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: 'Git forge holding the platform repo: its URL and platform repo, the credentials secret, and whether the operator self-hosts a Forgejo.'
+            displayName: Forge
+            path: forge
+          - description: 'The ArgoCD (OpenShift GitOps) instance dotvirt drives: its namespace and application-controller service account.'
+            displayName: ArgoCD
+            path: argocd
+          - description: How the UI is exposed (a Route on OpenShift or an Ingress on vanilla Kubernetes) and at which host.
+            displayName: Ingress
+            path: ingress
+          - description: Prometheus/Thanos query API backing the Performance tab.
+            displayName: Metrics
+            path: metrics
+          - description: Add "Sign in with OpenShift" beside the token login. The operator publishes the OAuthClient to apply in status.ssoOAuthClient.
+            displayName: OpenShift SSO
+            path: auth.openShiftSSO
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        statusDescriptors:
+          - displayName: Phase
+            path: phase
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Console URL
+            path: consoleURL
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - displayName: Forge URL
+            path: forgeURL
+            x-descriptors:
+              - urn:alm:descriptor:org.w3:link
+          - displayName: SSO OAuthClient (apply to finish SSO)
+            path: ssoOAuthClient
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Forge Admin (reveal bootstrap password)
+            path: forgeAdminHint
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+  description: |
+    dotvirt is a web console for KubeVirt with a point-and-click workflow
+    familiar to virtualization admins, built the GitOps way: every project is a git
+    repository of VM manifests, every change ships as a pull request, and
+    ArgoCD applies what merges. dotvirt itself owns nothing: requests run under
+    your own Kubernetes token, and nothing reaches the cluster except through a
+    merged PR.
+
+    ### Get started
+
+    1. Install the operator. The console then offers to create a `Dotvirt`
+       resource; the defaults work as-is on OpenShift.
+    2. Wait for the `Available` condition, then open `status.consoleURL`.
+    3. Sign in with a Kubernetes token (`oc whoami -t`), or set
+       `auth.openShiftSSO: true` and click "Finish SSO setup" once as a
+       cluster admin.
+
+    Every TLS hop is verified out of the box: the operator wires the cluster's
+    ingress and service CAs through the whole stack.
+
+    ### What you get
+
+    - VM inventory and detail views with live power, migrate, and snapshot
+      actions
+    - Every change staged as a reviewable pull request
+    - Per-object GitOps drift and sync status, with one-click resync
+    - Host capacity and balance with DRS-style predictive and automatic
+      rebalancing
+    - Network segments (UDN/CUDN), distributed firewall, and topology views
+    - VM template library, storage, events, issues, and Prometheus-backed
+      metrics
+
+    ### Bring existing VMs under GitOps
+
+    Label a namespace `dotvirt.io/project=<name>`, then use "Attach repo" and
+    "Adopt into git" in the console: running VMs and networks become one
+    reviewable PR. The same flow recovers a project whose repo was lost or
+    whose forge moved; the Changes panel warns before any merge could prune
+    something still running.
+
+    ### Configuration
+
+    The defaults derive everything on OpenShift. Set only what you need:
+
+    - `forge.managed: true` runs an evaluation Forgejo; for production point
+      `forge.url` and `forge.credentialsSecret` at your own Forgejo/Gitea
+    - `ingress.host` pins the console hostname (required on vanilla Kubernetes)
+    - `auth.openShiftSSO` adds "Sign in with OpenShift"
+    - `metrics.url` points the Performance tab at a Prometheus/Thanos API
+
+    Status reports the rest: `consoleURL`, `forgeURL`, `forgeAdminHint` (the
+    command that reveals the managed forge's admin password), `ssoOAuthClient`,
+    and one condition per install step, so `kubectl describe dotvirt` explains
+    a stuck install.
+
+    ### Prerequisites
+
+    - ArgoCD (OpenShift GitOps or community) and KubeVirt: required; the
+      operator waits for them and reports what is missing
+    - OVN-Kubernetes, NMState, CDI: optional; unlock the networking tier and
+      image upload
+
+    ### Uninstalling
+
+    Uninstalling the operator changes nothing: the install and your workloads
+    keep running, and a reinstall picks the `Dotvirt` resource back up.
+    Deleting the `Dotvirt` resource removes the install (console, forge, Argo
+    wiring), never your VMs; the managed forge's git data survives on its
+    PersistentVolumeClaim. A finished SSO leaves its admin-created
+    `OAuthClient` behind: `kubectl delete oauthclient <name>` when retiring
+    for good.
+  displayName: dotvirt operator
+  icon:
+    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjE2MS4yNiA1LjMzIDk4MS41NiA4MDAuMjUiIGZpbGw9Im5vbmUiPgogIDxjaXJjbGUgY3g9IjU2MS4zNSIgY3k9IjQwNS40MiIgcj0iMzk0LjA5IiBmaWxsPSIjRjM3NzJCIi8+CiAgPGNpcmNsZSBjeD0iMTAzNi43OCIgY3k9IjY5OS41NCIgcj0iMTAwLjA0IiBmaWxsPSIjRjM3NzJCIi8+CiAgPHBhdGggZmlsbD0iI0ZGRkZGRiIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNDgyLjk2LDY1NC4wMCBDNDgwLjg5LDY0NS4wNiA0ODIuODMsNTU0LjA4IDQ4Mi44Myw1MzcuMDAgQzQ4Mi44Myw0NTIuMzMgNDgyLjgzLDM2Ny42NyA0ODIuODMsMjgzLjAwIEM0ODIuODMsMjU0LjMzIDQ4Mi44MywyMjUuNjcgNDgyLjgzLDE5Ny4wMCBDNDgyLjgzLDE5My4xMiA0ODEuOTksMTcwLjk1IDQ4NC40NywxNzAuMDAgQzQ5MC42NywxNjcuODcgNTA1LjU4LDE2OS44MyA1MTIuNjcsMTY5LjgzIEM1MzQuMjIsMTY5LjgzIDU1NS43OCwxNjkuODMgNTc3LjMzLDE2OS44MyBDNjA2LjI5LDE2OS44MyA2MzUuNzEsMTY5LjI4IDY2NC4zMywxNzAuODIgQzY2OS4zOCwxNzEuMDkgNjc0LjY1LDE3MC4yMyA2NzkuNjcsMTcwLjg3IEM3MzMuNDksMTc3Ljc4IDc4Ni45NCwxOTMuMzQgODI5LjAwLDIzMC41MiBDODg1LjA0LDI4MC4wNyA5MDguNzQsMzU1LjQwIDkwNC44Miw0MjguMzMgQzkwNC4yNyw0MzguNTcgOTAyLjE2LDQ0OC45MyA5MDAuODcsNDU5LjAwIEM4OTguMTUsNDgwLjI1IDg5Mi4xOSw1MDIuODIgODgyLjYyLDUyMi4zMyBDODY3LjUwLDU1My4xNyA4NDcuMjAsNTc5LjM0IDgyMC43OCw2MDEuMzMgQzgwNi4yNiw2MTMuNDEgNzg5LjIyLDYyMS43NyA3NzIuMzMsNjMwLjA1IEM3MDkuNjAsNjYwLjgxIDYzNy43Miw2NTQuODMgNTY4LjMzLDY1NC44MyBDNTQ2LjY3LDY1NC44MyA1MjUuMDAsNjU0LjgzIDUwMy4zMyw2NTQuODMgQzUwMC42MSw2NTQuODMgNDgzLjU0LDY1NS4zMiA0ODIuOTYsNjU0LjAwIFogTTU5NC42NywyNzIuOTYgQzU5My40MSwyNzMuNTEgNTkzLjgzLDI4Ni40OCA1OTMuODMsMjg4LjY3IEM1OTMuODMsMzA1LjExIDU5My44MywzMjEuNTYgNTkzLjgzLDMzOC4wMCBDNTkzLjgzLDM4Ni41NiA1OTMuODMsNDM1LjExIDU5My44Myw0ODMuNjcgQzU5My44Myw0OTYuNzQgNTkxLjc2LDU0MS41MiA1OTMuOTYsNTUxLjAwIEM1OTQuNTIsNTUyLjI4IDYyOC4yOCw1NTEuODMgNjM1LjAwLDU1MS44MyBDNjgwLjI4LDU1MS44MyA3MjAuMDksNTQ2LjAxIDc1NS4wMCw1MTUuMTQgQzgxMC43Nyw0NjUuODQgODA2Ljg0LDM1NS43NyA3NTAuMDAsMzA1LjUyIEM3MTcuNzgsMjc3LjA0IDY3NS4zMSwyNzIuODMgNjM0LjAwLDI3Mi44MyBDNjIzLjM3LDI3Mi44MyA2MDQuMzMsMjcwLjcyIDU5NC42NywyNzIuOTYgWiIvPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - deletecollection
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+                - serviceaccounts
+                - services
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - deletecollection
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - argoproj.io
+              resources:
+                - applications
+                - applicationsets
+                - appprojects
+              verbs:
+                - create
+                - deletecollection
+                - patch
+            - apiGroups:
+                - dotvirt.io
+              resources:
+                - dotvirts
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - dotvirt.io
+              resources:
+                - dotvirts/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - dotvirt.io
+              resources:
+                - dotvirts/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+              verbs:
+                - create
+                - deletecollection
+                - patch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resourceNames:
+                - dotvirt
+                - dotvirt-argocd-apply
+                - dotvirt-platform-network-admin
+              resources:
+                - clusterroles
+              verbs:
+                - bind
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes/custom-host
+              verbs:
+                - create
+                - update
+          serviceAccountName: dotvirt-operator-controller
+      deployments:
+        - label:
+            app: dotvirt-operator
+          name: dotvirt-operator-controller
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: dotvirt-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app: dotvirt-operator
+              spec:
+                containers:
+                  - args:
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                    env:
+                      - name: RELATED_IMAGE_DOTVIRT
+                        value: quay.io/epheo/dotvirt@sha256:8aae700cbb961a3acfe64b1699ae9a6244cbde80670b8fadcad25bed18db64d0
+                      - name: RELATED_IMAGE_FORGEJO
+                        value: codeberg.org/forgejo/forgejo:11-rootless@sha256:5135f11de848bea6d59c0a96688e90c361380ba102bdc08dbd5aa52cca2b179b
+                    image: quay.io/epheo/dotvirt-operator@sha256:72d240459ebb6afe36a208198462332013a0974d1c8e57d2b8203cd3fe02b4b8
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        memory: 256Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: dotvirt-operator-controller
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: dotvirt-operator-controller
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - kubevirt
+    - gitops
+    - argocd
+    - virtualization
+    - openshift
+  links:
+    - name: Source
+      url: https://github.com/epheo/dotvirt
+    - name: Documentation
+      url: https://github.com/epheo/dotvirt/blob/main/README.md
+    - name: Operator
+      url: https://github.com/epheo/dotvirt/blob/main/operator/README.md
+  maintainers:
+    - email: github@epheo.eu
+      name: epheo
+  maturity: alpha
+  minKubeVersion: 1.30.0
+  provider:
+    name: epheo
+  relatedImages:
+    - image: quay.io/epheo/dotvirt@sha256:8aae700cbb961a3acfe64b1699ae9a6244cbde80670b8fadcad25bed18db64d0
+      name: dotvirt
+    - image: quay.io/epheo/dotvirt-operator@sha256:72d240459ebb6afe36a208198462332013a0974d1c8e57d2b8203cd3fe02b4b8
+      name: dotvirt-operator-72d240459ebb6afe36a208198462332013a0974d1c8e57d2b8203cd3fe02b4b8-annotation
+    - image: codeberg.org/forgejo/forgejo:11-rootless@sha256:5135f11de848bea6d59c0a96688e90c361380ba102bdc08dbd5aa52cca2b179b
+      name: forgejo
+    - image: quay.io/epheo/dotvirt-operator@sha256:72d240459ebb6afe36a208198462332013a0974d1c8e57d2b8203cd3fe02b4b8
+      name: manager
+  version: 0.0.36

--- a/operators/dotvirt-operator/0.0.36/manifests/dotvirt-platform-network-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/dotvirt-operator/0.0.36/manifests/dotvirt-platform-network-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: dotvirt-operator
+    app.kubernetes.io/name: dotvirt
+  name: dotvirt-platform-network-admin
+rules:
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - clusteruserdefinednetworks
+  - egressips
+  - adminpolicybasedexternalroutes
+  verbs:
+  - create
+- apiGroups:
+  - policy.networking.k8s.io
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  verbs:
+  - create
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkconfigurationpolicies
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - kubedeschedulers
+  verbs:
+  - create
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigs
+  verbs:
+  - create
+- apiGroups:
+  - template.kubevirt.io
+  resources:
+  - virtualmachinetemplates
+  verbs:
+  - create

--- a/operators/dotvirt-operator/0.0.36/manifests/dotvirt.io_dotvirts.yaml
+++ b/operators/dotvirt-operator/0.0.36/manifests/dotvirt.io_dotvirts.yaml
@@ -1,0 +1,274 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: dotvirts.dotvirt.io
+spec:
+  group: dotvirt.io
+  names:
+    kind: Dotvirt
+    listKind: DotvirtList
+    plural: dotvirts
+    shortNames:
+    - dv
+    singular: dotvirt
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.consoleURL
+      name: Console
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Dotvirt is one dotvirt install. Namespaced singleton in the operator's namespace;
+          the operator itself holds the cluster RBAC to provision cluster-scoped resources.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DotvirtSpec is the desired dotvirt install.
+            properties:
+              argocd:
+                description: |-
+                  ArgoCDSpec locates the ArgoCD install dotvirt rides. Defaults suit OpenShift
+                  GitOps (openshift-gitops); override for community ArgoCD (argocd /
+                  argocd-application-controller). The operator binds the apply RBAC + AppProjects
+                  to this controller ServiceAccount.
+                properties:
+                  controllerServiceAccount:
+                    description: |-
+                      ControllerServiceAccount is the application-controller ServiceAccount the
+                      apply RBAC and AppProjects bind to; empty = the platform default.
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is where the ArgoCD instance runs; empty = the platform default
+                      (openshift-gitops on OpenShift, argocd elsewhere).
+                    type: string
+                  serverURL:
+                    description: |-
+                      ServerURL is the externally reachable ArgoCD base URL the forge posts webhooks
+                      to (.../api/webhook) for instant sync. Empty = discover the OpenShift GitOps
+                      server Route; if neither resolves, the webhook is skipped (Argo falls back to
+                      its poll).
+                    type: string
+                type: object
+              auth:
+                description: AuthSpec enables OpenShift SSO beside the always-present
+                  token login.
+                properties:
+                  openShiftSSO:
+                    description: |-
+                      OpenShiftSSO adds a "Sign in with OpenShift" button beside the token login. The
+                      operator generates the client credential and, once the console host is assigned,
+                      reports the exact OAuthClient to apply (redirect URI filled in) in
+                      status.ssoOAuthClient. Registering that cluster-scoped OAuthClient stays a
+                      cluster-admin act the operator deliberately doesn't perform. OpenShift only.
+                    type: boolean
+                type: object
+              forge:
+                description: |-
+                  ForgeSpec points dotvirt at its git forge and the platform-tier repo. The forge
+                  credential here is the INSTALL-TIME admin token the operator uses to create the
+                  platform repo, distinct from (and more privileged than) dotvirt's runtime
+                  clone/push token, preserving the install-provisioner vs runtime-owns-nothing split.
+                properties:
+                  credentialsSecret:
+                    description: |-
+                      CredentialsSecret names a Secret holding the forge-admin credential (keys: url,
+                      username, token). For a managed forge the operator WRITES this secret; point it at
+                      an existing secret only for a bring-your-own forge.
+                    type: string
+                  insecureTLS:
+                    description: |-
+                      InsecureTLS skips TLS verification when calling the forge API (a self-signed forge
+                      Route, e.g. the bundled Forgejo). DEV/EVAL ONLY; never enable against a forge with
+                      a trusted certificate.
+                    type: boolean
+                  managed:
+                    description: Managed deploys a self-hosted Forgejo for evaluation;
+                      false = bring your own.
+                    type: boolean
+                  platformRepo:
+                    description: |-
+                      PlatformRepo is the cluster-scoped + tenancy repo (CUDN/NNCP/Namespace). The
+                      operator ensures it exists; dotvirt routes platform creates here by kind. Defaults
+                      to <forge URL>/dotvirt/platform.git for a managed forge.
+                    type: string
+                  url:
+                    description: |-
+                      URL is the forge base URL. Leave empty with managed on OpenShift: the operator
+                      exposes Forgejo on a router-assigned host and reports it in status.forgeURL. Set it
+                      for a bring-your-own forge, or to pin the managed forge's host.
+                    type: string
+                type: object
+              image:
+                description: Image is the dotvirt app image to deploy.
+                type: string
+              ingress:
+                description: IngressSpec controls how the UI is exposed.
+                properties:
+                  host:
+                    description: |-
+                      Host is the external hostname the UI is served on. Leave empty on OpenShift for a
+                      router-assigned host (reported in status.consoleURL); required for an Ingress on
+                      vanilla Kubernetes.
+                    type: string
+                  type:
+                    description: |-
+                      IngressType selects how the dotvirt Route is exposed. "auto" picks Route on
+                      OpenShift and Ingress on vanilla Kubernetes (the operator detects the platform).
+                      No gateway value: nothing renders it, so admission rejects it instead of a
+                      silent no-exposure install.
+                    enum:
+                    - auto
+                    - route
+                    - ingress
+                    type: string
+                type: object
+              metrics:
+                description: |-
+                  MetricsSpec points the Performance tab at a Prometheus/Thanos query API; empty
+                  disables it.
+                properties:
+                  url:
+                    description: |-
+                      URL is a Prometheus-compatible query API base URL (for OpenShift, the
+                      cluster Thanos querier service).
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DotvirtStatus is the observed install state.
+            properties:
+              conditions:
+                description: Conditions follow the standard k8s conventions (see the
+                  Condition* consts).
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              consoleURL:
+                description: |-
+                  ConsoleURL is the external URL the dotvirt UI is served on; assigned by the
+                  operator when spec.ingress.host is left empty on OpenShift.
+                type: string
+              forgeAdminHint:
+                description: |-
+                  ForgeAdminHint is the command that reveals the managed Forgejo bootstrap admin
+                  password (user dotvirt-bot); the value stays in the Secret, never in status.
+                  Set only for a managed forge.
+                type: string
+              forgeURL:
+                description: |-
+                  ForgeURL is the effective external forge base URL: the configured spec.forge.url,
+                  or the host the operator assigned to a managed Forgejo when the URL was left empty.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the .metadata.generation last reconciled.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is a short human-facing summary (e.g. Pending,
+                  Provisioning, Ready).
+                type: string
+              ssoOAuthClient:
+                description: |-
+                  SSOOAuthClient is a ready-to-apply command that registers the cluster-scoped
+                  OAuthClient SSO needs, with the redirect URI filled from the assigned console host.
+                  Set only while auth.openShiftSSO is on; run it once to finish SSO.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/dotvirt-operator/0.0.36/manifests/dotvirt_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/dotvirt-operator/0.0.36/manifests/dotvirt_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,134 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: dotvirt-operator
+    app.kubernetes.io/name: dotvirt
+  name: dotvirt
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachines
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - instancetype.kubevirt.io
+  resources:
+  - virtualmachineclusterinstancetypes
+  - virtualmachineclusterpreferences
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - datasources
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - network-attachment-definitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - userdefinednetworks
+  - clusteruserdefinednetworks
+  - egressfirewalls
+  - egressips
+  - adminpolicybasedexternalroutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy.networking.k8s.io
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nmstate.io
+  resources:
+  - nodenetworkstates
+  - nodenetworkconfigurationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - kubedeschedulers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list

--- a/operators/dotvirt-operator/0.0.36/metadata/annotations.yaml
+++ b/operators/dotvirt-operator/0.0.36/metadata/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: dotvirt-operator
+  operators.operatorframework.io.bundle.channels.v1: stable-v0
+  operators.operatorframework.io.bundle.channel.default.v1: stable-v0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: "v4.18"

--- a/operators/dotvirt-operator/0.0.36/release-config.yaml
+++ b/operators/dotvirt-operator/0.0.36/release-config.yaml
@@ -1,0 +1,4 @@
+---
+catalog_templates:
+  - template_name: semver.yaml
+    channels: [Stable]

--- a/operators/dotvirt-operator/0.0.36/tests/scorecard/config.yaml
+++ b/operators/dotvirt-operator/0.0.36/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test


### PR DESCRIPTION
Change review moves to its own route with field diffs, impact and PR lane; a repoless project can be released back to a plain namespace.
PatternFly-modeled light and dark theme; VM page reworked with a staged power button and a fact-card summary.
